### PR TITLE
ImageService: improve thumbnail processing

### DIFF
--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -245,7 +245,7 @@ class ImageService:
                 iiif_url = references["http://iiif.io/api/image"]
                 if isinstance(iiif_url, list) and iiif_url:
                     iiif_url = iiif_url[0]
-                
+
                 # Transform ContentDM IIIF URLs
                 if "contentdm.oclc.org" in iiif_url:
                     # Extract collection and item ID from the URL
@@ -254,7 +254,7 @@ class ImageService:
                         collection, item_id = match.groups()
                         # Construct the correct IIIF URL format
                         thumbnail_url = f"https://cdm16022.contentdm.oclc.org/iiif/2/{collection}:{item_id}/full/200,/0/default.jpg"
-                
+
                 # For non-ContentDM IIIF URLs, use standard format
                 if not thumbnail_url:
                     thumbnail_url = f"{iiif_url}/full/200,/0/default.jpg"
@@ -279,7 +279,7 @@ class ImageService:
             elif "urn:x-esri:serviceType:ArcGIS#DynamicMapLayer" in references:
                 viewer_endpoint = references["urn:x-esri:serviceType:ArcGIS#DynamicMapLayer"]
                 thumbnail_url = f"{viewer_endpoint}/info/thumbnail/thumbnail.png"
-            
+
             # Check for WMS
             elif "http://www.opengis.net/def/serviceType/ogc/wms" in references:
                 wms_endpoint = references["http://www.opengis.net/def/serviceType/ogc/wms"]
@@ -294,7 +294,7 @@ class ImageService:
                     f"HEIGHT={height}&"
                     f"LAYERS={layers}"
                 )
-            
+
             # Check for TMS
             elif "http://www.opengis.net/def/serviceType/ogc/tms" in references:
                 tms_endpoint = references["http://www.opengis.net/def/serviceType/ogc/tms"]
@@ -306,11 +306,11 @@ class ImageService:
                 # Check if we have the image cached
                 image_hash = hashlib.sha256(thumbnail_url.encode()).hexdigest()
                 image_key = f"image:{image_hash}"
-                
+
                 if self.image_cache.exists(image_key):
                     self.logger.info(f"🚀 Cache HIT for image {doc_id}")
                     return f"{self.application_url}/api/v1/thumbnails/{image_hash}"
-                
+
                 # Validate the thumbnail URL before queueing for caching
                 if not self._validate_thumbnail_url(thumbnail_url):
                     self.logger.warning(f"Invalid thumbnail URL for {doc_id}: {thumbnail_url}")
@@ -319,6 +319,7 @@ class ImageService:
                 # If not cached, queue for background processing and return original URL
                 self.logger.info(f"🐌 Queueing image fetch for {doc_id}: {thumbnail_url}")
                 from app.tasks.worker import fetch_and_cache_image
+
                 task = fetch_and_cache_image.delay(thumbnail_url)
                 self.logger.info(f"Task ID: {task.id}")
                 return thumbnail_url

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -190,6 +190,11 @@ class ImageService:
             Thumbnail URL if available, None otherwise
         """
         try:
+            # Check for restricted access rights
+            if self.metadata.get("dct_accessrights_s") == "Restricted":
+                self.logger.info("Skipping thumbnail for restricted item")
+                return None
+
             doc_id = self.metadata.get("id")
             if not doc_id:
                 return None

--- a/app/services/image_service.py
+++ b/app/services/image_service.py
@@ -95,6 +95,13 @@ class ImageService:
             return manifest_url
 
         try:
+            # Check for Stanford-style thumbnail array
+            if isinstance(manifest_json.get("thumbnail"), list) and manifest_json["thumbnail"]:
+                self.logger.debug("Image: Stanford-style thumbnail array")
+                thumbnail = manifest_json["thumbnail"][0]
+                if isinstance(thumbnail, dict) and thumbnail.get("id"):
+                    return thumbnail["id"]
+
             # Sequences - Return the first image if it exists
             if manifest_json.get("sequences"):
                 self.logger.debug("Image: sequences")

--- a/app/services/search_service.py
+++ b/app/services/search_service.py
@@ -187,7 +187,7 @@ class SearchService:
             if include_summaries:
                 try:
                     summaries_query = """
-                        SELECT * FROM ai_enrichments 
+                        SELECT * FROM item_ai_enrichments 
                         WHERE item_id = :item_id 
                         ORDER BY created_at DESC
                     """


### PR DESCRIPTION
* Restore ESRI thumbs
* Restore thumbnail cacheing
* Honor Stanford IIIF manifest thumbs
* Don't thumb restricted items
* Ensure thumbs are valid URLs (no 404s or 500s)