### PR TITLE
[codex] Add WxS identifiers to web service modal

### DIFF
--- a/backend/app/services/link_service.py
+++ b/backend/app/services/link_service.py
@@ -1,6 +1,7 @@
 import logging
+import re
 from typing import Any, Dict, List, Optional
-from urllib.parse import quote
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
 
 from app.services.distribution_repository import (
     DistributionContext,
@@ -10,6 +11,10 @@ from app.services.distribution_repository import (
 from db.database import database
 
 logger = logging.getLogger(__name__)
+BBOX_ENVELOPE_RE = re.compile(
+    r"ENVELOPE\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^)]+)\s*\)",
+    re.IGNORECASE,
+)
 
 
 class LinkService:
@@ -33,7 +38,7 @@ class LinkService:
         self.by_uri = distribution_context.by_uri
         self._legacy_refs_cache: Optional[Dict[str, Any]] = None
 
-    def get_links(self) -> Dict[str, List[Dict[str, str]]]:
+    def get_links(self) -> Dict[str, List[Dict[str, Any]]]:
         """
         Get all links for a resource organized by category.
 
@@ -83,7 +88,7 @@ class LinkService:
 
         return links
 
-    def _get_web_services_links(self) -> List[Dict[str, str]]:
+    def _get_web_services_links(self) -> List[Dict[str, Any]]:
         """Get the “Web Services” links derived from resource distributions."""
         links = []
         try:
@@ -102,14 +107,33 @@ class LinkService:
 
             # OGC Services
             service_map = {
-                "http://www.opengis.net/def/serviceType/ogc/wms": "Web Mapping Service (WMS)",
-                "http://www.opengis.net/def/serviceType/ogc/wfs": "Web Feature Service (WFS)",
-                "http://www.opengis.net/def/serviceType/ogc/wcs": "Web Coverage Service (WCS)",
-                "http://www.opengis.net/def/serviceType/ogc/wmts": "Web Map Tile Service (WMTS)",
+                "http://www.opengis.net/def/serviceType/ogc/wms": (
+                    "Web Mapping Service (WMS)",
+                    "WMS",
+                ),
+                "http://www.opengis.net/def/serviceType/ogc/wfs": (
+                    "Web Feature Service (WFS)",
+                    "WFS",
+                ),
+                "http://www.opengis.net/def/serviceType/ogc/wcs": (
+                    "Web Coverage Service (WCS)",
+                    "WCS",
+                ),
+                "http://www.opengis.net/def/serviceType/ogc/wmts": (
+                    "Web Map Tile Service (WMTS)",
+                    "WMTS",
+                ),
             }
-            for uri, label in service_map.items():
+            for uri, (label, service_type) in service_map.items():
                 if url := self._first_url(uri):
-                    links.append({"label": label, "url": url})
+                    links.append(
+                        self._web_service_link(
+                            label,
+                            url,
+                            service_type=service_type,
+                            include_wxs_identifier=True,
+                        )
+                    )
 
             # Tile Services
             tile_map = {
@@ -229,7 +253,7 @@ class LinkService:
         return links
 
     @staticmethod
-    async def get_resource_links(resource_id: str) -> Dict[str, List[Dict[str, str]]]:
+    async def get_resource_links(resource_id: str) -> Dict[str, List[Dict[str, Any]]]:
         """
         Get all links for a resource by its ID organized by category.
 
@@ -242,7 +266,7 @@ class LinkService:
         try:
             # Fetch the resource from the database
             resource_query = """
-                SELECT id, dct_title_s
+                SELECT id, dct_title_s, dct_references_s, "gbl_wxsIdentifier_s", dcat_bbox
                 FROM resources
                 WHERE id = :resource_id
             """
@@ -260,6 +284,131 @@ class LinkService:
         except Exception as e:
             logger.error(f"Error getting resource links for {resource_id}: {e}", exc_info=True)
             return {}
+
+    def _web_service_link(
+        self,
+        label: str,
+        url: str,
+        *,
+        service_type: Optional[str] = None,
+        include_wxs_identifier: bool = False,
+    ) -> Dict[str, Any]:
+        link: Dict[str, Any] = {"label": label, "url": url}
+        wxs_identifier = None
+        if include_wxs_identifier:
+            wxs_identifier = self._wxs_identifier()
+            if wxs_identifier:
+                link["wxs_identifier"] = wxs_identifier
+        if wxs_identifier and service_type:
+            request = self._ogc_layer_request(
+                url,
+                service_type=service_type,
+                wxs_identifier=wxs_identifier,
+            )
+            if request:
+                link.update(request)
+        return link
+
+    def _ogc_layer_request(
+        self,
+        service_url: str,
+        *,
+        service_type: str,
+        wxs_identifier: str,
+    ) -> Optional[Dict[str, str]]:
+        service_type = service_type.upper()
+        if service_type == "WMS":
+            bbox = self._wms_bbox()
+            if not bbox:
+                return None
+            request_url = self._url_with_query(
+                service_url,
+                {
+                    "SERVICE": "WMS",
+                    "VERSION": "1.1.1",
+                    "REQUEST": "GetMap",
+                    "LAYERS": wxs_identifier,
+                    "STYLES": "",
+                    "BBOX": bbox,
+                    "WIDTH": "1024",
+                    "HEIGHT": "768",
+                    "SRS": "EPSG:4326",
+                    "FORMAT": "image/png",
+                    "TRANSPARENT": "true",
+                    "EXCEPTIONS": "application/vnd.ogc.se_inimage",
+                },
+            )
+            return {"request_url": request_url, "request_label": "Open map preview"}
+        if service_type == "WFS":
+            request_url = self._url_with_query(
+                service_url,
+                {
+                    "SERVICE": "WFS",
+                    "VERSION": "1.1.0",
+                    "REQUEST": "DescribeFeatureType",
+                    "TYPENAME": wxs_identifier,
+                },
+            )
+            return {"request_url": request_url, "request_label": "Open layer schema"}
+        if service_type == "WCS":
+            request_url = self._url_with_query(
+                service_url,
+                {
+                    "SERVICE": "WCS",
+                    "VERSION": "2.0.1",
+                    "REQUEST": "DescribeCoverage",
+                    "COVERAGEID": wxs_identifier,
+                },
+            )
+            return {"request_url": request_url, "request_label": "Open coverage description"}
+        return None
+
+    @staticmethod
+    def _url_with_query(url: str, params: Dict[str, str]) -> str:
+        parts = urlsplit(url)
+        query = dict(parse_qsl(parts.query, keep_blank_values=True))
+        query.update(params)
+        return urlunsplit(
+            (
+                parts.scheme,
+                parts.netloc,
+                parts.path,
+                urlencode(query),
+                parts.fragment,
+            )
+        )
+
+    def _wms_bbox(self) -> Optional[str]:
+        bbox = self.resource_dict.get("dcat_bbox")
+        if not isinstance(bbox, str):
+            return None
+        match = BBOX_ENVELOPE_RE.search(bbox)
+        if match:
+            try:
+                min_x, max_x, max_y, min_y = (float(value.strip()) for value in match.groups())
+            except ValueError:
+                return None
+            return f"{min_x:g},{min_y:g},{max_x:g},{max_y:g}"
+
+        parts = [part.strip() for part in bbox.split(",")]
+        if len(parts) != 4:
+            return None
+        try:
+            min_x, min_y, max_x, max_y = (float(value) for value in parts)
+        except ValueError:
+            return None
+        return f"{min_x:g},{min_y:g},{max_x:g},{max_y:g}"
+
+    def _wxs_identifier(self) -> Optional[str]:
+        for key in ("gbl_wxsIdentifier_s", "gbl_wxsidentifier_s"):
+            value = self.resource_dict.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, str) and item.strip():
+                        return item.strip()
+        return None
 
     def _first_url(self, uri: str) -> Optional[str]:
         # Prefer distribution context if available

--- a/backend/tests/services/test_link_service.py
+++ b/backend/tests/services/test_link_service.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from app.services import link_service as link_service_module
 from app.services.link_service import LinkService
 
 
@@ -211,6 +212,47 @@ class TestLinkServiceWebServicesLinks:
         assert {"label": "Web Feature Service (WFS)", "url": "http://example.com/wfs"} in links
         assert {"label": "Web Coverage Service (WCS)", "url": "http://example.com/wcs"} in links
         assert {"label": "Web Map Tile Service (WMTS)", "url": "http://example.com/wmts"} in links
+
+    def test_get_web_services_links_ogc_services_include_wxs_identifier(self):
+        """Test OGC service links include the layer identifier when present."""
+        resource_dict = {
+            "gbl_wxsIdentifier_s": "druid:ff131yz1610",
+            "dcat_bbox": "ENVELOPE(-124,-122,39,38)",
+            "dct_references_s": json.dumps(
+                {
+                    "http://www.opengis.net/def/serviceType/ogc/wms": "http://example.com/wms",
+                    "http://www.opengis.net/def/serviceType/ogc/wfs": "http://example.com/wfs",
+                }
+            ),
+        }
+
+        service = LinkService(resource_dict)
+        links = service._get_web_services_links()
+
+        assert links == [
+            {
+                "label": "Web Mapping Service (WMS)",
+                "url": "http://example.com/wms",
+                "wxs_identifier": "druid:ff131yz1610",
+                "request_url": (
+                    "http://example.com/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&"
+                    "LAYERS=druid%3Aff131yz1610&STYLES=&BBOX=-124%2C38%2C-122%2C39&"
+                    "WIDTH=1024&HEIGHT=768&SRS=EPSG%3A4326&FORMAT=image%2Fpng&"
+                    "TRANSPARENT=true&EXCEPTIONS=application%2Fvnd.ogc.se_inimage"
+                ),
+                "request_label": "Open map preview",
+            },
+            {
+                "label": "Web Feature Service (WFS)",
+                "url": "http://example.com/wfs",
+                "wxs_identifier": "druid:ff131yz1610",
+                "request_url": (
+                    "http://example.com/wfs?SERVICE=WFS&VERSION=1.1.0&"
+                    "REQUEST=DescribeFeatureType&TYPENAME=druid%3Aff131yz1610"
+                ),
+                "request_label": "Open layer schema",
+            },
+        ]
 
     def test_get_web_services_links_tile_services(self):
         """Test getting tile service links."""
@@ -653,6 +695,24 @@ class TestLinkServiceGetLinks:
 
 class TestLinkServiceStaticMethod:
     """Test cases for the static get_resource_links method."""
+
+    @pytest.mark.asyncio
+    async def test_get_resource_links_queries_mixed_case_wxs_identifier(self, monkeypatch):
+        """The resources table stores the Aardvark WxS column with mixed case."""
+        captured = {}
+
+        async def fake_fetch_one(query, values):
+            captured["query"] = query
+            captured["values"] = values
+            return None
+
+        monkeypatch.setattr(link_service_module.database, "fetch_one", fake_fetch_one)
+
+        result = await LinkService.get_resource_links("stanford-bs024ty5255")
+
+        assert result == {}
+        assert '"gbl_wxsIdentifier_s"' in captured["query"]
+        assert captured["values"] == {"resource_id": "stanford-bs024ty5255"}
 
     @pytest.mark.asyncio
     async def test_get_resource_links_with_real_database(self):

--- a/frontend/src/__tests__/components/LinksTable.test.tsx
+++ b/frontend/src/__tests__/components/LinksTable.test.tsx
@@ -86,6 +86,43 @@ describe('LinksTable', () => {
     expect(screen.getByText('WFS Service')).toBeInTheDocument();
   });
 
+  it('shows WxS identifiers in the Web Services lightbox', () => {
+    render(
+      <LinksTable
+        links={{
+          'Web Services': [
+            {
+              label: 'Web Mapping Service (WMS)',
+              url: 'https://geowebservices.stanford.edu/geoserver/wms',
+              wxs_identifier: 'druid:ff131yz1610',
+              request_url:
+                'https://geowebservices.stanford.edu/geoserver/wms?SERVICE=WMS&REQUEST=GetMap',
+              request_label: 'Open map preview',
+            },
+          ],
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Web Services' }));
+
+    expect(screen.getByText('Service URL')).toBeInTheDocument();
+    expect(screen.getByText('WxS Identifier')).toBeInTheDocument();
+    expect(screen.getByText('druid:ff131yz1610')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Copy service URL' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Copy WxS identifier' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Open map preview' })
+    ).toHaveAttribute(
+      'href',
+      'https://geowebservices.stanford.edu/geoserver/wms?SERVICE=WMS&REQUEST=GetMap'
+    );
+  });
+
   it('portals the lightbox outside its render container', () => {
     render(
       <div data-testid="sticky-sidebar">

--- a/frontend/src/components/resource/LinksTable.tsx
+++ b/frontend/src/components/resource/LinksTable.tsx
@@ -12,6 +12,8 @@ import {
   MapPin,
   Loader2,
   Download,
+  Clipboard,
+  Check,
 } from 'lucide-react';
 import { getApiBasePath } from '../../services/api';
 import { scheduleAnalyticsBatch } from '../../services/analytics';
@@ -20,6 +22,9 @@ interface LinkItem {
   label: string;
   url: string;
   format?: 'iso' | 'fgdc' | 'html';
+  wxs_identifier?: string;
+  request_url?: string;
+  request_label?: string;
 }
 
 interface LinksTableProps {
@@ -41,6 +46,7 @@ export function LinksTable({ links, resourceId, searchId }: LinksTableProps) {
   const [metadataHtml, setMetadataHtml] = useState<string | null>(null);
   const [metadataLoading, setMetadataLoading] = useState(false);
   const [metadataError, setMetadataError] = useState<string | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
   const transformableMetadataItems =
     lightboxContent?.category.toLowerCase().includes('metadata') && resourceId
@@ -146,7 +152,11 @@ export function LinksTable({ links, resourceId, searchId }: LinksTableProps) {
     return 'outbound_link_click';
   };
 
-  const trackLinkClick = (category: string, item: LinkItem) => {
+  const trackLinkClick = (
+    category: string,
+    item: LinkItem,
+    destinationUrl = item.url
+  ) => {
     scheduleAnalyticsBatch({
       events: [
         {
@@ -154,16 +164,60 @@ export function LinksTable({ links, resourceId, searchId }: LinksTableProps) {
           search_id: searchId,
           resource_id: resourceId,
           label: item.label,
-          destination_url: item.url,
+          destination_url: destinationUrl,
           source_component: 'LinksTable',
           properties: {
             category,
             format: item.format,
+            wxs_identifier: item.wxs_identifier,
           },
         },
       ],
     });
   };
+
+  const copyToClipboard = async (value: string, key: string) => {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+      } else {
+        const textArea = document.createElement('textarea');
+        textArea.value = value;
+        textArea.setAttribute('readonly', '');
+        textArea.style.position = 'absolute';
+        textArea.style.left = '-9999px';
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+      }
+      setCopiedKey(key);
+      window.setTimeout(() => {
+        setCopiedKey((current) => (current === key ? null : current));
+      }, 1500);
+    } catch {
+      setCopiedKey(null);
+    }
+  };
+
+  const renderCopyButton = (value: string, key: string, label: string) => (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        void copyToClipboard(value, key);
+      }}
+      className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded border border-gray-200 text-gray-500 hover:border-blue-300 hover:bg-blue-50 hover:text-blue-600"
+      aria-label={`Copy ${label}`}
+      title={`Copy ${label}`}
+    >
+      {copiedKey === key ? (
+        <Check className="h-4 w-4" />
+      ) : (
+        <Clipboard className="h-4 w-4" />
+      )}
+    </button>
+  );
 
   const getCategoryIcon = (category: string) => {
     const categoryLower = category.toLowerCase();
@@ -337,28 +391,96 @@ export function LinksTable({ links, resourceId, searchId }: LinksTableProps) {
               </>
             ) : (
               <div className="space-y-3">
-                {lightboxContent.items.map((link, index) => (
-                  <a
-                    key={index}
-                    href={link.url}
-                    onClick={() =>
-                      trackLinkClick(lightboxContent.category, link)
-                    }
-                    className="flex items-center gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors group"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <ExternalLink className="w-5 h-5 text-gray-400 group-hover:text-blue-500" />
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium text-gray-900 group-hover:text-blue-600">
-                        {link.label}
+                {lightboxContent.items.map((link, index) => {
+                  if (link.wxs_identifier) {
+                    return (
+                      <div
+                        key={index}
+                        className="flex items-start gap-3 p-3 border border-gray-200 rounded-lg"
+                      >
+                        <Code className="w-5 h-5 mt-0.5 text-gray-400" />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-medium text-gray-900">
+                            {link.label}
+                          </div>
+                          <div className="mt-2 space-y-2">
+                            <div className="flex items-start gap-2">
+                              <div className="flex-1 min-w-0">
+                                <div className="text-[11px] font-medium uppercase text-gray-500">
+                                  Service URL
+                                </div>
+                                <div className="text-xs text-gray-600 break-all">
+                                  {link.url}
+                                </div>
+                              </div>
+                              {renderCopyButton(
+                                link.url,
+                                `${index}-service-url`,
+                                'service URL'
+                              )}
+                            </div>
+                            <div className="flex items-start gap-2">
+                              <div className="flex-1 min-w-0">
+                                <div className="text-[11px] font-medium uppercase text-gray-500">
+                                  WxS Identifier
+                                </div>
+                                <code className="text-xs font-mono text-gray-900 break-all">
+                                  {link.wxs_identifier}
+                                </code>
+                              </div>
+                              {renderCopyButton(
+                                link.wxs_identifier,
+                                `${index}-wxs-identifier`,
+                                'WxS identifier'
+                              )}
+                            </div>
+                            {link.request_url && (
+                              <a
+                                href={link.request_url}
+                                onClick={() =>
+                                  trackLinkClick(
+                                    lightboxContent.category,
+                                    link,
+                                    link.request_url
+                                  )
+                                }
+                                className="inline-flex items-center gap-2 text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <ExternalLink className="h-4 w-4" />
+                                {link.request_label ?? 'Open layer request'}
+                              </a>
+                            )}
+                          </div>
+                        </div>
                       </div>
-                      <div className="text-xs text-gray-500 mt-1 break-all">
-                        {link.url}
+                    );
+                  }
+
+                  return (
+                    <a
+                      key={index}
+                      href={link.url}
+                      onClick={() =>
+                        trackLinkClick(lightboxContent.category, link)
+                      }
+                      className="flex items-center gap-3 p-3 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-blue-300 transition-colors group"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <ExternalLink className="w-5 h-5 text-gray-400 group-hover:text-blue-500" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium text-gray-900 group-hover:text-blue-600">
+                          {link.label}
+                        </div>
+                        <div className="text-xs text-gray-500 mt-1 break-all">
+                          {link.url}
+                        </div>
                       </div>
-                    </div>
-                  </a>
-                ))}
+                    </a>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/frontend/src/pages/ResourceView.tsx
+++ b/frontend/src/pages/ResourceView.tsx
@@ -67,7 +67,17 @@ interface ResourceData extends GeoDocument {
       citation?: string;
       thumbnail_url?: string;
       static_map?: string;
-      links?: Record<string, Array<{ label: string; url: string }>>;
+      links?: Record<
+        string,
+        Array<{
+          label: string;
+          url: string;
+          format?: 'iso' | 'fgdc' | 'html';
+          wxs_identifier?: string;
+          request_url?: string;
+          request_label?: string;
+        }>
+      >;
       relationships?: Record<string, unknown>;
       similar_items?: Array<{
         id: string;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -98,6 +98,17 @@ export interface GeoDocument {
         generation_path?: string;
         download_type?: string;
       }>;
+      links?: Record<
+        string,
+        Array<{
+          label: string;
+          url: string;
+          format?: 'iso' | 'fgdc' | 'html';
+          wxs_identifier?: string;
+          request_url?: string;
+          request_label?: string;
+        }>
+      >;
       relationships?: Record<string, unknown>;
       relationship_counts?: Record<string, number>;
       relationship_browse_links?: Record<string, string>;


### PR DESCRIPTION
## Summary

Fixes #175.

This updates the web services link flow so OGC service entries expose the pieces users need separately and safely:

- includes the copyable base service URL for WMS/WFS/WCS/WMTS links
- includes the copyable `gbl_wxsIdentifier_s` layer identifier when present
- adds scoped helper request URLs for layer-specific WMS, WFS, and WCS workflows
- renders those values in the Web Services modal with copy controls

For WMS, the helper request now builds a layer-scoped `GetMap` preview using the resource bbox and `EXCEPTIONS=application/vnd.ogc.se_inimage`, so GeoServer layer errors open in the browser as an image response instead of downloading XML. This avoids provider-wide `GetCapabilities` calls and keeps the preview scoped to the resource.

## Validation

- `python -m pytest backend/tests/services/test_link_service.py`
- `npm test -- LinksTable.test.tsx --run`
- `ruff check backend/app/services/link_service.py backend/tests/services/test_link_service.py`
- targeted frontend ESLint on changed files
- targeted Prettier check on changed files

Note: repo-wide frontend lint/format currently reports unrelated pre-existing failures outside this change.