### PR TITLE
Homepage fixes — Per on-campus launch meeting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,9 +49,11 @@ coverage.xml
 
 # --- VCS & env files ---
 .git
+/.git/
 .gitignore
 .env
 .env.*
+/.kamal/
 
 # --- Databases & data dumps (can be huge) ---
 *.sqlite*
@@ -81,11 +83,15 @@ coverage.xml
 # --- Logs ---
 *.log
 logs/
+/logs/
+/test_logs/
+/tmp/
 
 # --- Local runtime data dirs (don’t bake into image) ---
 elasticsearch-data/
 paradedb-data/
 data/
+/data/
 backend/data/
 backend/logs/
 backend/tmp/

--- a/Dockerfile.kamal
+++ b/Dockerfile.kamal
@@ -120,6 +120,7 @@ COPY --from=frontend_prod_deps /frontend/node_modules ./frontend/node_modules
 
 # Copy only the backend runtime surface, not tests, fixture data, or local envs.
 COPY backend/pyproject.toml backend/uv.lock ./backend/
+COPY backend/__appsignal__.py ./backend/__appsignal__.py
 COPY backend/app ./backend/app
 COPY backend/db ./backend/db
 COPY backend/scripts ./scripts
@@ -157,10 +158,12 @@ EXPOSE 8000
 # HEALTHCHECK for all roles (web, cron, flower, worker). Each role runs different process:
 # Web: nginx on 8000 | Flower: Celery on 5555 | Cron: cron (PID 1) | Worker: celery, no HTTP
 HEALTHCHECK --interval=10s --timeout=5s --start-period=45s --retries=3 \
-  CMD curl -sf http://127.0.0.1:8000/api/docs -o /dev/null || \
-      curl -sf http://127.0.0.1:5555/ -o /dev/null || \
-      grep -q cron /proc/1/comm 2>/dev/null || \
-      kill -0 1 2>/dev/null || exit 1
+  CMD case "$KAMAL_CONTAINER_NAME" in \
+        *-web-*) curl -sf http://127.0.0.1:8000/api/docs -o /dev/null ;; \
+        *-flower-*) curl -sf http://127.0.0.1:5555/ -o /dev/null ;; \
+        *-cron-*) grep -q cron /proc/1/comm 2>/dev/null ;; \
+        *) kill -0 1 2>/dev/null ;; \
+      esac
 
 # Kamal will override this via servers.web.cmd, but keep a sensible default.
 CMD ["bash", "-lc", "/app/scripts/start_web_singlehost.sh"]

--- a/frontend/src/__tests__/components/home/HomePageHexMapBackground.carousel-a11y.test.tsx
+++ b/frontend/src/__tests__/components/home/HomePageHexMapBackground.carousel-a11y.test.tsx
@@ -5,7 +5,9 @@
 import { render, screen } from '@testing-library/react';
 import { axeWithWCAG22 } from '../../../test-utils/axe';
 import { BrowserRouter } from 'react-router';
-import { vi } from 'vitest';
+import { afterEach, beforeEach, vi } from 'vitest';
+import Cookies from 'js-cookie';
+import * as api from '../../../services/api';
 import { HomePageHexMapBackground } from '../../../components/home/HomePageHexMapBackground.client';
 
 vi.mock('leaflet/dist/leaflet.css', () => ({}));
@@ -81,7 +83,20 @@ vi.mock('react-router', async (importOriginal) => {
   };
 });
 
+const FEATURED_CAROUSEL_HIDDEN_COOKIE = 'btaa_home_featured_carousel_hidden';
+
 describe('HomePageHexMapBackground – Featured carousel accessibility', () => {
+  beforeEach(() => {
+    Cookies.set(FEATURED_CAROUSEL_HIDDEN_COOKIE, '0', { path: '/' });
+    vi.mocked(api.fetchFeaturedResourcePreview).mockImplementation(
+      () => new Promise(() => {})
+    );
+  });
+
+  afterEach(() => {
+    Cookies.remove(FEATURED_CAROUSEL_HIDDEN_COOKIE, { path: '/' });
+  });
+
   it('has no accessibility violations in carousel region', async () => {
     render(
       <BrowserRouter>

--- a/frontend/src/__tests__/components/home/HomePageHexMapBackground.carousel.test.tsx
+++ b/frontend/src/__tests__/components/home/HomePageHexMapBackground.carousel.test.tsx
@@ -17,8 +17,18 @@ import * as api from '../../../services/api';
 import { FEATURED_RESOURCE_IDS } from '../../../config/featured';
 import { HomePageHexMapBackground } from '../../../components/home/HomePageHexMapBackground.client';
 
+const mockNavigate = vi.hoisted(() => vi.fn());
+
 vi.mock('leaflet/dist/leaflet.css', () => ({}));
 vi.mock('leaflet-gesture-handling', () => ({ GestureHandling: {} }));
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 vi.mock('../../../components/map/BasemapSwitcherControl', () => ({
   BasemapSwitcherControl: () => null,
@@ -83,7 +93,39 @@ vi.mock('react-leaflet', () => ({
 }));
 
 vi.mock('../../../components/map/MapUpdaterHex', () => ({
-  MapUpdaterHex: () => null,
+  MapUpdaterHex: ({
+    onHexClick,
+    onHexHover,
+    enableSearchPopup,
+  }: {
+    onHexClick?: (data: {
+      h3: string;
+      count: number;
+      resolution: number;
+      bbox: { north: number; west: number; south: number; east: number };
+    }) => void;
+    onHexHover?: (data: unknown) => void;
+    enableSearchPopup?: boolean;
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-homepage-hex"
+      data-enable-search-popup={String(Boolean(enableSearchPopup))}
+      onMouseEnter={() =>
+        onHexHover?.({ h3: '862a1072fffffff', count: 12, resolution: 6 })
+      }
+      onClick={() =>
+        onHexClick?.({
+          h3: '862a1072fffffff',
+          count: 12,
+          resolution: 6,
+          bbox: { north: 45, west: -94, south: 44, east: -93 },
+        })
+      }
+    >
+      Mock homepage hex
+    </button>
+  ),
 }));
 
 vi.mock('../../../components/home/FeaturedMapController', () => ({
@@ -120,10 +162,7 @@ function makeMockDetail(id: string, title: string, thumbnailUrl?: string) {
       ui: {
         thumbnail_url: thumbnailUrl ?? null,
         viewer: {
-          geometry: {
-            type: 'Point',
-            coordinates: [-93.265, 44.9778],
-          },
+          geometry: 'POINT (-93.265 44.9778)',
         },
       },
     },
@@ -143,6 +182,8 @@ describe('HomePageHexMapBackground – Featured carousel behavior', () => {
     vi.useRealTimers();
     localStorage.clear();
     vi.clearAllMocks();
+    mockNavigate.mockClear();
+    window.history.pushState({}, '', '/');
     Cookies.remove(FEATURED_CAROUSEL_HIDDEN_COOKIE, { path: '/' });
     vi.mocked(api.fetchFeaturedResourcePreview).mockImplementation(
       (id: string) => {
@@ -161,7 +202,12 @@ describe('HomePageHexMapBackground – Featured carousel behavior', () => {
     Cookies.remove(FEATURED_CAROUSEL_HIDDEN_COOKIE, { path: '/' });
   });
 
-  const renderCarousel = () => {
+  const renderCarousel = ({
+    featuredVisible = false,
+  }: { featuredVisible?: boolean } = {}) => {
+    if (featuredVisible) {
+      Cookies.set(FEATURED_CAROUSEL_HIDDEN_COOKIE, '0', { path: '/' });
+    }
     render(
       <BrowserRouter>
         <HomePageHexMapBackground />
@@ -186,7 +232,7 @@ describe('HomePageHexMapBackground – Featured carousel behavior', () => {
     screen.getByRole('progressbar', { name: /Time remaining/i });
 
   it('carousel region renders with expected structure', async () => {
-    renderCarousel();
+    renderCarousel({ featuredVisible: true });
     const carousel = await screen.findByRole('region', {
       name: /Featured resources/i,
     });
@@ -195,8 +241,20 @@ describe('HomePageHexMapBackground – Featured carousel behavior', () => {
     expect(getPlayPauseButton()).toBeInTheDocument();
   });
 
-  it('hides and restores the featured carousel preference with a cookie', async () => {
+  it('starts collapsed by default when no carousel preference exists', () => {
     renderCarousel();
+
+    expect(
+      screen.queryByRole('region', { name: /Featured resources/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Show featured highlights/i })
+    ).toBeInTheDocument();
+    expect(api.fetchFeaturedResourcePreview).not.toHaveBeenCalled();
+  });
+
+  it('hides and restores the featured carousel preference with a cookie', async () => {
+    renderCarousel({ featuredVisible: true });
 
     expect(
       await screen.findByText(/BTAA Collection Highlights/i)
@@ -264,8 +322,21 @@ describe('HomePageHexMapBackground – Featured carousel behavior', () => {
     );
   });
 
-  it('clicking a featured item thumbnail highlights it without starting the animation', async () => {
+  it('clicking a homepage hex navigates to a geo bbox search without opening a popup', async () => {
     renderCarousel();
+
+    const hex = await screen.findByTestId('mock-homepage-hex');
+    expect(hex).toHaveAttribute('data-enable-search-popup', 'false');
+
+    await user.click(hex);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/search?include_filters%5Bgeo%5D%5Btype%5D=bbox&include_filters%5Bgeo%5D%5Bfield%5D=dcat_bbox&include_filters%5Bgeo%5D%5Brelation%5D=intersects&include_filters%5Bgeo%5D%5Btop_left%5D%5Blat%5D=45&include_filters%5Bgeo%5D%5Btop_left%5D%5Blon%5D=-94&include_filters%5Bgeo%5D%5Bbottom_right%5D%5Blat%5D=44&include_filters%5Bgeo%5D%5Bbottom_right%5D%5Blon%5D=-93'
+    );
+  });
+
+  it('clicking a featured item thumbnail highlights it without starting the animation', async () => {
+    renderCarousel({ featuredVisible: true });
     await waitForFeaturedData();
 
     const thirdThumb = screen.getByRole('button', {
@@ -306,7 +377,7 @@ describe('HomePageHexMapBackground – Featured carousel behavior', () => {
       }
     );
 
-    renderCarousel();
+    renderCarousel({ featuredVisible: true });
 
     const image = await screen.findByTestId('featured-thumbnail-image-0');
     fireEvent.error(image);

--- a/frontend/src/components/home/HomePageHexMapBackground.client.tsx
+++ b/frontend/src/components/home/HomePageHexMapBackground.client.tsx
@@ -6,8 +6,7 @@ import Cookies from 'js-cookie';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { registerLeafletGestureHandling } from '../../config/leafletGestureHandling';
-import { cellArea, UNITS } from 'h3-js';
-import { MapUpdaterHex, type HexHoverData } from '../map/MapUpdaterHex';
+import { MapUpdaterHex, type HexBoundingBox } from '../map/MapUpdaterHex';
 import { HexLayerToggleControl } from '../map/HexLayerToggleControl';
 import { BboxRectangleSelector } from '../map/BboxRectangleSelector';
 import { leafletGestureMapOptions } from '../../config/leafletConfig';
@@ -18,7 +17,6 @@ import { getApiBasePath } from '../../services/api';
 import type { GeoDocumentDetails } from '../../types/api';
 import { getResourceIcon } from '../../utils/resourceIcons';
 import { ResultCardPill } from '../search/ResultCardPill';
-import { formatCount } from '../../utils/formatNumber';
 import { parseBboxToLeafletBounds } from '../../utils/bbox';
 import {
   getSavedHexLayerEnabled,
@@ -112,9 +110,9 @@ const DARK_BIG_TEN_BLUE = '#003C5B';
 
 function getSavedFeaturedCarouselVisible(): boolean {
   try {
-    return Cookies.get(FEATURED_CAROUSEL_HIDDEN_COOKIE) !== '1';
+    return Cookies.get(FEATURED_CAROUSEL_HIDDEN_COOKIE) === '0';
   } catch {
-    return true;
+    return false;
   }
 }
 
@@ -173,56 +171,16 @@ function FeaturedItemBoundsLayer({
   );
 }
 
-/** Format H3 cell area in km² for display (e.g. 0.25, 15.3, 1,234). */
-function formatAreaKm2(km2: number): string {
-  if (km2 >= 1000)
-    return km2.toLocaleString('en-US', { maximumFractionDigits: 0 });
-  if (km2 >= 1)
-    return km2.toLocaleString('en-US', {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 2,
-    });
-  return km2.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 4,
-  });
-}
-
-function HexHoverCard({ hoveredHex }: { hoveredHex: HexHoverData }) {
-  let areaKm2: number | null = null;
-  try {
-    areaKm2 = cellArea(hoveredHex.h3, UNITS.km2);
-  } catch {
-    // Invalid H3 index or library error
-  }
-  return (
-    <div
-      data-hex-popover
-      className="absolute bottom-4 left-4 z-[1000] rounded-lg border border-gray-200 bg-white/95 shadow-lg backdrop-blur-sm p-3 min-w-[180px]"
-      role="status"
-      aria-live="polite"
-    >
-      <h3 className="text-sm font-semibold text-gray-900 mb-1">
-        H3 {hoveredHex.h3}
-      </h3>
-      <dl className="text-sm text-gray-600 space-y-1 mb-2">
-        <div className="flex justify-between gap-4">
-          <dt className="font-medium">Resources</dt>
-          <dd>{formatCount(hoveredHex.count)}</dd>
-        </div>
-        <div className="flex justify-between gap-4">
-          <dt className="font-medium">Resolution</dt>
-          <dd>Level {hoveredHex.resolution}</dd>
-        </div>
-        {areaKm2 != null && (
-          <div className="flex justify-between gap-4">
-            <dt className="font-medium">Area</dt>
-            <dd>{formatAreaKm2(areaKm2)} km²</dd>
-          </div>
-        )}
-      </dl>
-    </div>
-  );
+function buildBboxSearchUrl(bbox: HexBoundingBox, relation = 'intersects') {
+  const params = new URLSearchParams();
+  params.set('include_filters[geo][type]', 'bbox');
+  params.set('include_filters[geo][field]', 'dcat_bbox');
+  params.set('include_filters[geo][relation]', relation);
+  params.set('include_filters[geo][top_left][lat]', bbox.north.toString());
+  params.set('include_filters[geo][top_left][lon]', bbox.west.toString());
+  params.set('include_filters[geo][bottom_right][lat]', bbox.south.toString());
+  params.set('include_filters[geo][bottom_right][lon]', bbox.east.toString());
+  return `/search?${params.toString()}`;
 }
 
 /** One-time pan so Chicago (dense hex cluster) appears in the desired position on the homepage. Marks as programmatic so it is not counted as user engagement. */
@@ -281,29 +239,34 @@ function SearchHereControl() {
     const bounds = map.getBounds();
     const ne = bounds.getNorthEast();
     const sw = bounds.getSouthWest();
-    const params = new URLSearchParams();
-    params.set('include_filters[geo][type]', 'bbox');
-    params.set('include_filters[geo][field]', 'dcat_bbox');
-    params.set('include_filters[geo][relation]', 'intersects');
-    params.set('include_filters[geo][top_left][lat]', ne.lat.toString());
-    params.set('include_filters[geo][top_left][lon]', sw.lng.toString());
-    params.set('include_filters[geo][bottom_right][lat]', sw.lat.toString());
-    params.set('include_filters[geo][bottom_right][lon]', ne.lng.toString());
-    navigate(`/search?${params.toString()}`);
+    navigate(
+      buildBboxSearchUrl({
+        north: ne.lat,
+        west: sw.lng,
+        south: sw.lat,
+        east: ne.lng,
+      })
+    );
   };
 
   if (!showSearchButton) return null;
   return (
-    <div className="absolute top-2 right-2 z-[1000]">
-      <button
-        type="button"
-        onClick={handleSearchHere}
-        className="flex items-center rounded-lg border border-brand bg-brand px-3 py-2 text-sm font-medium text-white shadow-lg transition-colors hover:bg-[#002f49] focus:outline-none focus:ring-2 focus:ring-brand-active focus:ring-offset-2"
-        aria-label="Search in this area"
-      >
-        <span>Search here</span>
-      </button>
-    </div>
+    <>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-[4px] z-[998] border-2 border-[#ff7a00] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.7),0_0_10px_rgba(255,122,0,0.32)]"
+      />
+      <div className="absolute top-2 right-2 z-[1000]">
+        <button
+          type="button"
+          onClick={handleSearchHere}
+          className="flex items-center rounded-lg bg-[#ff7a00] px-4 py-2.5 text-sm font-bold text-white shadow-[0_0_8px_1px_rgba(0,166,255,0.22),0_3px_8px_rgba(0,80,150,0.1)] transition-colors hover:bg-[#ff8f1f] focus:outline-none focus:ring-2 focus:ring-[#003c5b] focus:ring-offset-2"
+          aria-label="Search in this area"
+        >
+          <span>Search here</span>
+        </button>
+      </div>
+    </>
   );
 }
 
@@ -349,8 +312,8 @@ function HomeMapResetListener({
 /**
  * Non-interactive Leaflet hex map used as the background of the homepage.
  * Center is south of the US so North America appears just under the search form.
- * Hovering a hex shows a glowing blue border and popover at bottom-left.
- * Featured resources carousel at bottom; when an item is active, map flies to its bbox and a popup shows thumbnail and link.
+ * Hovering a hex shows a glowing blue border; clicking a hex searches its bbox.
+ * Featured resources carousel at bottom; when an item is active, map flies to its bbox and shows a preview card.
  */
 export function HomePageHexMapBackground() {
   const [activeIndex, setActiveIndex] = useState(0);
@@ -384,10 +347,10 @@ export function HomePageHexMapBackground() {
     resolution: number;
     loading: boolean;
   }>({ hexes: [], resolution: 6, loading: false });
-  const [hoveredHex, setHoveredHex] = useState<HexHoverData | null>(null);
   const [hexLayerEnabled, setHexLayerEnabled] = useState(
     getSavedHexLayerEnabled
   );
+  const navigate = useNavigate();
   const initialHomeViewRef = useRef<{
     center: [number, number];
     zoom: number;
@@ -408,6 +371,13 @@ export function HomePageHexMapBackground() {
       });
     },
     []
+  );
+  const handleHexHover = useCallback(() => undefined, []);
+  const handleHexClick = useCallback(
+    ({ bbox }: { bbox: HexBoundingBox }) => {
+      navigate(buildBboxSearchUrl(bbox));
+    },
+    [navigate]
   );
 
   const [preCarouselProgress] = useState(1);
@@ -528,10 +498,6 @@ export function HomePageHexMapBackground() {
   return (
     <div className="absolute inset-0 z-0">
       <style>{`.hex-hover-glow { filter: drop-shadow(0 0 8px rgba(59, 130, 246, 0.9)); }
-.map-hex-search-popup .leaflet-popup-content-wrapper { background: transparent; box-shadow: none; padding: 0; border-radius: 0; }
-.map-hex-search-popup .leaflet-popup-content { margin: 0; min-width: 0; }
-.map-hex-search-popup .leaflet-popup-tip-container { margin-top: -1px; }
-.map-hex-search-popup .leaflet-popup-tip { background: rgba(255, 255, 255, 0.95); box-shadow: none; }
 .homepage-map .leaflet-top.leaflet-left { top: 1rem; }`}</style>
       <p className="sr-only">
         For a list of hex data, use the hex table button in the bottom-left
@@ -570,9 +536,6 @@ export function HomePageHexMapBackground() {
             stackOrder="beforeBasemap"
             onToggle={(enabled) => {
               setHexLayerEnabled(enabled);
-              if (!enabled) {
-                setHoveredHex(null);
-              }
             }}
           />
           <MapPanner
@@ -590,13 +553,11 @@ export function HomePageHexMapBackground() {
           <SearchHereControl />
           {hexLayerEnabled && (
             <>
-              {hoveredHex && <HexHoverCard hoveredHex={hoveredHex} />}
               <MapUpdaterHex
                 searchQuery=""
                 onFeatureClick={() => {}}
-                enableSearchPopup
-                onHexHover={setHoveredHex}
-                hoveredHex={hoveredHex}
+                onHexClick={handleHexClick}
+                onHexHover={handleHexHover}
                 onHexData={handleHexData}
                 queryString={queryString}
               />

--- a/frontend/src/components/map/MapUpdaterHex.tsx
+++ b/frontend/src/components/map/MapUpdaterHex.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import L from 'leaflet';
 import { GeoJSON, useMap, useMapEvents } from 'react-leaflet';
-import { cellArea, cellToBoundary, UNITS } from 'h3-js';
+import { cellToBoundary } from 'h3-js';
 import type { MapFeatureClickPayload } from '../../types/map';
 import { useMapH3 } from '../../hooks/useMapH3';
 import { formatCount } from '../../utils/formatNumber';
@@ -74,26 +74,29 @@ function getColor(intensity: number): string {
 }
 
 export type HexHoverData = { h3: string; count: number; resolution: number };
+export type HexBoundingBox = {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+};
 
-function formatAreaKm2(km2: number): string {
-  if (km2 >= 1000)
-    return km2.toLocaleString('en-US', { maximumFractionDigits: 0 });
-  if (km2 >= 1)
-    return km2.toLocaleString('en-US', {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 2,
-    });
-  return km2.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 4,
-  });
+function getHexBoundingBox(h3Index: string): HexBoundingBox {
+  const vertices = cellToBoundary(h3Index);
+  const lats = vertices.map(([lat]) => lat);
+  const lngs = vertices.map(([, lng]) => lng);
+  return {
+    west: Math.min(...lngs),
+    south: Math.min(...lats),
+    east: Math.max(...lngs),
+    north: Math.max(...lats),
+  };
 }
 
 export function MapUpdaterHex({
   searchQuery,
   onFeatureClick,
   onHexClick,
-  enableSearchPopup = false,
   onHexData,
   onHexHover,
   hoveredHex,
@@ -101,8 +104,12 @@ export function MapUpdaterHex({
 }: {
   searchQuery: string;
   onFeatureClick: (feature: MapFeatureClickPayload) => void;
-  onHexClick?: (data: { h3: string; count: number; resolution: number }) => void;
-  enableSearchPopup?: boolean;
+  onHexClick?: (data: {
+    h3: string;
+    count: number;
+    resolution: number;
+    bbox: HexBoundingBox;
+  }) => void;
   onHexData?: (stats: {
     hexCount: number;
     totalInView: number;
@@ -122,54 +129,6 @@ export function MapUpdaterHex({
     defaultStyle: L.PathOptions;
   } | null>(null);
   const prevHoveredHexRef = useRef<HexHoverData | null | undefined>(undefined);
-
-  const openSearchPopup = useCallback(
-    (layer: L.Layer, h3: string, count: number, popupResolution: number) => {
-      if (!(layer instanceof L.Path)) return;
-      let areaMarkup = '';
-      try {
-        const areaKm2 = cellArea(h3, UNITS.km2);
-        areaMarkup =
-          `<div class="flex justify-between gap-4">` +
-          `<dt class="font-medium">Area</dt>` +
-          `<dd>${formatAreaKm2(areaKm2)} km²</dd>` +
-          `</div>`;
-      } catch {
-        // Invalid H3 index or library error
-      }
-      const searchUrl = buildSearchUrl(
-        h3,
-        popupResolution,
-        searchQuery,
-        queryString
-      );
-      const popupHtml =
-        `<div class="rounded-lg border border-gray-200 bg-white/95 shadow-lg backdrop-blur-sm p-3 min-w-[180px]">` +
-        `<h3 class="text-sm font-semibold text-gray-900 mb-1">H3 ${h3}</h3>` +
-        `<dl class="text-sm text-gray-600 space-y-1 mb-2">` +
-        `<div class="flex justify-between gap-4">` +
-        `<dt class="font-medium">Resources</dt>` +
-        `<dd>${formatCount(count)}</dd>` +
-        `</div>` +
-        `<div class="flex justify-between gap-4">` +
-        `<dt class="font-medium">Resolution</dt>` +
-        `<dd>Level ${popupResolution}</dd>` +
-        `</div>` +
-        areaMarkup +
-        `</dl>` +
-        `<a href="${searchUrl}" class="text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline">Search this hex</a>` +
-        `</div>`;
-      layer.bindPopup(popupHtml, {
-        autoPan: false,
-        closeButton: false,
-        autoClose: true,
-        closeOnClick: true,
-        className: 'map-hex-search-popup',
-      });
-      layer.openPopup();
-    },
-    [queryString, searchQuery]
-  );
 
   const updateBbox = useCallback(() => {
     const b = map.getBounds();
@@ -328,10 +287,12 @@ export function MapUpdaterHex({
         };
 
         if (!onHexHover) {
-          const params = new URLSearchParams();
-          if (searchQuery) params.set('q', searchQuery);
-          params.set(`include_filters[h3_res${resolution}][]`, h3);
-          const searchUrl = `/search?${params.toString()}`;
+          const searchUrl = buildSearchUrl(
+            h3,
+            resolution,
+            searchQuery,
+            queryString
+          );
           layer.bindPopup(
             `<div class="map-hex-popup"><h3 class="text-sm font-semibold mb-1">H3 ${h3}</h3><p class="text-sm mb-2"><strong>Resources:</strong> ${formatCount(count)}</p><a href="${searchUrl}" class="text-blue-600 hover:underline text-sm">Search this hex</a></div>`
           );
@@ -342,9 +303,10 @@ export function MapUpdaterHex({
           if (prev && prev.layer !== layer) {
             prev.layer.setStyle(prev.defaultStyle);
           }
-          (layer as L.Path).setStyle(hoverStyle);
-          layer.bringToFront();
-          hoveredRef.current = { layer: layer as L.Path, defaultStyle };
+          const pathLayer = layer as L.Path;
+          pathLayer.setStyle(hoverStyle);
+          pathLayer.bringToFront();
+          hoveredRef.current = { layer: pathLayer, defaultStyle };
           onHexHover?.({ h3, count, resolution });
         });
         layer.on('mouseout', () => {
@@ -359,13 +321,14 @@ export function MapUpdaterHex({
           if (event.originalEvent.ctrlKey || event.originalEvent.metaKey) {
             return;
           }
-          if (enableSearchPopup) {
-            L.DomEvent.stopPropagation(event);
-            openSearchPopup(layer, h3, count, resolution);
-            return;
-          }
           if (onHexClick) {
-            onHexClick({ h3, count, resolution });
+            L.DomEvent.stopPropagation(event);
+            onHexClick({
+              h3,
+              count,
+              resolution,
+              bbox: getHexBoundingBox(h3),
+            });
             return;
           }
           onFeatureClick({

--- a/frontend/src/components/search/GeospatialFilterMap.client.tsx
+++ b/frontend/src/components/search/GeospatialFilterMap.client.tsx
@@ -9,6 +9,7 @@ import { MapGeosearchControl } from '../map/MapGeosearchControl';
 import { attachBasemapSwitcher } from '../../config/basemaps';
 import { leafletGestureMapOptions } from '../../config/leafletConfig';
 import { registerLeafletGestureHandling } from '../../config/leafletGestureHandling';
+import { normalizeBboxSearchEnvelope } from '../../utils/bbox';
 import {
   getSavedHexLayerEnabled,
   saveHexLayerEnabled,
@@ -232,12 +233,10 @@ export function GeospatialFilterMap({
         }, 100);
       });
 
-      // Handle map move/zoom events - show preview rectangle and "Search here" button
+      // Handle map move/zoom events - show the bbox frame and "Search here" button
       const handleMapMoveEnd = () => {
         if (isUpdatingFromParamsRef.current) return;
         if (!mapRef.current) return;
-
-        const bounds = mapRef.current.getBounds();
 
         // Clear place geometry when user manually moves the map
         if (selectedPlaceGeoJsonRef.current) {
@@ -250,19 +249,6 @@ export function GeospatialFilterMap({
           mapRef.current.removeLayer(previewRectangleRef.current);
           previewRectangleRef.current = null;
         }
-
-        // Add preview rectangle to show what area would be searched
-        // Use a different style to indicate it's a preview (not yet applied)
-        const previewRectangle = L.rectangle(bounds, {
-          color: '#3b82f6',
-          weight: 2,
-          opacity: 0.6,
-          fillColor: '#3b82f6',
-          fillOpacity: 0.15,
-          dashArray: '5, 5', // Dashed line to indicate preview
-        }).addTo(mapRef.current);
-
-        previewRectangleRef.current = previewRectangle;
 
         // Show the "Search here" button
         setShowSearchButton(true);
@@ -625,16 +611,30 @@ export function GeospatialFilterMap({
     // Add new bbox filter from current map bounds
     const ne = bounds.getNorthEast();
     const sw = bounds.getSouthWest();
+    const bbox = normalizeBboxSearchEnvelope(sw.lng, sw.lat, ne.lng, ne.lat);
+    if (!bbox) return;
 
     // Top-left is northwest corner (north = higher lat, west = lower lon)
     // Bottom-right is southeast corner (south = lower lat, east = higher lon)
     newParams.set('include_filters[geo][type]', 'bbox');
     newParams.set('include_filters[geo][field]', 'dcat_bbox');
     newParams.set('include_filters[geo][relation]', relation);
-    newParams.set('include_filters[geo][top_left][lat]', ne.lat.toString());
-    newParams.set('include_filters[geo][top_left][lon]', sw.lng.toString());
-    newParams.set('include_filters[geo][bottom_right][lat]', sw.lat.toString());
-    newParams.set('include_filters[geo][bottom_right][lon]', ne.lng.toString());
+    newParams.set(
+      'include_filters[geo][top_left][lat]',
+      bbox.topLeft.lat.toString()
+    );
+    newParams.set(
+      'include_filters[geo][top_left][lon]',
+      bbox.topLeft.lon.toString()
+    );
+    newParams.set(
+      'include_filters[geo][bottom_right][lat]',
+      bbox.bottomRight.lat.toString()
+    );
+    newParams.set(
+      'include_filters[geo][bottom_right][lon]',
+      bbox.bottomRight.lon.toString()
+    );
 
     // Reset to page 1 when bbox changes
     newParams.delete('page');
@@ -782,13 +782,20 @@ export function GeospatialFilterMap({
           />
           <MapGeosearchControl mapInstance={mapInstance} />
           {showSearchButton && (
-            <button
-              onClick={handleSearchHere}
-              className="absolute top-2 right-2 z-[1000] flex items-center px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg shadow-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
-              aria-label="Search in this area"
-            >
-              <span>Search here</span>
-            </button>
+            <>
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-[4px] z-[999] rounded-[4px] border-2 border-[#ff7a00] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.7),0_0_10px_rgba(255,122,0,0.32)]"
+              />
+              <button
+                type="button"
+                onClick={handleSearchHere}
+                className="absolute top-2 right-2 z-[1000] flex items-center rounded-lg bg-[#ff7a00] px-4 py-2.5 text-sm font-bold text-white shadow-[0_0_8px_1px_rgba(0,166,255,0.22),0_3px_8px_rgba(0,80,150,0.1)] transition-colors hover:bg-[#ff8f1f] focus:outline-none focus:ring-2 focus:ring-[#003c5b] focus:ring-offset-2"
+                aria-label="Search in this area"
+              >
+                <span>Search here</span>
+              </button>
+            </>
           )}
         </div>
         <HexLayerToggleControl

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -400,19 +400,32 @@ export function HomePage() {
     <div className="min-h-screen flex flex-col">
       <Seo title="Big Ten Academic Alliance Geoportal" />
       {showAnnouncement && (
-        <div className="bg-white text-gray-800 px-4 sm:px-6 lg:px-8 py-2 text-sm border-b border-gray-200">
-          <p className="text-center">
-            {announcement.text}{' '}
-            <a
-              href={announcement.link_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-brand-active underline underline-offset-2 hover:no-underline"
+        <div className="bg-[#fff8df] text-gray-950 px-4 sm:px-6 lg:px-8 py-2 text-sm font-bold leading-5 border-b border-[#e6d08f]">
+          <div className="mx-auto flex max-w-5xl items-center justify-center gap-3">
+            <span
+              aria-hidden
+              className="relative hidden h-px max-w-sm flex-1 bg-[#c9a24a] sm:block"
             >
-              {announcement.link_label}
-              <ArrowRight className="w-4 h-4" aria-hidden />
-            </a>
-          </p>
+              <span className="absolute right-0 top-1/2 h-1.5 w-1.5 -translate-y-1/2 translate-x-1/2 rotate-45 bg-[#c9a24a]" />
+            </span>
+            <p className="shrink-0 text-center">
+              {announcement.text}{' '}
+              <a
+                href={announcement.link_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-semibold text-gray-950 no-underline underline-offset-2 hover:underline hover:decoration-2"
+              >
+                {announcement.link_label}
+              </a>
+            </p>
+            <span
+              aria-hidden
+              className="relative hidden h-px max-w-sm flex-1 bg-[#c9a24a] sm:block"
+            >
+              <span className="absolute left-0 top-1/2 h-1.5 w-1.5 -translate-x-1/2 -translate-y-1/2 rotate-45 bg-[#c9a24a]" />
+            </span>
+          </div>
         </div>
       )}
       <Header />


### PR DESCRIPTION
Addresses the hompage improvements discussed at our on campus meeting last week.

1. This changes the Hex behavior on the homepage: removes the info card, the popup card, and makes hexagon-clicks into a simple hex-scoped bbox search.

2. This makes the "Search here" button much more prominent (eye-catching orange, with a orange border wrapping the map).

3. This also fixes the top announcement banner to make it more prominent.

4. Homepage featured-items carousel defaults to hidden state

<img width="1722" height="1043" alt="Screenshot 2026-05-19 at 2 12 38 PM" src="https://github.com/user-attachments/assets/e5762c9c-9181-4c96-90d3-04365a5f5aad" />


Fixes #234 
Fixes #233 
Fixes #232 

