### PR TITLE
[codex] Fix metadata modal header overlap

### DIFF
--- a/frontend/src/__tests__/components/LinksTable.test.tsx
+++ b/frontend/src/__tests__/components/LinksTable.test.tsx
@@ -10,10 +10,17 @@ vi.mock('../../services/analytics', () => ({
 
 // Mock fetch for metadata display endpoint
 const mockFetch = vi.fn();
+const originalFetch = globalThis.fetch;
 
 describe('LinksTable', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    document.body.style.overflow = '';
   });
 
   const mockLinks = {
@@ -79,6 +86,23 @@ describe('LinksTable', () => {
     expect(screen.getByText('WFS Service')).toBeInTheDocument();
   });
 
+  it('portals the lightbox outside its render container', () => {
+    render(
+      <div data-testid="sticky-sidebar">
+        <LinksTable links={mockLinks} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Web Services' }));
+
+    const sidebar = screen.getByTestId('sticky-sidebar');
+    const dialog = screen.getByRole('dialog', { name: 'Web Services' });
+    const overlay = screen.getByTestId('links-table-lightbox-overlay');
+
+    expect(sidebar).not.toContainElement(dialog);
+    expect(overlay.parentElement).toBe(document.body);
+  });
+
   it('closes lightbox when close button is clicked', () => {
     render(<LinksTable links={mockLinks} />);
     const webServicesButton = screen.getByRole('button', {
@@ -123,8 +147,6 @@ describe('LinksTable', () => {
 
   describe('Metadata lightbox with transformable formats', () => {
     it('opens Metadata lightbox and fetches transformed content when resourceId and format provided', async () => {
-      const originalFetch = global.fetch;
-      global.fetch = mockFetch;
       mockFetch.mockResolvedValueOnce({
         ok: true,
         text: () =>
@@ -148,8 +170,6 @@ describe('LinksTable', () => {
       await waitFor(() => {
         expect(screen.getByTitle('ISO 19115 XML')).toBeInTheDocument();
       });
-
-      global.fetch = originalFetch;
     });
 
     it('shows Download button when viewing transformed metadata', async () => {

--- a/frontend/src/components/resource/LinksTable.tsx
+++ b/frontend/src/components/resource/LinksTable.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
+import { createPortal } from 'react-dom';
 import {
   ExternalLink,
   Link as LinkIcon,
@@ -27,11 +28,8 @@ interface LinksTableProps {
   searchId?: string;
 }
 
-export function LinksTable({
-  links,
-  resourceId,
-  searchId,
-}: LinksTableProps) {
+export function LinksTable({ links, resourceId, searchId }: LinksTableProps) {
+  const lightboxTitleId = useId();
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxContent, setLightboxContent] = useState<{
     category: string;
@@ -112,13 +110,27 @@ export function LinksTable({
     };
   }, [activeMetadataLink?.format, activeMetadataLink?.label, resourceId]);
 
+  useEffect(() => {
+    if (!lightboxOpen || typeof document === 'undefined') return;
+
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousBodyOverflow;
+    };
+  }, [lightboxOpen]);
+
   if (!links || Object.keys(links).length === 0) return null;
 
   const resolveEventType = (category: string) => {
     const categoryLower = category.toLowerCase();
 
     if (categoryLower.includes('metadata')) return 'metadata_download';
-    if (categoryLower.includes('web services') || categoryLower.includes('api')) {
+    if (
+      categoryLower.includes('web services') ||
+      categoryLower.includes('api')
+    ) {
       return 'web_service_click';
     }
     if (categoryLower.includes('source') || categoryLower.includes('visit')) {
@@ -233,6 +245,127 @@ export function LinksTable({
   const showMetadataView =
     isMetadataLightbox && resourceId && transformableMetadataItems.length > 0;
 
+  const lightboxModal =
+    lightboxOpen && lightboxContent ? (
+      <div
+        className="fixed inset-0 z-[10050] flex items-center justify-center bg-black/50 p-4"
+        data-testid="links-table-lightbox-overlay"
+        onMouseDown={(event) => {
+          if (event.target === event.currentTarget) closeLightbox();
+        }}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={lightboxTitleId}
+          className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[85vh] overflow-hidden flex flex-col"
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <div className="flex items-center justify-between px-6 py-4 bg-gray-50 border-b border-gray-200 shrink-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3
+                id={lightboxTitleId}
+                className="text-lg font-semibold text-gray-900"
+              >
+                {lightboxContent.category}
+              </h3>
+              {/* Format tabs - Metadata only */}
+              {showMetadataView && transformableMetadataItems.length > 1 && (
+                <div className="flex gap-1 ml-2" role="tablist">
+                  {transformableMetadataItems.map((link) => (
+                    <button
+                      key={link.format}
+                      type="button"
+                      role="tab"
+                      aria-selected={activeMetadataLink?.format === link.format}
+                      onClick={() => setActiveMetadataLink(link)}
+                      className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
+                        activeMetadataLink?.format === link.format
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                      }`}
+                    >
+                      {link.label.replace(' XML', '').replace(' Metadata', '')}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {showMetadataView && activeMetadataLink && (
+                <a
+                  href={activeMetadataLink.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    trackLinkClick(lightboxContent.category, activeMetadataLink)
+                  }
+                  className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded"
+                >
+                  <Download className="w-4 h-4" />
+                  Download
+                </a>
+              )}
+              <button
+                onClick={closeLightbox}
+                className="text-gray-400 hover:text-gray-600 transition-colors p-1"
+                aria-label="Close"
+              >
+                <X className="w-6 h-6" />
+              </button>
+            </div>
+          </div>
+          <div className="p-6 overflow-y-auto flex-1 min-h-0">
+            {showMetadataView ? (
+              <>
+                {metadataLoading && (
+                  <div className="flex items-center justify-center py-12">
+                    <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
+                  </div>
+                )}
+                {metadataError && !metadataLoading && (
+                  <div className="text-red-600 text-sm">{metadataError}</div>
+                )}
+                {metadataHtml && !metadataLoading && (
+                  <iframe
+                    title={activeMetadataLink?.label ?? 'Metadata'}
+                    srcDoc={metadataHtml}
+                    className="w-full min-h-[500px] border border-gray-200 rounded-lg"
+                    sandbox="allow-same-origin"
+                  />
+                )}
+              </>
+            ) : (
+              <div className="space-y-3">
+                {lightboxContent.items.map((link, index) => (
+                  <a
+                    key={index}
+                    href={link.url}
+                    onClick={() =>
+                      trackLinkClick(lightboxContent.category, link)
+                    }
+                    className="flex items-center gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors group"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="w-5 h-5 text-gray-400 group-hover:text-blue-500" />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-gray-900 group-hover:text-blue-600">
+                        {link.label}
+                      </div>
+                      <div className="text-xs text-gray-500 mt-1 break-all">
+                        {link.url}
+                      </div>
+                    </div>
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    ) : null;
+
   return (
     <>
       <div className="bg-white rounded-lg shadow-md overflow-hidden">
@@ -255,115 +388,9 @@ export function LinksTable({
         </div>
       </div>
 
-      {/* Lightbox Modal */}
-      {lightboxOpen && lightboxContent && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999] p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-4xl w-full max-h-[85vh] overflow-hidden flex flex-col">
-            <div className="flex items-center justify-between px-6 py-4 bg-gray-50 border-b border-gray-200 shrink-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <h3 className="text-lg font-semibold text-gray-900">
-                  {lightboxContent.category}
-                </h3>
-                {/* Format tabs - Metadata only */}
-                {showMetadataView && transformableMetadataItems.length > 1 && (
-                  <div className="flex gap-1 ml-2" role="tablist">
-                    {transformableMetadataItems.map((link) => (
-                      <button
-                        key={link.format}
-                        type="button"
-                        role="tab"
-                        aria-selected={
-                          activeMetadataLink?.format === link.format
-                        }
-                        onClick={() => setActiveMetadataLink(link)}
-                        className={`px-3 py-1.5 text-sm font-medium rounded transition-colors ${
-                          activeMetadataLink?.format === link.format
-                            ? 'bg-blue-600 text-white'
-                            : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-                        }`}
-                      >
-                        {link.label
-                          .replace(' XML', '')
-                          .replace(' Metadata', '')}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                {showMetadataView && activeMetadataLink && (
-                  <a
-                    href={activeMetadataLink.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={() =>
-                      trackLinkClick(lightboxContent.category, activeMetadataLink)
-                    }
-                    className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded"
-                  >
-                    <Download className="w-4 h-4" />
-                    Download
-                  </a>
-                )}
-                <button
-                  onClick={closeLightbox}
-                  className="text-gray-400 hover:text-gray-600 transition-colors p-1"
-                  aria-label="Close"
-                >
-                  <X className="w-6 h-6" />
-                </button>
-              </div>
-            </div>
-            <div className="p-6 overflow-y-auto flex-1 min-h-0">
-              {showMetadataView ? (
-                <>
-                  {metadataLoading && (
-                    <div className="flex items-center justify-center py-12">
-                      <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
-                    </div>
-                  )}
-                  {metadataError && !metadataLoading && (
-                    <div className="text-red-600 text-sm">{metadataError}</div>
-                  )}
-                  {metadataHtml && !metadataLoading && (
-                    <iframe
-                      title={activeMetadataLink?.label ?? 'Metadata'}
-                      srcDoc={metadataHtml}
-                      className="w-full min-h-[500px] border border-gray-200 rounded-lg"
-                      sandbox="allow-same-origin"
-                    />
-                  )}
-                </>
-              ) : (
-                <div className="space-y-3">
-                  {lightboxContent.items.map((link, index) => (
-                    <a
-                      key={index}
-                      href={link.url}
-                      onClick={() =>
-                        trackLinkClick(lightboxContent.category, link)
-                      }
-                      className="flex items-center gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors group"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <ExternalLink className="w-5 h-5 text-gray-400 group-hover:text-blue-500" />
-                      <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium text-gray-900 group-hover:text-blue-600">
-                          {link.label}
-                        </div>
-                        <div className="text-xs text-gray-500 mt-1 break-all">
-                          {link.url}
-                        </div>
-                      </div>
-                    </a>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
+      {lightboxModal && typeof document !== 'undefined'
+        ? createPortal(lightboxModal, document.body)
+        : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Render the resource LinksTable lightbox through a React portal attached to document.body so it escapes sticky sidebar and page stacking contexts.
- Raise the overlay to the shared modal layer and lock body scrolling while the lightbox is open.
- Add a regression test that confirms the lightbox is portaled outside its render container, plus more deterministic metadata fetch mocking in the LinksTable tests.

## Root Cause

The Metadata link modal was rendered inline inside the resource page/sidebar. In browser layouts with the sticky header and resource sidebar stacking contexts, the fixed overlay could be painted underneath the page header, partially obscuring the modal at actual zoom.

## Validation

- npm test -- src/__tests__/components/LinksTable.test.tsx --run
- ./node_modules/.bin/eslint src/components/resource/LinksTable.tsx src/__tests__/components/LinksTable.test.tsx
- ./node_modules/.bin/prettier --check src/components/resource/LinksTable.tsx src/__tests__/components/LinksTable.test.tsx
- git diff --check

Note: npm run lint -- src/components/resource/LinksTable.tsx src/__tests__/components/LinksTable.test.tsx invokes the project script that always lints the full src tree and still reports unrelated existing lint errors outside this change.