### PR TITLE
[codex] Fix map gesture handling and hero close target

### DIFF
--- a/frontend/src/__tests__/components/GeospatialFilterMap.client.test.tsx
+++ b/frontend/src/__tests__/components/GeospatialFilterMap.client.test.tsx
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { GeospatialFilterMap } from '../../components/search/GeospatialFilterMap.client';
 import { fetchMapH3 } from '../../services/api';
+import L from 'leaflet';
 
 const mockControl = { addTo: vi.fn(), remove: vi.fn() };
 const mockMapInstance = {
@@ -29,6 +36,21 @@ const mockMapInstance = {
 vi.mock('leaflet', () => {
   return {
     default: {
+      Handler: {
+        extend: vi.fn((definition) => definition),
+      },
+      Map: {
+        addInitHook: vi.fn(),
+      },
+      DomEvent: {
+        on: vi.fn(),
+        off: vi.fn(),
+        preventDefault: vi.fn(),
+      },
+      DomUtil: {
+        addClass: vi.fn(),
+        removeClass: vi.fn(),
+      },
       map: vi.fn(() => mockMapInstance),
       tileLayer: vi.fn(() => ({ addTo: vi.fn() })),
       rectangle: vi.fn(() => ({ addTo: vi.fn() })),
@@ -104,6 +126,26 @@ describe('GeospatialFilterMap client', () => {
     });
   });
 
+  it('enables command/control gesture handling for scroll zoom', async () => {
+    render(
+      <MemoryRouter initialEntries={['/search?q=chicago&view=gallery']}>
+        <Routes>
+          <Route path="/search" element={<GeospatialFilterMap />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(L.map).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        expect.objectContaining({
+          gestureHandling: true,
+          scrollWheelZoom: true,
+        })
+      );
+    });
+  });
+
   it('waits until window load before issuing the initial hex request', async () => {
     vi.useFakeTimers();
 
@@ -120,6 +162,14 @@ describe('GeospatialFilterMap client', () => {
         </Routes>
       </MemoryRouter>
     );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(L.map).toHaveBeenCalled();
 
     act(() => {
       vi.advanceTimersByTime(2000);
@@ -168,19 +218,24 @@ describe('GeospatialFilterMap client', () => {
     );
 
     await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(L.map).toHaveBeenCalled();
+
+    await act(async () => {
       vi.advanceTimersByTime(250);
       await Promise.resolve();
       await Promise.resolve();
     });
 
     expect(fetchMapH3).toHaveBeenCalledTimes(1);
-    expect(mockMapInstance.fitBounds).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        padding: [24, 24],
-        maxZoom: 14,
-      }
-    );
+    expect(mockMapInstance.fitBounds).toHaveBeenCalledWith(expect.anything(), {
+      padding: [24, 24],
+      maxZoom: 14,
+    });
 
     Object.defineProperty(document, 'readyState', {
       configurable: true,

--- a/frontend/src/__tests__/components/MapView.test.tsx
+++ b/frontend/src/__tests__/components/MapView.test.tsx
@@ -2,6 +2,21 @@
 vi.mock('leaflet/dist/leaflet.css', () => ({}));
 vi.mock('leaflet', () => ({
   default: {
+    Handler: {
+      extend: vi.fn((definition) => definition),
+    },
+    Map: {
+      addInitHook: vi.fn(),
+    },
+    DomEvent: {
+      on: vi.fn(),
+      off: vi.fn(),
+      preventDefault: vi.fn(),
+    },
+    DomUtil: {
+      addClass: vi.fn(),
+      removeClass: vi.fn(),
+    },
     map: vi.fn(() => ({
       setView: vi.fn().mockReturnThis(),
       eachLayer: vi.fn(),

--- a/frontend/src/__tests__/components/resource/LocationMap.client.test.tsx
+++ b/frontend/src/__tests__/components/resource/LocationMap.client.test.tsx
@@ -1,0 +1,84 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import L from 'leaflet';
+import LocationMap from '../../../components/resource/LocationMap.client';
+
+const mockMapInstance = {
+  setView: vi.fn().mockReturnThis(),
+  eachLayer: vi.fn(),
+  removeLayer: vi.fn(),
+  fitBounds: vi.fn(),
+  remove: vi.fn(),
+  hasLayer: vi.fn().mockReturnValue(false),
+};
+
+vi.mock('leaflet/dist/leaflet.css', () => ({}));
+vi.mock('../../../config/basemaps', () => ({
+  attachBasemapSwitcher: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('leaflet', () => ({
+  default: {
+    Handler: {
+      extend: vi.fn((definition) => definition),
+    },
+    Map: {
+      addInitHook: vi.fn(),
+    },
+    DomEvent: {
+      on: vi.fn(),
+      off: vi.fn(),
+      preventDefault: vi.fn(),
+    },
+    DomUtil: {
+      addClass: vi.fn(),
+      removeClass: vi.fn(),
+    },
+    map: vi.fn(() => mockMapInstance),
+    GeoJSON: class MockGeoJSON {},
+    geoJSON: vi.fn(() => ({
+      addTo: vi.fn().mockReturnThis(),
+      getBounds: vi.fn(() => 'geometry-bounds'),
+    })),
+    latLng: vi.fn((lat, lng) => ({ lat, lng })),
+    latLngBounds: vi.fn(() => 'multipolygon-bounds'),
+    rectangle: vi.fn(() => ({
+      addTo: vi.fn().mockReturnThis(),
+    })),
+  },
+}));
+
+describe('LocationMap client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enables command/control gesture handling for scroll zoom', async () => {
+    render(
+      <LocationMap
+        geometry={{
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-93.3, 44.9],
+              [-93.2, 44.9],
+              [-93.2, 45],
+              [-93.3, 45],
+              [-93.3, 44.9],
+            ],
+          ],
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(L.map).toHaveBeenCalledWith(
+        expect.any(HTMLDivElement),
+        expect.objectContaining({
+          gestureHandling: true,
+          scrollWheelZoom: true,
+        })
+      );
+    });
+  });
+});

--- a/frontend/src/__tests__/components/search/MapResultView.test.tsx
+++ b/frontend/src/__tests__/components/search/MapResultView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { MapProvider } from '../../../context/MapContext';
 import { MapResultView } from '../../../components/search/MapResultView.client';
@@ -19,9 +19,21 @@ vi.mock('leaflet/dist/leaflet.css', () => ({}));
 vi.mock('react-leaflet', () => ({
   MapContainer: ({
     children,
+    gestureHandling,
+    scrollWheelZoom,
   }: {
     children: React.ReactNode;
-  }) => <div data-testid="map-container">{children}</div>,
+    gestureHandling?: boolean;
+    scrollWheelZoom?: boolean;
+  }) => (
+    <div
+      data-testid="map-container"
+      data-gesture-handling={String(gestureHandling)}
+      data-scroll-wheel-zoom={String(scrollWheelZoom)}
+    >
+      {children}
+    </div>
+  ),
   GeoJSON: () => null,
   useMap: () => mockMap,
 }));
@@ -138,8 +150,20 @@ describe('MapResultView', () => {
         </TestWrapper>
       );
 
-      expect(screen.getByTestId('map-container')).toBeInTheDocument();
-      expect(screen.getByTestId('basemap-switcher')).toBeInTheDocument();
+      expect(await screen.findByTestId('map-container')).toBeInTheDocument();
+      expect(await screen.findByTestId('basemap-switcher')).toBeInTheDocument();
+    });
+
+    it('enables command/control gesture handling for scroll zoom', async () => {
+      render(
+        <TestWrapper>
+          <MapResultView results={mockResultsWithCentroid} />
+        </TestWrapper>
+      );
+
+      const map = await screen.findByTestId('map-container');
+      expect(map).toHaveAttribute('data-gesture-handling', 'true');
+      expect(map).toHaveAttribute('data-scroll-wheel-zoom', 'true');
     });
 
     it('shows "No mappable results" when no pins', () => {
@@ -167,7 +191,7 @@ describe('MapResultView', () => {
       ).toBeInTheDocument();
     });
 
-    it('accepts resultStartIndex for numbered pins', () => {
+    it('accepts resultStartIndex for numbered pins', async () => {
       render(
         <TestWrapper>
           <MapResultView
@@ -177,10 +201,10 @@ describe('MapResultView', () => {
         </TestWrapper>
       );
 
-      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+      expect(await screen.findByTestId('map-container')).toBeInTheDocument();
     });
 
-    it('accepts highlightedResourceId and highlightedGeometry', () => {
+    it('accepts highlightedResourceId and highlightedGeometry', async () => {
       render(
         <TestWrapper>
           <MapResultView
@@ -191,14 +215,22 @@ describe('MapResultView', () => {
         </TestWrapper>
       );
 
-      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+      expect(await screen.findByTestId('map-container')).toBeInTheDocument();
     });
 
-    it('adds dashed extent overlay for MultiPolygon (same as resource view LocationMap)', () => {
+    it('adds dashed extent overlay for MultiPolygon (same as resource view LocationMap)', async () => {
       const multiPolygonJson = JSON.stringify({
         type: 'MultiPolygon',
         coordinates: [
-          [[[-75.6, 39.8], [-75.8, 39.7], [-80.5, 39.7], [-80.5, 42.3], [-75.6, 39.8]]],
+          [
+            [
+              [-75.6, 39.8],
+              [-75.8, 39.7],
+              [-80.5, 39.7],
+              [-80.5, 42.3],
+              [-75.6, 39.8],
+            ],
+          ],
         ],
       });
       render(
@@ -212,20 +244,23 @@ describe('MapResultView', () => {
       );
 
       // HighlightOverlayController adds geoJSON layer + dashed rectangle for MultiPolygon
-      const addLayerCalls = mockMap.addLayer.mock.calls.length;
-      expect(addLayerCalls).toBeGreaterThanOrEqual(2);
+      await waitFor(() => {
+        expect(mockMap.addLayer.mock.calls.length).toBeGreaterThanOrEqual(2);
+      });
     });
   });
 
   describe('map refit on results change', () => {
-    it('refits map when search results change (e.g. facet filter applied)', () => {
+    it('refits map when search results change (e.g. facet filter applied)', async () => {
       const { rerender } = render(
         <TestWrapper>
           <MapResultView results={mockResultsFrance} />
         </TestWrapper>
       );
 
-      expect(mockFlyToBounds).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(mockFlyToBounds).toHaveBeenCalledTimes(1);
+      });
 
       rerender(
         <TestWrapper>
@@ -234,30 +269,32 @@ describe('MapResultView', () => {
       );
 
       // Should refit again when results change
-      expect(mockFlyToBounds).toHaveBeenCalledTimes(2);
+      await waitFor(() => {
+        expect(mockFlyToBounds).toHaveBeenCalledTimes(2);
+      });
     });
   });
 
   describe('centroid resolution', () => {
-    it('renders pins for results with dcat_centroid', () => {
+    it('renders pins for results with dcat_centroid', async () => {
       render(
         <TestWrapper>
           <MapResultView results={mockResultsWithCentroid} />
         </TestWrapper>
       );
 
-      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+      expect(await screen.findByTestId('map-container')).toBeInTheDocument();
       expect(screen.queryByText('No mappable results')).not.toBeInTheDocument();
     });
 
-    it('renders pins for results with geometry fallback (no centroid)', () => {
+    it('renders pins for results with geometry fallback (no centroid)', async () => {
       render(
         <TestWrapper>
           <MapResultView results={mockResultsWithGeometryOnly} />
         </TestWrapper>
       );
 
-      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+      expect(await screen.findByTestId('map-container')).toBeInTheDocument();
       expect(screen.queryByText('No mappable results')).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/__tests__/pages/Home.test.tsx
+++ b/frontend/src/__tests__/pages/Home.test.tsx
@@ -42,9 +42,7 @@ describe('Home Page', () => {
       screen.getByRole('link', { name: /read gin news & stories/i })
     ).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: /theme/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /theme/i })).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: /creator/i })
     ).not.toBeInTheDocument();
@@ -59,12 +57,16 @@ describe('Home Page', () => {
     expect(
       screen.getByRole('heading', { name: /urban base layers collection/i })
     ).toBeInTheDocument();
-    expect(screen.getByAltText(/logo for indiana university/i)).toBeInTheDocument();
+    expect(
+      screen.getByAltText(/logo for indiana university/i)
+    ).toBeInTheDocument();
     expect(
       screen.getByAltText(/logo for university of washington/i)
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /search resources near indiana university/i })
+      screen.getByRole('link', {
+        name: /search resources near indiana university/i,
+      })
     ).toHaveAttribute(
       'href',
       getPartnerInstitutionSearchHref({
@@ -98,6 +100,11 @@ describe('Home Page', () => {
     const closeButton = screen.getByRole('button', {
       name: /hide map description/i,
     });
+    expect(closeButton).toHaveClass('pointer-events-auto', 'h-9', 'w-9');
+    expect(closeButton.querySelector('svg')).not.toHaveClass(
+      'pointer-events-none'
+    );
+
     await userEvent.click(closeButton);
 
     expect(
@@ -109,7 +116,9 @@ describe('Home Page', () => {
     renderHome();
 
     await userEvent.click(
-      screen.getByRole('button', { name: /open big ten academic alliance video/i })
+      screen.getByRole('button', {
+        name: /open big ten academic alliance video/i,
+      })
     );
 
     expect(

--- a/frontend/src/__tests__/pages/Home.test.tsx
+++ b/frontend/src/__tests__/pages/Home.test.tsx
@@ -31,7 +31,7 @@ describe('Home Page', () => {
   };
 
   it('renders the search input', async () => {
-    const { container } = renderHome();
+    renderHome();
     await waitFor(() => {
       expect(
         screen.getByRole('heading', { name: /partner institutions/i })
@@ -90,6 +90,19 @@ describe('Home Page', () => {
       // The suggestions dropdown should appear with the mocked suggestion
       expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
     });
+  });
+
+  it('hides the hero description when the close button is clicked', async () => {
+    renderHome();
+
+    const closeButton = screen.getByRole('button', {
+      name: /hide map description/i,
+    });
+    await userEvent.click(closeButton);
+
+    expect(
+      screen.queryByRole('button', { name: /hide map description/i })
+    ).not.toBeInTheDocument();
   });
 
   it('opens the BTAA video lightbox when the BTAA tile is clicked', async () => {

--- a/frontend/src/components/home/HomePageHexMapBackground.client.tsx
+++ b/frontend/src/components/home/HomePageHexMapBackground.client.tsx
@@ -9,6 +9,7 @@ import { cellArea, UNITS } from 'h3-js';
 import { MapUpdaterHex, type HexHoverData } from '../map/MapUpdaterHex';
 import { HexLayerToggleControl } from '../map/HexLayerToggleControl';
 import { BboxRectangleSelector } from '../map/BboxRectangleSelector';
+import { leafletGestureMapOptions } from '../../config/leafletConfig';
 import { HOME_PAGE_MAP_CENTER, DEFAULT_US_ZOOM } from '../../config/mapView';
 import { FEATURED_ITEMS } from '../../config/featured';
 import { fetchFeaturedResourcePreview } from '../../services/api';
@@ -67,7 +68,8 @@ function toSsrThumbnailUrl(url: string | undefined): string {
     return url;
   } catch {
     if (url.includes('/api/v1/thumbnails/')) {
-      if (IMMUTABLE_THUMBNAIL_PATH_RE.test(url)) return toBrowserApiAssetUrl(url);
+      if (IMMUTABLE_THUMBNAIL_PATH_RE.test(url))
+        return toBrowserApiAssetUrl(url);
       return url.replace('/api/v1/thumbnails/', '/thumbnails/');
     }
     if (url.includes('/api/v1/resources/') && url.endsWith('/thumbnail'))
@@ -497,14 +499,12 @@ export function HomePageHexMapBackground() {
           className="homepage-map h-full w-full"
           zoomControl={false}
           dragging={true}
-          scrollWheelZoom={true}
           doubleClickZoom={true}
           touchZoom={true}
           keyboard={true}
           attributionControl={true}
           zoomAnimationThreshold={1}
-          // @ts-expect-error - gestureHandling is a leaflet-gesture-handling plugin option
-          gestureHandling={true}
+          {...leafletGestureMapOptions}
         >
           <ZoomControl position="topleft" />
           <MapGeosearchControl />

--- a/frontend/src/components/resource/LocationMap.client.tsx
+++ b/frontend/src/components/resource/LocationMap.client.tsx
@@ -3,6 +3,8 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { normalizeGeometry } from '../../utils/geometryUtils';
 import { attachBasemapSwitcher } from '../../config/basemaps';
+import { leafletGestureMapOptions } from '../../config/leafletConfig';
+import { registerLeafletGestureHandling } from '../../config/leafletGestureHandling';
 
 interface LocationMapProps {
   geometry:
@@ -20,108 +22,119 @@ export const LocationMap: React.FC<LocationMapProps> = ({ geometry }) => {
 
   useEffect(() => {
     if (!mapContainer.current || !geometry) return;
+    let cancelled = false;
 
-    // Normalize the geometry to GeoJSON format
-    const normalizedGeometry = normalizeGeometry(geometry);
-    if (!normalizedGeometry) {
-      console.warn('Could not normalize geometry:', geometry);
-      return;
-    }
-
-    // Initialize map if it doesn't exist
-    if (!mapRef.current) {
-      mapRef.current = L.map(mapContainer.current).setView([0, 0], 2);
-      basemapCleanupRef.current = attachBasemapSwitcher(mapRef.current, L);
-    }
-
-    // Clear existing layers
-    mapRef.current.eachLayer((layer) => {
-      if (layer instanceof L.GeoJSON) {
-        mapRef.current?.removeLayer(layer);
+    const renderMap = () => {
+      // Normalize the geometry to GeoJSON format
+      const normalizedGeometry = normalizeGeometry(geometry);
+      if (!normalizedGeometry) {
+        console.warn('Could not normalize geometry:', geometry);
+        return;
       }
-    });
 
-    try {
-      // Handle MultiPolygon by converting to individual Polygon features
-      // Standard GeoJSON: coordinates = [[ring1, hole?], [ring2], ...] per polygon
-      let features;
-      if (normalizedGeometry.type === 'MultiPolygon') {
-        features = normalizedGeometry.coordinates.map((polygonRings) => {
-          return {
-            type: 'Feature' as const,
-            geometry: {
-              type: 'Polygon' as const,
-              coordinates: polygonRings, // [exteriorRing, hole1?, ...]
+      // Initialize map if it doesn't exist
+      if (!mapRef.current) {
+        registerLeafletGestureHandling(L);
+        if (cancelled || !mapContainer.current) return;
+        mapRef.current = L.map(
+          mapContainer.current,
+          leafletGestureMapOptions
+        ).setView([0, 0], 2);
+        basemapCleanupRef.current = attachBasemapSwitcher(mapRef.current, L);
+      }
+
+      // Clear existing layers
+      mapRef.current.eachLayer((layer) => {
+        if (layer instanceof L.GeoJSON) {
+          mapRef.current?.removeLayer(layer);
+        }
+      });
+
+      try {
+        // Handle MultiPolygon by converting to individual Polygon features
+        // Standard GeoJSON: coordinates = [[ring1, hole?], [ring2], ...] per polygon
+        let features;
+        if (normalizedGeometry.type === 'MultiPolygon') {
+          features = normalizedGeometry.coordinates.map((polygonRings) => {
+            return {
+              type: 'Feature' as const,
+              geometry: {
+                type: 'Polygon' as const,
+                coordinates: polygonRings, // [exteriorRing, hole1?, ...]
+              },
+              properties: {},
+            };
+          });
+        } else {
+          features = [
+            {
+              type: 'Feature' as const,
+              geometry: normalizedGeometry,
+              properties: {},
             },
-            properties: {},
-          };
-        });
-      } else {
-        features = [
-          {
-            type: 'Feature' as const,
-            geometry: normalizedGeometry,
-            properties: {},
+          ];
+        }
+
+        // Add the GeoJSON layer
+        const geoJsonLayer = L.geoJSON(features, {
+          style: {
+            color: '#2563eb',
+            weight: 2,
+            opacity: 0.6,
+            fillOpacity: 0.1,
           },
-        ];
-      }
+        }).addTo(mapRef.current);
 
-      // Add the GeoJSON layer
-      const geoJsonLayer = L.geoJSON(features, {
-        style: {
-          color: '#2563eb',
-          weight: 2,
-          opacity: 0.6,
-          fillOpacity: 0.1,
-        },
-      }).addTo(mapRef.current);
+        // Add a dashed bounding box for MultiPolygon to show full extent
+        if (normalizedGeometry.type === 'MultiPolygon') {
+          // Calculate the bounding box of all polygons
+          let minLat = Infinity,
+            maxLat = -Infinity,
+            minLon = Infinity,
+            maxLon = -Infinity;
 
-      // Add a dashed bounding box for MultiPolygon to show full extent
-      if (normalizedGeometry.type === 'MultiPolygon') {
-        // Calculate the bounding box of all polygons
-        let minLat = Infinity,
-          maxLat = -Infinity,
-          minLon = Infinity,
-          maxLon = -Infinity;
-
-        normalizedGeometry.coordinates.forEach((polygonRings) => {
-          polygonRings.forEach((ring) => {
-            ring.forEach((coord) => {
-              const [lon, lat] = coord;
-              minLat = Math.min(minLat, lat);
-              maxLat = Math.max(maxLat, lat);
-              minLon = Math.min(minLon, lon);
-              maxLon = Math.max(maxLon, lon);
+          normalizedGeometry.coordinates.forEach((polygonRings) => {
+            polygonRings.forEach((ring) => {
+              ring.forEach((coord) => {
+                const [lon, lat] = coord;
+                minLat = Math.min(minLat, lat);
+                maxLat = Math.max(maxLat, lat);
+                minLon = Math.min(minLon, lon);
+                maxLon = Math.max(maxLon, lon);
+              });
             });
           });
+
+          // Create a bounding box rectangle
+          const bounds = L.latLngBounds(
+            L.latLng(minLat, minLon),
+            L.latLng(maxLat, maxLon)
+          );
+
+          // Add dashed rectangle to show full extent
+          L.rectangle(bounds, {
+            color: '#2563eb',
+            weight: 2,
+            opacity: 0.8,
+            fillOpacity: 0,
+            dashArray: '10, 5',
+            className: 'multipolygon-extent',
+          }).addTo(mapRef.current);
+        }
+
+        // Fit bounds to show the feature
+        mapRef.current.fitBounds(geoJsonLayer.getBounds(), {
+          padding: [20, 20],
         });
-
-        // Create a bounding box rectangle
-        const bounds = L.latLngBounds(
-          L.latLng(minLat, minLon),
-          L.latLng(maxLat, maxLon)
-        );
-
-        // Add dashed rectangle to show full extent
-        L.rectangle(bounds, {
-          color: '#2563eb',
-          weight: 2,
-          opacity: 0.8,
-          fillOpacity: 0,
-          dashArray: '10, 5',
-          className: 'multipolygon-extent',
-        }).addTo(mapRef.current);
+      } catch (error) {
+        console.error('Error rendering geometry:', error);
       }
+    };
 
-      // Fit bounds to show the feature
-      mapRef.current.fitBounds(geoJsonLayer.getBounds(), {
-        padding: [20, 20],
-      });
-    } catch (error) {
-      console.error('Error rendering geometry:', error);
-    }
+    renderMap();
 
     return () => {
+      cancelled = true;
       basemapCleanupRef.current?.();
       basemapCleanupRef.current = null;
       if (mapRef.current) {

--- a/frontend/src/components/search/GeospatialFilterMap.client.tsx
+++ b/frontend/src/components/search/GeospatialFilterMap.client.tsx
@@ -7,6 +7,8 @@ import { fetchMapH3 } from '../../services/api';
 import { HexLayerToggleControl } from '../map/HexLayerToggleControl';
 import { MapGeosearchControl } from '../map/MapGeosearchControl';
 import { attachBasemapSwitcher } from '../../config/basemaps';
+import { leafletGestureMapOptions } from '../../config/leafletConfig';
+import { registerLeafletGestureHandling } from '../../config/leafletGestureHandling';
 import {
   getSavedHexLayerEnabled,
   saveHexLayerEnabled,
@@ -145,22 +147,34 @@ export function GeospatialFilterMap({
     }
     return null;
   }, [searchParams]);
+  const getBBoxFromParamsRef = useRef(getBBoxFromParams);
+
+  useEffect(() => {
+    getBBoxFromParamsRef.current = getBBoxFromParams;
+  }, [getBBoxFromParams]);
 
   // Initialize map
   useEffect(() => {
     if (!mapContainerRef.current) return;
 
-    if (!mapRef.current) {
+    let cancelled = false;
+
+    const initializeMap = () => {
+      if (!mapContainerRef.current || mapRef.current) return;
+      registerLeafletGestureHandling(L);
+      if (cancelled || !mapContainerRef.current || mapRef.current) return;
+
       mapRef.current = L.map(mapContainerRef.current, {
         zoomControl: true,
         attributionControl: false,
         minZoom: 1,
+        ...leafletGestureMapOptions,
       });
       setMapInstance(mapRef.current);
       basemapCleanupRef.current = attachBasemapSwitcher(mapRef.current, L);
 
       // Set initial view: if URL has a location bbox, fit to it; otherwise world
-      const initialBbox = getBBoxFromParams();
+      const initialBbox = getBBoxFromParamsRef.current();
       if (initialBbox) {
         const bounds = L.latLngBounds(
           [initialBbox.bottomRight.lat, initialBbox.topLeft.lon],
@@ -192,7 +206,7 @@ export function GeospatialFilterMap({
             if (rect.width > 0 && rect.height > 0) {
               mapRef.current.invalidateSize();
               // If we have a bbox in URL, re-fit so bounds are correct after layout
-              const bbox = getBBoxFromParams();
+              const bbox = getBBoxFromParamsRef.current();
               if (bbox) {
                 const bounds = L.latLngBounds(
                   [bbox.bottomRight.lat, bbox.topLeft.lon],
@@ -256,9 +270,12 @@ export function GeospatialFilterMap({
 
       mapRef.current.on('moveend', handleMapMoveEnd);
       mapRef.current.on('zoomend', handleMapMoveEnd);
-    }
+    };
+
+    initializeMap();
 
     return () => {
+      cancelled = true;
       setMapInstance(null);
       basemapCleanupRef.current?.();
       basemapCleanupRef.current = null;
@@ -267,7 +284,7 @@ export function GeospatialFilterMap({
         mapRef.current = null;
       }
     };
-  }, [setSearchParams]);
+  }, []);
 
   // Update map view from URL params
   // This handles cases where bbox params are set programmatically (e.g., from autocomplete)
@@ -428,7 +445,7 @@ export function GeospatialFilterMap({
 
   // H3 hex layer: fetch hexes for current view and add GeoJSON layer; fit to hex cluster when search changes
   useEffect(() => {
-    const map = mapRef.current;
+    const map = mapInstance;
     if (!map) return;
 
     if (!hexLayerEnabled) {
@@ -591,7 +608,7 @@ export function GeospatialFilterMap({
         hexLayerRef.current = null;
       }
     };
-  }, [searchParams, hexLayerEnabled]);
+  }, [searchParams, hexLayerEnabled, mapInstance, getBBoxFromParams]);
 
   const handleSearchHere = () => {
     if (!mapRef.current) return;

--- a/frontend/src/components/search/MapResultView.client.tsx
+++ b/frontend/src/components/search/MapResultView.client.tsx
@@ -11,6 +11,10 @@ import {
 import L from 'leaflet';
 import OverlappingMarkerSpiderfier from '@krozamdev/overlapping-marker-spiderfier';
 import { BasemapSwitcherControl } from '../map/BasemapSwitcherControl';
+import { leafletGestureMapOptions } from '../../config/leafletConfig';
+import { registerLeafletGestureHandling } from '../../config/leafletGestureHandling';
+
+registerLeafletGestureHandling(L);
 
 interface MapResultViewProps {
   results: GeoDocument[];
@@ -48,7 +52,10 @@ function parseBbox(bbox: string | undefined): Bounds | null {
     const maxy = parseFloat(envMatch[3]);
     const miny = parseFloat(envMatch[4]);
     if (!isNaN(minx + maxx + maxy + miny)) {
-      return [[miny, minx], [maxy, maxx]];
+      return [
+        [miny, minx],
+        [maxy, maxx],
+      ];
     }
   }
 
@@ -56,7 +63,10 @@ function parseBbox(bbox: string | undefined): Bounds | null {
   const parts = s.split(',').map((p) => parseFloat(p.trim()));
   if (parts.length >= 4 && parts.every((n) => !isNaN(n))) {
     const [minx, miny, maxx, maxy] = parts;
-    return [[miny, minx], [maxy, maxx]];
+    return [
+      [miny, minx],
+      [maxy, maxx],
+    ];
   }
 
   return null;
@@ -77,7 +87,10 @@ const HighlightOverlayController: React.FC<{
       for (const ref of [geoJsonRef, rectRef]) {
         if (!ref.current) continue;
         try {
-          if (typeof map?.hasLayer === 'function' && map.hasLayer(ref.current)) {
+          if (
+            typeof map?.hasLayer === 'function' &&
+            map.hasLayer(ref.current)
+          ) {
             map.removeLayer(ref.current);
           }
         } catch {
@@ -99,15 +112,18 @@ const HighlightOverlayController: React.FC<{
       if (features.length === 0) return;
 
       // Same Feature format as LocationMap; try-catch handles any Leaflet errors
-      const geoJsonLayer = L.geoJSON({ type: 'FeatureCollection', features }, {
-        style: {
-          color: '#f59e0b',
-          weight: 3,
-          opacity: 1,
-          fillOpacity: 0.25,
-          fillColor: '#f59e0b',
-        },
-      });
+      const geoJsonLayer = L.geoJSON(
+        { type: 'FeatureCollection', features },
+        {
+          style: {
+            color: '#f59e0b',
+            weight: 3,
+            opacity: 1,
+            fillOpacity: 0.25,
+            fillColor: '#f59e0b',
+          },
+        }
+      );
       geoJsonLayer.addTo(map);
       geoJsonRef.current = geoJsonLayer;
 
@@ -166,13 +182,13 @@ const MapInitialFitController: React.FC<{
     const valid = bounds.filter(
       ([[minLat, minLon], [maxLat, maxLon]]) =>
         !isNaN(minLat + minLon + maxLat + maxLon) &&
-        minLat >= -90 && maxLat <= 90 &&
-        minLon >= -180 && maxLon <= 180
+        minLat >= -90 &&
+        maxLat <= 90 &&
+        minLon >= -180 &&
+        maxLon <= 180
     );
     if (valid.length === 0) return;
-    const group = L.featureGroup(
-      valid.map((b) => L.rectangle(b))
-    );
+    const group = L.featureGroup(valid.map((b) => L.rectangle(b)));
     if (group.getBounds().isValid()) {
       map.flyToBounds(group.getBounds(), { padding: [50, 50], duration: 0.5 });
     }
@@ -215,11 +231,17 @@ interface MarkerEntry {
 
 /** Renders numbered markers with OverlappingMarkerSpiderfier for overlapping pins */
 const SpiderfiedMarkers: React.FC<{
-  pins: { resource: GeoDocument; position: [number, number]; resultNumber: number }[];
+  pins: {
+    resource: GeoDocument;
+    position: [number, number];
+    resultNumber: number;
+  }[];
   highlightedResourceId: string | null;
 }> = ({ pins, highlightedResourceId }) => {
   const map = useMap();
-  const omsRef = useRef<InstanceType<typeof OverlappingMarkerSpiderfier> | null>(null);
+  const omsRef = useRef<InstanceType<
+    typeof OverlappingMarkerSpiderfier
+  > | null>(null);
   const entriesRef = useRef<MarkerEntry[]>([]);
 
   useEffect(() => {
@@ -232,13 +254,16 @@ const SpiderfiedMarkers: React.FC<{
     omsRef.current = oms;
 
     const popup = L.popup();
-    oms.addListener('click', (marker: L.Marker & { _popupContent?: HTMLElement }) => {
-      if (marker._popupContent) {
-        popup.setContent(marker._popupContent);
-        popup.setLatLng(marker.getLatLng());
-        map.openPopup(popup);
+    oms.addListener(
+      'click',
+      (marker: L.Marker & { _popupContent?: HTMLElement }) => {
+        if (marker._popupContent) {
+          popup.setContent(marker._popupContent);
+          popup.setLatLng(marker.getLatLng());
+          map.openPopup(popup);
+        }
       }
-    });
+    );
 
     const entries: MarkerEntry[] = [];
     pins.forEach((p) => {
@@ -266,10 +291,15 @@ const SpiderfiedMarkers: React.FC<{
       detailsLink.textContent = 'View Details';
 
       container.append(resultLabel, title, idLabel, detailsLink);
-      (marker as L.Marker & { _popupContent?: HTMLElement })._popupContent = container;
+      (marker as L.Marker & { _popupContent?: HTMLElement })._popupContent =
+        container;
       marker.addTo(map);
       oms.addMarker(marker);
-      entries.push({ marker, resourceId: p.resource.id, resultNumber: p.resultNumber });
+      entries.push({
+        marker,
+        resourceId: p.resource.id,
+        resultNumber: p.resultNumber,
+      });
     });
     entriesRef.current = entries;
 
@@ -352,8 +382,7 @@ export const MapResultView: React.FC<MapResultViewProps> = ({
         b = getBboxFromGeometry(geom ?? undefined) ?? null;
       }
       if (!b) {
-        const centroid =
-          ogm?.dcat_centroid ?? ogm?.dcat_centroid_original;
+        const centroid = ogm?.dcat_centroid ?? ogm?.dcat_centroid_original;
         let pos = parseCentroid(centroid);
         if (!pos) {
           const geom =
@@ -365,7 +394,10 @@ export const MapResultView: React.FC<MapResultViewProps> = ({
         if (pos) {
           const [lat, lon] = pos;
           const ε = 0.01;
-          b = [[lat - ε, lon - ε], [lat + ε, lon + ε]];
+          b = [
+            [lat - ε, lon - ε],
+            [lat + ε, lon + ε],
+          ];
         }
       }
       if (b) out.push(b);
@@ -388,7 +420,7 @@ export const MapResultView: React.FC<MapResultViewProps> = ({
         center={[0, 0]}
         zoom={2}
         className="h-full w-full"
-        scrollWheelZoom={true}
+        {...leafletGestureMapOptions}
       >
         <BasemapSwitcherControl />
 

--- a/frontend/src/components/search/MapView.tsx
+++ b/frontend/src/components/search/MapView.tsx
@@ -6,6 +6,8 @@ import { useMap } from '../../context/MapContext';
 import { isValidGeoJsonForLeaflet } from '../../utils/geometryUtils';
 import { useSearchParams } from 'react-router';
 import { attachBasemapSwitcher } from '../../config/basemaps';
+import { leafletGestureMapOptions } from '../../config/leafletConfig';
+import { registerLeafletGestureHandling } from '../../config/leafletGestureHandling';
 import { debugLog } from '../../utils/logger';
 
 interface MapViewProps {
@@ -31,7 +33,9 @@ export function MapView({ results }: MapViewProps) {
   // Leaflet requires `window`, so only load it in the browser.
   const loadLeaflet = useCallback(async () => {
     const mod = await import('leaflet');
-    return mod.default;
+    const LeafletNamespace = mod.default;
+    registerLeafletGestureHandling(LeafletNamespace);
+    return LeafletNamespace;
   }, []);
 
   // Parse bbox from URL params
@@ -84,10 +88,10 @@ export function MapView({ results }: MapViewProps) {
         const L = await loadLeaflet();
         if (!mapContainer.current) return;
         if (mapRef.current) return;
-        mapRef.current = L.map(mapContainer.current).setView(
-          [39.8283, -98.5795],
-          3
-        );
+        mapRef.current = L.map(
+          mapContainer.current,
+          leafletGestureMapOptions
+        ).setView([39.8283, -98.5795], 3);
         basemapCleanupRef.current = attachBasemapSwitcher(mapRef.current, L);
         debugLog('✅ Map initialized');
       })();

--- a/frontend/src/config/leafletConfig.ts
+++ b/frontend/src/config/leafletConfig.ts
@@ -1,9 +1,18 @@
 // src/config/leafletConfig.ts
+import type * as Leaflet from 'leaflet';
+
+export type LeafletGestureMapOptions = Leaflet.MapOptions & {
+  gestureHandling: true;
+  scrollWheelZoom: true;
+};
+
+export const leafletGestureMapOptions: LeafletGestureMapOptions = {
+  gestureHandling: true,
+  scrollWheelZoom: true,
+};
+
 export const leafletViewerOptions = {
-  MAP: {
-    gestureHandling: true,
-    scrollWheelZoom: true,
-  },
+  MAP: leafletGestureMapOptions,
   BOUNDSOVERLAY: {
     INDEX: { color: '#3388ff' },
     SHOW: { color: '#3388ff' },

--- a/frontend/src/config/leafletGestureHandling.ts
+++ b/frontend/src/config/leafletGestureHandling.ts
@@ -1,19 +1,97 @@
 import type * as Leaflet from 'leaflet';
-import { GestureHandling } from 'leaflet-gesture-handling';
-import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css';
 
 const REGISTERED_FLAG = '__btaaGestureHandlingRegistered';
+const SCROLL_WARNING_CLASS = 'leaflet-gesture-handling-scroll-warning';
+const SCROLL_WARNING_DURATION_MS = 1000;
 
 type LeafletMapConstructor = typeof Leaflet.Map & {
   [REGISTERED_FLAG]?: boolean;
 };
 
+type GestureHandlerInstance = Leaflet.Handler & {
+  _map: Leaflet.Map;
+  _gestureScrollTimer?: number;
+  _handleScroll: (event: Event) => void;
+  _handleMouseOut: () => void;
+};
+
 export function registerLeafletGestureHandling(
   LeafletNamespace: typeof Leaflet
-) {
+): void {
   const mapConstructor = LeafletNamespace.Map as LeafletMapConstructor;
 
   if (mapConstructor[REGISTERED_FLAG]) return;
+  if (typeof window === 'undefined') return;
+
+  const GestureHandling = LeafletNamespace.Handler.extend({
+    addHooks(this: GestureHandlerInstance) {
+      const map = this._map;
+      const container = map.getContainer();
+      const isMac = navigator.platform.toUpperCase().includes('MAC');
+
+      container.setAttribute(
+        'data-gesture-handling-scroll-content',
+        isMac
+          ? 'Use command + scroll to zoom the map'
+          : 'Use control + scroll to zoom the map'
+      );
+      map.scrollWheelZoom.disable();
+
+      LeafletNamespace.DomEvent.on(
+        container,
+        'wheel',
+        this._handleScroll,
+        this
+      );
+      map.on('mouseout', this._handleMouseOut, this);
+    },
+
+    removeHooks(this: GestureHandlerInstance) {
+      const map = this._map;
+      const container = map.getContainer();
+
+      if (this._gestureScrollTimer !== undefined) {
+        window.clearTimeout(this._gestureScrollTimer);
+      }
+      LeafletNamespace.DomUtil.removeClass(container, SCROLL_WARNING_CLASS);
+      LeafletNamespace.DomEvent.off(
+        container,
+        'wheel',
+        this._handleScroll,
+        this
+      );
+      map.off('mouseout', this._handleMouseOut, this);
+      map.scrollWheelZoom.enable();
+    },
+
+    _handleScroll(this: GestureHandlerInstance, event: Event) {
+      const wheelEvent = event as WheelEvent;
+      const map = this._map;
+      const container = map.getContainer();
+
+      if (wheelEvent.ctrlKey || wheelEvent.metaKey) {
+        LeafletNamespace.DomEvent.preventDefault(wheelEvent);
+        LeafletNamespace.DomUtil.removeClass(container, SCROLL_WARNING_CLASS);
+        map.scrollWheelZoom.enable();
+        return;
+      }
+
+      map.scrollWheelZoom.disable();
+      LeafletNamespace.DomUtil.addClass(container, SCROLL_WARNING_CLASS);
+      window.clearTimeout(this._gestureScrollTimer);
+      this._gestureScrollTimer = window.setTimeout(() => {
+        LeafletNamespace.DomUtil.removeClass(container, SCROLL_WARNING_CLASS);
+      }, SCROLL_WARNING_DURATION_MS);
+    },
+
+    _handleMouseOut(this: GestureHandlerInstance) {
+      const map = this._map;
+      const container = map.getContainer();
+
+      map.scrollWheelZoom.disable();
+      LeafletNamespace.DomUtil.removeClass(container, SCROLL_WARNING_CLASS);
+    },
+  });
 
   LeafletNamespace.Map.addInitHook(
     'addHandler',

--- a/frontend/src/geoblacklight/leaflet_viewer_controller.js
+++ b/frontend/src/geoblacklight/leaflet_viewer_controller.js
@@ -3,12 +3,12 @@ import BaseLeafletViewerController from '@geoblacklight/frontend/app/javascript/
 import Sleep from 'geoblacklight/leaflet/controls/sleep';
 import { registerLeafletGestureHandling } from '../config/leafletGestureHandling';
 
-registerLeafletGestureHandling(Leaflet);
-
 export default class LeafletViewerController extends BaseLeafletViewerController {
   // Keep the GeoBlacklight controller behavior, but let local MAP options reach L.map.
   async loadMap() {
     if (this.map) return;
+
+    registerLeafletGestureHandling(Leaflet);
 
     const sleepSettings = this.optionsValue.SLEEP || { SLEEP: false };
     const mapSettings = this.optionsValue.MAP || {};

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -435,11 +435,11 @@ export function HomePage() {
                 <button
                   type="button"
                   onClick={() => setShowHeroDescription(false)}
-                  className="absolute right-3 top-3 z-30 inline-flex h-8 w-8 cursor-pointer items-center justify-center border border-gray-300 bg-white/90 text-gray-600 transition-colors hover:bg-white hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-active"
+                  className="pointer-events-auto absolute right-2 top-2 z-50 inline-flex h-9 w-9 cursor-pointer touch-manipulation items-center justify-center border border-gray-300 bg-white/90 text-gray-600 transition-colors hover:bg-white hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-active"
                   aria-label="Hide map description"
                   title="Hide"
                 >
-                  <X className="pointer-events-none h-4 w-4" aria-hidden />
+                  <X className="h-4 w-4" aria-hidden />
                 </button>
                 <div className="relative z-10 pr-12">
                   <p className="text-xs font-semibold uppercase tracking-[0.14em] text-brand-primary">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -435,23 +435,25 @@ export function HomePage() {
                 <button
                   type="button"
                   onClick={() => setShowHeroDescription(false)}
-                  className="absolute right-3 top-3 z-10 inline-flex h-7 w-7 items-center justify-center border border-gray-300 bg-white/90 text-gray-600 transition-colors hover:bg-white hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-active"
+                  className="absolute right-3 top-3 z-30 inline-flex h-8 w-8 cursor-pointer items-center justify-center border border-gray-300 bg-white/90 text-gray-600 transition-colors hover:bg-white hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-active"
                   aria-label="Hide map description"
                   title="Hide"
                 >
-                  <X className="h-4 w-4" />
+                  <X className="pointer-events-none h-4 w-4" aria-hidden />
                 </button>
-                <p className="relative z-10 text-xs font-semibold uppercase tracking-[0.14em] text-brand-primary">
-                  BTAA Geoportal
-                </p>
-                <p className="relative z-10 mt-1 text-xl lg:text-2xl font-semibold text-gray-800">
-                  {theme.institution.hero_text ||
-                    'Search geospatial resources from Big Ten Academic Alliance institutions'}
-                </p>
-                <p className="relative z-10 text-sm text-gray-600 mt-2">
-                  {theme.institution.hero_description ||
-                    'Browse and download GIS data, maps, and other geospatial resources.'}
-                </p>
+                <div className="relative z-10 pr-12">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-brand-primary">
+                    BTAA Geoportal
+                  </p>
+                  <p className="mt-1 text-xl lg:text-2xl font-semibold text-gray-800">
+                    {theme.institution.hero_text ||
+                      'Search geospatial resources from Big Ten Academic Alliance institutions'}
+                  </p>
+                  <p className="text-sm text-gray-600 mt-2">
+                    {theme.institution.hero_description ||
+                      'Browse and download GIS data, maps, and other geospatial resources.'}
+                  </p>
+                </div>
               </div>
             </div>
           )}

--- a/frontend/src/pages/MapPage.client.tsx
+++ b/frontend/src/pages/MapPage.client.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react';
 import { Link } from 'react-router';
 import { Seo } from '../components/Seo';
 import { MapContainer } from 'react-leaflet';
+import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { Header } from '../components/layout/Header';
 import { Footer } from '../components/layout/Footer';
@@ -20,9 +21,13 @@ import { SelectedFeaturePanel } from '../components/map/SelectedFeaturePanel';
 import { StatsBar } from '../components/map/StatsBar';
 import { BasemapSwitcherControl } from '../components/map/BasemapSwitcherControl';
 import { formatCount } from '../utils/formatNumber';
+import { leafletGestureMapOptions } from '../config/leafletConfig';
+import { registerLeafletGestureHandling } from '../config/leafletGestureHandling';
 import { DEFAULT_US_CENTER, DEFAULT_US_ZOOM } from '../config/mapView';
 import type { ZoomLevel } from '../types/map';
 import type { MapFeatureClickPayload } from '../types/map';
+
+registerLeafletGestureHandling(L);
 
 export function MapPage() {
   // Local UI state: selected feature popup, current search query, and zoom level tab
@@ -161,7 +166,7 @@ export function MapPage() {
                   center={DEFAULT_US_CENTER}
                   zoom={DEFAULT_US_ZOOM}
                   className="h-full w-full"
-                  scrollWheelZoom
+                  {...leafletGestureMapOptions}
                 >
                   <BasemapSwitcherControl />
                   <MapUpdaterHex
@@ -269,6 +274,7 @@ export function MapPage() {
                   center={DEFAULT_US_CENTER}
                   zoom={DEFAULT_US_ZOOM}
                   className="h-80 w-full rounded-lg"
+                  {...leafletGestureMapOptions}
                 >
                   <BasemapSwitcherControl />
                   <MapUpdater
@@ -285,6 +291,7 @@ export function MapPage() {
                   center={DEFAULT_US_CENTER}
                   zoom={DEFAULT_US_ZOOM}
                   className="h-80 w-full rounded-lg"
+                  {...leafletGestureMapOptions}
                 >
                   <BasemapSwitcherControl />
                   <MapUpdater
@@ -301,6 +308,7 @@ export function MapPage() {
                   center={DEFAULT_US_CENTER}
                   zoom={DEFAULT_US_ZOOM}
                   className="h-80 w-full rounded-lg"
+                  {...leafletGestureMapOptions}
                 >
                   <BasemapSwitcherControl />
                   <MapUpdater

--- a/frontend/src/styles/leaflet.css
+++ b/frontend/src/styles/leaflet.css
@@ -154,3 +154,36 @@
 .leaflet-control-attribution a {
   color: #1d4ed8 !important;
 }
+
+.leaflet-container.leaflet-gesture-handling-scroll-warning::after {
+  content: attr(data-gesture-handling-scroll-content);
+  position: absolute;
+  inset: 0;
+  z-index: 461;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 15px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #ffffff;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  font-size: 20px;
+  line-height: 1.35;
+  text-align: center;
+  pointer-events: none;
+  animation: leaflet-gestures-fadein 0.2s ease-out;
+}
+
+@keyframes leaflet-gestures-fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary

This fixes the shared Leaflet command/control scroll behavior across the homepage map, map page, search map views, search results Location map, resource sidebar Location map, and the GeoBlacklight viewer config.

It also fixes the homepage hero description close control so the visible X is part of the clickable hit target and the button has a slightly larger pointer-active target.

## Root Cause

The previous gesture setup imported `leaflet-gesture-handling` in a way that allowed the plugin to touch browser-only Leaflet globals during Vite SSR, causing an immediate `L is not defined` overlay. Some map surfaces also were not using the same shared map options.

## Validation

- `npm test -- --run src/__tests__/pages/Home.test.tsx src/__tests__/components/GeospatialFilterMap.client.test.tsx src/__tests__/components/resource/LocationMap.client.test.tsx src/__tests__/components/search/MapResultView.test.tsx src/__tests__/components/MapView.test.tsx src/__tests__/components/home/HomePageHexMapBackground.carousel.test.tsx src/__tests__/components/home/HomePageHexMapBackground.carousel-a11y.test.tsx`
- Targeted ESLint on the changed files
- Targeted Prettier check on the changed files
- Targeted TypeScript check for shared Leaflet config
- Docker dev server route checks for `/`, `/search?view=map`, `/search?view=gallery`, and `/resources/stanford-fc944xn1421`, all returning `200` with no `L is not defined` error

Note: the focused test run still prints existing non-fatal homepage carousel `act(...)` warnings and a Happy DOM YouTube DNS warning, but all tests pass.