### PR TITLE
174 advanced search

### DIFF
--- a/backend/app/elasticsearch/search.py
+++ b/backend/app/elasticsearch/search.py
@@ -174,6 +174,10 @@ def get_facet_aggregation_config(facet_name: str) -> dict:
             "field": "b1g_code_s",
             "size": DEFAULT_FACET_SIZE,
         },
+        "b1g_localCollectionLabel_sm": {
+            "field": "b1g_localCollectionLabel_sm.keyword",
+            "size": DEFAULT_FACET_SIZE,
+        },
         "geo_country": {
             "field": "geo_country.keyword",
             "size": GEO_COUNTRY_FACET_SIZE,

--- a/backend/tests/elasticsearch/test_facet_functions.py
+++ b/backend/tests/elasticsearch/test_facet_functions.py
@@ -34,6 +34,7 @@ class TestGetFacetAggregationConfig:
             "dct_publisher_sm",
             "schema_provider_s",
             "b1g_code_s",
+            "b1g_localCollectionLabel_sm",
             "dct_accessRights_s",
             "gbl_georeferenced_b",
             "geo_country",
@@ -60,6 +61,9 @@ class TestGetFacetAggregationConfig:
 
         config = get_facet_aggregation_config("schema_provider_s")
         assert config["field"] == "schema_provider_s.keyword"
+
+        config = get_facet_aggregation_config("b1g_localCollectionLabel_sm")
+        assert config["field"] == "b1g_localCollectionLabel_sm.keyword"
 
     def test_non_keyword_fields(self):
         """Test that non-keyword fields are correctly configured."""

--- a/frontend/src/__tests__/components/AdvancedSearchBuilder.test.tsx
+++ b/frontend/src/__tests__/components/AdvancedSearchBuilder.test.tsx
@@ -62,6 +62,7 @@ describe('AdvancedSearchBuilder', () => {
     }));
 
     expect(options).toEqual([
+      { value: 'all_fields', label: 'All Fields' },
       { value: 'dct_title_s', label: 'Title' },
       { value: 'dct_accessRights_s', label: 'Access Rights' },
       { value: 'dct_creator_sm', label: 'Creator' },

--- a/frontend/src/__tests__/components/AdvancedSearchBuilder.test.tsx
+++ b/frontend/src/__tests__/components/AdvancedSearchBuilder.test.tsx
@@ -52,6 +52,34 @@ describe('AdvancedSearchBuilder', () => {
     expect(operatorSelects).toHaveLength(2);
   });
 
+  it('renders the curated advanced search field list', () => {
+    renderBuilder();
+
+    const fieldSelect = screen.getByLabelText('Field') as HTMLSelectElement;
+    const options = Array.from(fieldSelect.options).map((option) => ({
+      value: option.value,
+      label: option.text,
+    }));
+
+    expect(options).toEqual([
+      { value: 'dct_title_s', label: 'Title' },
+      { value: 'dct_accessRights_s', label: 'Access Rights' },
+      { value: 'dct_creator_sm', label: 'Creator' },
+      { value: 'dct_description_sm', label: 'Description' },
+      {
+        value: 'b1g_localCollectionLabel_sm',
+        label: 'Local Collection',
+      },
+      { value: 'dct_spatial_sm', label: 'Place' },
+      { value: 'schema_provider_s', label: 'Provider' },
+      { value: 'dct_publisher_sm', label: 'Publisher' },
+      { value: 'gbl_resourceClass_sm', label: 'Resource Class' },
+      { value: 'gbl_resourceType_sm', label: 'Resource Type' },
+      { value: 'dct_subject_sm', label: 'Subject' },
+      { value: 'dcat_theme_sm', label: 'Theme' },
+    ]);
+  });
+
   it('calls onApply with sanitized clauses', async () => {
     const user = userEvent.setup();
     const { onApply } = renderBuilder({

--- a/frontend/src/components/search/AdvancedSearchBuilder.tsx
+++ b/frontend/src/components/search/AdvancedSearchBuilder.tsx
@@ -24,6 +24,7 @@ type BuilderRow = AdvancedClause & { id: string };
 const OPERATORS: AdvancedOperator[] = ['AND', 'OR', 'NOT'];
 
 const ADVANCED_SEARCH_FIELD_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'all_fields', label: 'All Fields' },
   { value: 'dct_title_s', label: 'Title' },
   { value: 'dct_accessRights_s', label: 'Access Rights' },
   { value: 'dct_creator_sm', label: 'Creator' },

--- a/frontend/src/components/search/AdvancedSearchBuilder.tsx
+++ b/frontend/src/components/search/AdvancedSearchBuilder.tsx
@@ -23,16 +23,22 @@ type BuilderRow = AdvancedClause & { id: string };
 
 const OPERATORS: AdvancedOperator[] = ['AND', 'OR', 'NOT'];
 
-const COMMON_FIELD_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'all_fields', label: 'All Text' },
+const ADVANCED_SEARCH_FIELD_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'dct_title_s', label: 'Title' },
+  { value: 'dct_accessRights_s', label: 'Access Rights' },
+  { value: 'dct_creator_sm', label: 'Creator' },
   { value: 'dct_description_sm', label: 'Description' },
-  { value: 'dct_spatial_sm', label: 'Place / Country' },
+  { value: 'b1g_localCollectionLabel_sm', label: 'Local Collection' },
+  { value: 'dct_spatial_sm', label: 'Place' },
+  { value: 'schema_provider_s', label: 'Provider' },
+  { value: 'dct_publisher_sm', label: 'Publisher' },
   { value: 'gbl_resourceClass_sm', label: 'Resource Class' },
   { value: 'gbl_resourceType_sm', label: 'Resource Type' },
   { value: 'dct_subject_sm', label: 'Subject' },
-  { value: 'schema_provider_s', label: 'Provider' },
+  { value: 'dcat_theme_sm', label: 'Theme' },
 ];
+
+const DEFAULT_FIELD = ADVANCED_SEARCH_FIELD_OPTIONS[0]?.value || 'dct_title_s';
 
 const generateRowId = () => {
   const globalCrypto =
@@ -49,7 +55,7 @@ function createRow(partial?: Partial<AdvancedClause>): BuilderRow {
   return {
     id: generateRowId(),
     op: partial?.op || 'AND',
-    field: partial?.field || 'all_fields',
+    field: partial?.field || DEFAULT_FIELD,
     q: partial?.q || '',
   };
 }
@@ -434,38 +440,22 @@ export function AdvancedSearchBuilder({
   };
 
   const fieldOptions = useMemo(() => {
-    const seen = new Set(COMMON_FIELD_OPTIONS.map((option) => option.value));
-
-    // Fields to exclude from the dropdown
-    const excludedFields = new Set([
-      'layer_modified_dt', // Last Modified
-      'gbl_mdversion_s', // Metadata Version
-      'layer_slug_s', // Layer ID
-      'layer_id_s', // Layer Identifier
-      'gbl_wxsidentifier_s', // WXS Identifier
-      'dct_references_s', // References
-      'dcat_bbox', // Bounding Box
-      'dcat_bbox_original', // Bounding Box
-      'dcat_centroid', // Centroid
-      'dcat_centroid_original', // Centroid
-      'locn_geometry', // Geometry
-      'locn_geometry_original', // Geometry
-      'solr_geom', // Geometry
-      'dc_publisher_sm', // Duplicate Publisher (prefer dct_publisher_sm)
-      'dc_type_sm', // Duplicate Type (prefer dct_type_sm)
-      'dc_subject_sm', // Duplicate Subject (prefer dct_subject_sm)
-    ]);
-
-    const remaining = Object.entries(FIELD_LABELS)
-      .filter(([field]) => !seen.has(field) && !excludedFields.has(field))
-      .map(([field, config]) => ({
+    const seen = new Set(
+      ADVANCED_SEARCH_FIELD_OPTIONS.map((option) => option.value)
+    );
+    const legacySelections = Array.from(new Set(rows.map((row) => row.field)))
+      .filter((field) => !seen.has(field))
+      .map((field) => ({
         value: field,
-        label: config.label || field,
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label));
+        label:
+          field === 'all_fields'
+            ? 'All Text'
+            : FIELD_LABELS[field]?.label || field,
+      }));
 
-    return [...COMMON_FIELD_OPTIONS, ...remaining];
-  }, []);
+    // Preserve any existing field selections from older URLs so they still render/edit cleanly.
+    return [...ADVANCED_SEARCH_FIELD_OPTIONS, ...legacySelections];
+  }, [rows]);
 
   const updateRow = (id: string, key: keyof AdvancedClause, value: string) => {
     setRows((prev) =>


### PR DESCRIPTION
## Summary

This PR simplifies the Advanced Search field selector by replacing the previous mixed approach of `COMMON_FIELD_OPTIONS` plus `excludedFields` with a single allowlist of fields.

## What Changed

- Replaced the dynamic Advanced Search field list with a hardcoded curated list.
- Added faceting for `Local Collection` to be a dropdown list

The Advanced Search UI now shows:

- All fields
- Title
- Access Rights
- Creator
- Description
- Local Collection
- Place
- Provider
- Publisher
- Resource Class
- Resource Type
- Subject
- Theme


