### PR TITLE
Feature/229 distributions fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: help lint lint-check format test lint-test test-coverage-compare wait-local-db clear-thumbnail-cache thumbnail-completeness-report prime-thumbnail-cache prime-static-map-cache prime-resource-cache prime-visual-caches visual-assets-export visual-assets-import visual-assets-stream-import visual-assets-sync-all db-export db-import db-sync gbl-admin-db-download gbl-admin-db-unzip gbl-admin-db-restore gbl-admin-db-sync gbl-admin-db-add-latest-btaa-fields gbl-admin-db-import-resources populate-distributions backfill-distributions populate-data-dictionaries gbl-admin-db-import-all reindex reindex-benchmark local-clear-search-cache sitemap-generate analytics-maintenance analytics-size-report es-unblock populate-relationships verify-h3-index kamal-reindex kamal-verify-h3-index kamal-clear-cache kamal-prime-thumbnail-cache kamal-prime-static-map-cache kamal-prime-visual-caches kamal-prime-resource-cache kamal-thumbnail-completeness-report kamal-api-response-cache-init kamal-api-response-cache-prune refresh-resource-caches kamal-refresh-resource-caches clear_cache frontend-reset ogm-refresh ogm-refresh-all ogm-refresh-repo ogm-status ogm-status-watch ogm-failures resource-aux-init resource-cache-init api-response-cache-init api-response-cache-prune bridge-init bridge-sync bridge-cancel bridge-status bridge-status-watch bridge-failures blog-sync
-.PHONY: kamal-blog-sync kamal-purge-home-blog-cache kamal-bridge-status kamal-bridge-status-watch kamal-cron-debug kamal-cron-test-bridge kamal-worker-logs kamal-network-sanity docs-serve docs-build k6-run k6-smoke k6-stress k6-endpoint-capacity cli-test cli-lint cli-format cli-build cli-man
+.PHONY: help lint lint-check format test lint-test test-coverage-compare wait-local-db clear-thumbnail-cache thumbnail-completeness-report prime-thumbnail-cache prime-static-map-cache prime-resource-cache prime-visual-caches visual-assets-export visual-assets-import visual-assets-stream-import visual-assets-sync-all db-export db-import db-sync gbl-admin-db-download gbl-admin-db-unzip gbl-admin-db-restore gbl-admin-db-sync gbl-admin-db-add-latest-btaa-fields gbl-admin-db-import-resources populate-distributions backfill-distributions populate-data-dictionaries gbl-admin-db-import-all reindex reindex-benchmark local-clear-search-cache sitemap-generate analytics-maintenance analytics-size-report es-unblock populate-relationships verify-h3-index kamal-reindex kamal-verify-h3-index kamal-clear-cache kamal-prime-thumbnail-cache kamal-prime-static-map-cache kamal-prime-visual-caches kamal-prime-resource-cache kamal-thumbnail-completeness-report kamal-api-response-cache-init kamal-api-response-cache-prune refresh-resource-caches kamal-refresh-resource-caches clear_cache frontend-reset ogm-refresh ogm-refresh-all ogm-refresh-repo ogm-status ogm-status-watch ogm-failures resource-aux-init resource-cache-init api-response-cache-init api-response-cache-prune bridge-init bridge-sync bridge-sync-batched bridge-cancel bridge-status bridge-status-watch bridge-failures blog-sync
+.PHONY: kamal-blog-sync kamal-purge-home-blog-cache kamal-bridge-sync-batched kamal-bridge-status kamal-bridge-status-watch kamal-cron-debug kamal-cron-test-bridge kamal-worker-logs kamal-network-sanity docs-serve docs-build k6-run k6-smoke k6-stress k6-endpoint-capacity cli-test cli-lint cli-format cli-build cli-man
 
 # Load environment variables from .env file if it exists
 -include .env
@@ -106,6 +106,10 @@ BRIDGE_TRIGGER ?= manual
 BRIDGE_LIMIT ?=
 BRIDGE_CHANGED_SINCE ?=
 BRIDGE_RESOURCE_ID ?= $(RESOURCE_ID)
+BRIDGE_BATCH_TRIGGER ?= manual_batched
+BRIDGE_BATCH_SIZE ?= 500
+BRIDGE_RESOURCE_SCOPE ?= all
+BRIDGE_MAX_RESOURCES ?=
 BRIDGE_STATUS_RAW ?=
 BRIDGE_STATUS_SHOW_LAST ?= 0
 BLOG_API_URL ?= http://localhost:8000
@@ -1331,7 +1335,28 @@ bridge-sync: bridge-init ## Trigger background bridge sync
 	@echo
 	@echo "Bridge sync request submitted."
 
-# Cancel all running bridge sync runs and revoke active/queued bridge_sync_all Celery tasks.
+# Trigger a batched full-resource reconciliation against the Geoportal bridge API.
+# Usage:
+#   make bridge-sync-batched
+#   make bridge-sync-batched BRIDGE_BATCH_SIZE=500
+#   make bridge-sync-batched BRIDGE_RESOURCE_SCOPE=bridge_active
+#   make bridge-sync-batched BRIDGE_MAX_RESOURCES=1000
+bridge-sync-batched: bridge-init ## Trigger batched bridge reconciliation
+	@echo "Triggering batched bridge sync via $(BRIDGE_API_URL)..."
+	@docker compose exec -T api bash -lc '\
+		ADMIN_USER=$${ADMIN_USERNAME:-admin}; \
+		ADMIN_PASS=$${ADMIN_PASSWORD:-changeme}; \
+		BODY="{\"bridge_trigger\":\"$(BRIDGE_BATCH_TRIGGER)\",\"batched\":true,\"batch_size\":$(BRIDGE_BATCH_SIZE),\"resource_scope\":\"$(BRIDGE_RESOURCE_SCOPE)\""; \
+		if [ -n "$(BRIDGE_MAX_RESOURCES)" ]; then BODY="$$BODY,\"max_resources\":$(BRIDGE_MAX_RESOURCES)"; fi; \
+		BODY="$$BODY}"; \
+		curl -fsS -u "$$ADMIN_USER:$$ADMIN_PASS" -X POST \
+			"$(BRIDGE_API_URL)/api/v1/admin/bridge/sync" \
+			-H "Content-Type: application/json" \
+			-d "$$BODY"'
+	@echo
+	@echo "Batched bridge sync request submitted."
+
+# Cancel all running bridge sync runs and revoke active/queued bridge sync Celery tasks.
 bridge-cancel: bridge-init ## Cancel all bridge syncs and queued bridge sync tasks
 	@echo "Cancelling all bridge syncs via $(BRIDGE_API_URL)..."
 	@docker compose exec -T api bash -lc '\
@@ -1398,6 +1423,30 @@ bridge-status-watch: bridge-init ## Poll bridge sync status continuously (curren
 #   make kamal-bridge-status
 #   make kamal-bridge-status BRIDGE_RUNS_LIMIT=20
 #   make kamal-bridge-status BRIDGE_RUN_ID=<run_id>
+kamal-bridge-sync-batched: ## Trigger batched bridge reconciliation on Kamal
+	@echo "Triggering batched bridge sync on Kamal (dest: $(KAMAL_DEST))..."
+	@if [ -z "$$KAMAL_SSH_USER" ] || [ -z "$$KAMAL_HOST" ]; then \
+		echo "ERROR: KAMAL_SSH_USER and KAMAL_HOST environment variables must be set."; \
+		echo "$(KAMAL_DEST_HELP)"; \
+		exit 1; \
+	fi
+	@kamal app exec -d $(KAMAL_DEST) --roles $(KAMAL_APP_ROLE) --reuse "bash -lc '\
+		ADMIN_USER=\$${ADMIN_USERNAME:-admin}; \
+		ADMIN_PASS=\$${ADMIN_PASSWORD:-changeme}; \
+		API_BASE=\"$(KAMAL_API_URL)\"; \
+		if [ -z \"\$$API_BASE\" ]; then API_BASE=\"\$$APPLICATION_URL\"; fi; \
+		if [ -z \"\$$API_BASE\" ]; then echo \"ERROR: KAMAL_API_URL or APPLICATION_URL must be set.\"; exit 1; fi; \
+		API_BASE=\"\$${API_BASE%/}\"; \
+		BODY=\"{\\\"bridge_trigger\\\":\\\"$(BRIDGE_BATCH_TRIGGER)\\\",\\\"batched\\\":true,\\\"batch_size\\\":$(BRIDGE_BATCH_SIZE),\\\"resource_scope\\\":\\\"$(BRIDGE_RESOURCE_SCOPE)\\\"\"; \
+		if [ -n \"$(BRIDGE_MAX_RESOURCES)\" ]; then BODY=\"\$$BODY,\\\"max_resources\\\":$(BRIDGE_MAX_RESOURCES)\"; fi; \
+		BODY=\"\$$BODY}\"; \
+		curl -fsS -u \"\$$ADMIN_USER:\$$ADMIN_PASS\" -X POST \
+			\"\$$API_BASE/api/v1/admin/bridge/sync\" \
+			-H \"Content-Type: application/json\" \
+			-d \"\$$BODY\"'"
+	@echo
+	@echo "Batched bridge sync request submitted on $(KAMAL_DEST)."
+
 kamal-bridge-status: ## Show bridge sync status on Kamal (BRIDGE_RUNS_LIMIT=N recent runs; BRIDGE_RUN_ID=... for one run)
 	@echo "Fetching bridge sync status from Kamal via $(KAMAL_API_URL)..."
 	@if [ -z "$$KAMAL_SSH_USER" ] || [ -z "$$KAMAL_HOST" ]; then \

--- a/backend/app/api/v1/endpoint_modules/admin.py
+++ b/backend/app/api/v1/endpoint_modules/admin.py
@@ -23,10 +23,11 @@ from app.services.admin_service import (
     ResourceProcessingService,
 )
 from app.services.api_key_service import APIKeyService
+from app.services.bridge_sync.batched import normalize_batch_size, normalize_resource_scope
 from app.services.bridge_sync.repository import BridgeSyncRepository
 from app.services.cache_service import CacheService
 from app.services.ogm_harvest.repository import OGMHarvestRepository
-from app.tasks.bridge_sync import bridge_sync_all
+from app.tasks.bridge_sync import bridge_sync_all, bridge_sync_enqueue_batches
 from app.tasks.gin_blog_sync import gin_blog_sync, run_gin_blog_sync
 from app.tasks.ogm_harvest import ogm_harvest_all, ogm_harvest_repo
 
@@ -101,6 +102,10 @@ class TriggerBridgeSyncRequest(BaseModel):
     limit: Optional[int] = None
     changed_since: Optional[str] = None
     resource_id: Optional[str] = None
+    batched: bool = False
+    batch_size: Optional[int] = None
+    resource_scope: str = "all"
+    max_resources: Optional[int] = None
 
 
 class TriggerGINBlogSyncRequest(BaseModel):
@@ -423,6 +428,44 @@ async def trigger_ogm_harvest(body: TriggerOGMHarvestRequest):
 @router.post("/bridge/sync")
 async def trigger_bridge_sync(body: TriggerBridgeSyncRequest):
     """Trigger a bridge sync crawl (enqueues Celery)."""
+    if body.batched:
+        if body.changed_since is not None or body.resource_id is not None or body.limit is not None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Batched bridge sync cannot be combined with limit, changed_since, "
+                    "or resource_id; use batch_size and max_resources instead"
+                ),
+            )
+        try:
+            resource_scope = normalize_resource_scope(body.resource_scope)
+            batch_size = normalize_batch_size(body.batch_size)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if body.max_resources is not None and body.max_resources < 0:
+            raise HTTPException(
+                status_code=400,
+                detail="max_resources must be greater than or equal to 0",
+            )
+
+        task_kwargs = {
+            "trigger": body.bridge_trigger,
+            "batch_size": batch_size,
+            "resource_scope": resource_scope,
+            "max_resources": body.max_resources,
+        }
+        task = bridge_sync_enqueue_batches.delay(**task_kwargs)
+        return create_response(
+            {
+                "queued": "kithe_bridge_batched",
+                "task_id": task.id,
+                "bridge_trigger": body.bridge_trigger,
+                "batch_size": batch_size,
+                "resource_scope": resource_scope,
+                "max_resources": body.max_resources,
+            }
+        )
+
     task_kwargs = {
         "trigger": body.bridge_trigger,
         "limit": body.limit,
@@ -444,13 +487,17 @@ async def trigger_bridge_sync(body: TriggerBridgeSyncRequest):
     )
 
 
-BRIDGE_SYNC_TASK_NAME = "bridge_sync_all"
+BRIDGE_SYNC_TASK_NAMES = {
+    "bridge_sync_all",
+    "bridge_sync_enqueue_batches",
+    "bridge_sync_resource_batch",
+}
 
 
 @router.post("/bridge/sync/cancel")
 async def cancel_bridge_sync():
     """Cancel all running bridge sync runs and revoke active/reserved
-    bridge_sync_all Celery tasks."""
+    bridge sync Celery tasks."""
     import asyncio
 
     runs_cancelled = await bridge_repo.cancel_all_running_runs(
@@ -473,10 +520,15 @@ async def cancel_bridge_sync():
             insp = celery_app.control.inspect(timeout=2.0)
             active_map = insp.active() or {}
             reserved_map = insp.reserved() or {}
-            active_ids = task_ids_for_name(active_map, BRIDGE_SYNC_TASK_NAME)
+            active_ids = [
+                tid
+                for task_name in BRIDGE_SYNC_TASK_NAMES
+                for tid in task_ids_for_name(active_map, task_name)
+            ]
             reserved_ids = [
                 tid
-                for tid in task_ids_for_name(reserved_map, BRIDGE_SYNC_TASK_NAME)
+                for task_name in BRIDGE_SYNC_TASK_NAMES
+                for tid in task_ids_for_name(reserved_map, task_name)
                 if tid not in active_ids
             ]
             for tid in active_ids:

--- a/backend/app/services/bridge_sync/batched.py
+++ b/backend/app/services/bridge_sync/batched.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from app.services.bridge_sync.client import KitheBridgeClient
+from app.services.bridge_sync.importer import BridgeResourceImporter
+from app.services.bridge_sync.repository import BridgeSyncRepository
+from db.database import database
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 500
+MAX_BATCH_SIZE = 1000
+VALID_RESOURCE_SCOPES = {"all", "published", "bridge_active"}
+
+BatchEnqueuer = Callable[..., Optional[str]]
+
+
+def normalize_batch_size(batch_size: Optional[int]) -> int:
+    if batch_size is None:
+        return DEFAULT_BATCH_SIZE
+    return max(1, min(int(batch_size), MAX_BATCH_SIZE))
+
+
+def normalize_resource_scope(resource_scope: Optional[str]) -> str:
+    scope = (resource_scope or "all").strip().lower()
+    if scope not in VALID_RESOURCE_SCOPES:
+        raise ValueError("resource_scope must be one of: all, published, bridge_active")
+    return scope
+
+
+def _chunks(items: Sequence[str], batch_size: int) -> List[List[str]]:
+    return [list(items[i : i + batch_size]) for i in range(0, len(items), batch_size)]
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            return datetime.fromisoformat(text).replace(tzinfo=None)
+        except ValueError:
+            pass
+    return datetime.utcnow()
+
+
+def _add_error_sample(
+    stats: Dict[str, Any],
+    *,
+    stage: str,
+    resource_id: Optional[str],
+    error: Exception,
+) -> None:
+    stats["errors"] = int(stats.get("errors") or 0) + 1
+    signature = f"{error.__class__.__name__}: {str(error)[:180]}"
+    signature_counts = stats.setdefault("_error_signature_counts", {})
+    signature_counts[signature] = int(signature_counts.get(signature) or 0) + 1
+
+    samples = stats.setdefault("error_samples", [])
+    if len(samples) < 20:
+        samples.append(
+            {
+                "stage": stage,
+                "resource_id": resource_id,
+                "error": str(error)[:500],
+            }
+        )
+
+
+def _finalize_error_stats(stats: Dict[str, Any]) -> None:
+    signature_counts = stats.pop("_error_signature_counts", {})
+    for item in stats.get("error_signatures") or []:
+        signature = item.get("signature") if isinstance(item, dict) else None
+        if signature:
+            signature_counts[str(signature)] = signature_counts.get(str(signature), 0) + int(
+                item.get("count") or 0
+            )
+    if signature_counts:
+        stats["error_signatures"] = [
+            {"signature": signature, "count": count}
+            for signature, count in sorted(
+                signature_counts.items(), key=lambda kv: kv[1], reverse=True
+            )[:10]
+        ]
+
+
+async def queue_batched_bridge_sync(
+    *,
+    trigger: str = "manual_batched",
+    batch_size: Optional[int] = None,
+    resource_scope: str = "all",
+    max_resources: Optional[int] = None,
+    enqueue_batch: BatchEnqueuer,
+    repo: Optional[BridgeSyncRepository] = None,
+) -> Dict[str, Any]:
+    if not database.is_connected:
+        await database.connect()
+
+    repo = repo or BridgeSyncRepository()
+    scope = normalize_resource_scope(resource_scope)
+    normalized_batch_size = normalize_batch_size(batch_size)
+    resource_limit = int(max_resources) if max_resources is not None else None
+    if resource_limit is not None and resource_limit < 0:
+        raise ValueError("max_resources must be greater than or equal to 0")
+
+    run_id = await repo.create_sync_run(bridge_trigger=trigger)
+    await repo.cancel_other_running_runs(
+        keep_bridge_id=run_id,
+        reason=f"superseded by batched bridge sync run {run_id}",
+    )
+
+    base_stats: Dict[str, Any] = {
+        "scope": "batched_full",
+        "resource_scope": scope,
+        "stage": "snapshotting",
+        "batch_size": normalized_batch_size,
+        "processed": 0,
+        "imported": 0,
+        "skipped": 0,
+        "errors": 0,
+        "missing": 0,
+        "retired": 0,
+        "updated_at": datetime.utcnow().isoformat() + "Z",
+        "post_sync": "run a full Elasticsearch reindex after this batched sync completes",
+    }
+    if resource_limit is not None:
+        base_stats["max_resources"] = resource_limit
+
+    await repo.update_sync_run(bridge_id=run_id, bridge_stats_json=base_stats)
+
+    resource_ids = await repo.list_resource_ids_for_batched_sync(
+        resource_scope=scope,
+        limit=resource_limit,
+    )
+    batches = _chunks(resource_ids, normalized_batch_size)
+    total_batches = len(batches)
+    queued_task_ids: List[str] = []
+
+    stats = {
+        **base_stats,
+        "stage": "batching",
+        "estimated_total": len(resource_ids),
+        "estimated_total_source": f"{scope}_resource_snapshot",
+        "total_resources": len(resource_ids),
+        "total_batches": total_batches,
+        "batches_queued": total_batches,
+        "batches_completed": 0,
+        "batches_failed": 0,
+        "batches_finished": 0,
+        "updated_at": datetime.utcnow().isoformat() + "Z",
+    }
+    await repo.update_sync_run(bridge_id=run_id, bridge_stats_json=stats)
+
+    if not batches:
+        stats["stage"] = "complete"
+        await repo.finalize_sync_run(
+            bridge_id=run_id,
+            bridge_status="success",
+            bridge_stats_json=stats,
+        )
+        return {"bridge_id": run_id, "stats": stats, "queued_batches": 0}
+
+    try:
+        for index, resource_id_batch in enumerate(batches, start=1):
+            task_id = enqueue_batch(
+                bridge_id=run_id,
+                resource_ids=resource_id_batch,
+                batch_number=index,
+                total_batches=total_batches,
+                trigger=trigger,
+            )
+            if task_id:
+                queued_task_ids.append(str(task_id))
+    except Exception as exc:
+        failed_stats = {
+            **stats,
+            "stage": "failed",
+            "batches_queued": len(queued_task_ids),
+            "errors": int(stats.get("errors") or 0) + 1,
+            "error_samples": [
+                {
+                    "stage": "enqueue_batches",
+                    "resource_id": None,
+                    "error": str(exc)[:500],
+                }
+            ],
+            "updated_at": datetime.utcnow().isoformat() + "Z",
+        }
+        await repo.finalize_sync_run(
+            bridge_id=run_id,
+            bridge_status="failed",
+            bridge_stats_json=failed_stats,
+            bridge_error=str(exc),
+        )
+        raise
+
+    return {
+        "bridge_id": run_id,
+        "stats": {**stats, "queued_task_ids_sample": queued_task_ids[:20]},
+        "queued_batches": total_batches,
+    }
+
+
+async def sync_bridge_resource_batch(
+    *,
+    bridge_id: int,
+    resource_ids: Sequence[str],
+    batch_number: Optional[int] = None,
+    total_batches: Optional[int] = None,
+    task_id: Optional[str] = None,
+    client: Optional[KitheBridgeClient] = None,
+    importer: Optional[BridgeResourceImporter] = None,
+    repo: Optional[BridgeSyncRepository] = None,
+) -> Dict[str, Any]:
+    if not database.is_connected:
+        await database.connect()
+
+    repo = repo or BridgeSyncRepository()
+    run = await repo.get_sync_run(bridge_id)
+    if not run:
+        raise ValueError(f"Bridge sync run {bridge_id} was not found")
+    if str(run.get("bridge_status") or "").lower() != "running":
+        return {
+            "bridge_id": bridge_id,
+            "batch_number": batch_number,
+            "skipped": True,
+            "reason": f"run status is {run.get('bridge_status')}",
+        }
+
+    run_started_at = _coerce_datetime(run.get("bridge_started_at"))
+    client = client or KitheBridgeClient()
+    importer = importer or BridgeResourceImporter(repo=repo)
+
+    batch_stats: Dict[str, Any] = {
+        "processed": len(resource_ids),
+        "imported": 0,
+        "skipped": 0,
+        "errors": 0,
+        "missing": 0,
+        "retired": 0,
+        "total_batches": total_batches,
+    }
+    records: List[Dict[str, Any]] = []
+    missing_ids: List[str] = []
+
+    for resource_id in resource_ids:
+        rid = str(resource_id or "").strip()
+        if not rid:
+            batch_stats["skipped"] += 1
+            continue
+        try:
+            record = await asyncio.to_thread(client.fetch_record, rid)
+        except Exception as exc:
+            logger.warning("Bridge batched fetch failed for %s: %s", rid, exc)
+            _add_error_sample(
+                batch_stats,
+                stage="fetch_record",
+                resource_id=rid,
+                error=exc,
+            )
+            continue
+
+        if record is None:
+            missing_ids.append(rid)
+        else:
+            records.append(record)
+
+    if records:
+        import_stats = await importer.upsert_records(
+            records,
+            run_started_at=run_started_at,
+            batch_size=min(len(records), normalize_batch_size(None)),
+        )
+        for key in ("imported", "skipped", "errors"):
+            batch_stats[key] = int(batch_stats.get(key) or 0) + int(import_stats.get(key) or 0)
+        if import_stats.get("error_samples"):
+            batch_stats.setdefault("error_samples", []).extend(import_stats["error_samples"])
+        if import_stats.get("error_signatures"):
+            batch_stats.setdefault("error_signatures", []).extend(import_stats["error_signatures"])
+
+    if missing_ids:
+        missing_since = datetime.utcnow()
+        await repo.mark_resources_missing(missing_ids, missing_since=missing_since)
+        retired_count = await repo.retire_missing_resources(
+            missing_ids,
+            retired_at=missing_since,
+        )
+        batch_stats["missing"] = len(missing_ids)
+        batch_stats["retired"] = retired_count
+
+    _finalize_error_stats(batch_stats)
+    parent_stats = await repo.record_batched_batch_result(
+        bridge_id=bridge_id,
+        batch_stats=batch_stats,
+        batch_number=batch_number,
+        task_id=task_id,
+        failed=False,
+    )
+    return {
+        "bridge_id": bridge_id,
+        "batch_number": batch_number,
+        "stats": batch_stats,
+        "parent_stats": parent_stats,
+    }

--- a/backend/app/services/bridge_sync/importer.py
+++ b/backend/app/services/bridge_sync/importer.py
@@ -18,6 +18,7 @@ from app.services.distribution_sync import (
 from app.services.ogm_harvest.aardvark_reader import extract_record_id
 from app.services.ogm_harvest.importer import _parse_iso_date, _parse_iso_datetime
 from app.services.reference_reconstruction import (
+    REFERENCE_NAME_TO_URI,
     build_effective_reference_payload,
     serialize_reference_payload,
 )
@@ -160,6 +161,75 @@ class BridgeResourceImporter:
 
         return out
 
+    def _authoritative_reference_uris_for_record(
+        self,
+        record: Dict[str, Any],
+        reference_type_id_to_uri: Dict[int, str],
+    ) -> Set[str]:
+        uris: Set[str] = set()
+
+        if "document_distributions" in record:
+            # Presence of this key means the bridge sent the current Kithe rows.
+            # Replace legacy references for known types so deleted rows do not survive.
+            uris.update(reference_type_id_to_uri.values())
+
+        if "document_downloads" in record:
+            uris.add(REFERENCE_NAME_TO_URI.get("download", "http://schema.org/downloadUrl"))
+
+        if "assets" in record:
+            for asset in record.get("assets") or []:
+                if not isinstance(asset, dict):
+                    continue
+                raw_key = asset.get("dct_references_uri_key")
+                key = str(raw_key).strip() if raw_key is not None else ""
+                uri = REFERENCE_NAME_TO_URI.get(key)
+                if uri:
+                    uris.add(uri)
+
+        return uris
+
+    def _document_distributions_cover_downloads(
+        self,
+        record: Dict[str, Any],
+        reference_type_id_to_uri: Dict[int, str],
+    ) -> bool:
+        download_uri = REFERENCE_NAME_TO_URI.get("download", "http://schema.org/downloadUrl")
+        for distribution in record.get("document_distributions") or []:
+            if not isinstance(distribution, dict):
+                continue
+            try:
+                type_id = int(distribution.get("reference_type_id"))
+            except (TypeError, ValueError):
+                continue
+            if reference_type_id_to_uri.get(type_id) == download_uri:
+                return True
+        return False
+
+    def _nested_row_for_record(
+        self,
+        resource_id: str,
+        record: Dict[str, Any],
+        reference_type_id_to_uri: Dict[int, str],
+    ) -> Dict[str, Any]:
+        nested_row: Dict[str, Any] = {"resource_id": resource_id}
+        distributions_cover_downloads = self._document_distributions_cover_downloads(
+            record,
+            reference_type_id_to_uri,
+        )
+        for key in (
+            "document_distributions",
+            "document_downloads",
+            "document_licensed_accesses",
+            "assets",
+        ):
+            if key in record:
+                nested_row[key] = (
+                    []
+                    if key == "document_downloads" and distributions_cover_downloads
+                    else record.get(key) or []
+                )
+        return nested_row
+
     async def upsert_records(
         self,
         records: List[Dict[str, Any]],
@@ -281,12 +351,24 @@ class BridgeResourceImporter:
                     stats["skipped"] += 1
                     continue
 
+                distributions_cover_downloads = self._document_distributions_cover_downloads(
+                    record,
+                    reference_type_id_to_uri,
+                )
                 effective_references = build_effective_reference_payload(
                     normalized.get("dct_references_s"),
                     document_distributions=record.get("document_distributions") or [],
-                    document_downloads=record.get("document_downloads") or [],
+                    document_downloads=(
+                        []
+                        if distributions_cover_downloads
+                        else record.get("document_downloads") or []
+                    ),
                     assets=record.get("assets") or [],
                     reference_type_id_to_uri=reference_type_id_to_uri,
+                    authoritative_uris=self._authoritative_reference_uris_for_record(
+                        record,
+                        reference_type_id_to_uri,
+                    ),
                 )
                 normalized["dct_references_s"] = serialize_reference_payload(effective_references)
 
@@ -300,14 +382,11 @@ class BridgeResourceImporter:
                     }
                 )
                 nested_rows.append(
-                    {
-                        "resource_id": str(rid),
-                        "document_distributions": record.get("document_distributions") or [],
-                        "document_downloads": record.get("document_downloads") or [],
-                        "document_licensed_accesses": record.get("document_licensed_accesses")
-                        or [],
-                        "assets": record.get("assets") or [],
-                    }
+                    self._nested_row_for_record(
+                        str(rid),
+                        record,
+                        reference_type_id_to_uri,
+                    )
                 )
 
                 if len(batch_rows) >= batch_size:

--- a/backend/app/services/bridge_sync/nested_sync.py
+++ b/backend/app/services/bridge_sync/nested_sync.py
@@ -28,14 +28,20 @@ def _group_by_resource(
         if not rid:
             continue
 
-        for d in item.get("document_downloads") or []:
-            by_downloads.setdefault(rid, []).append(d or {})
+        if "document_downloads" in item:
+            downloads = by_downloads.setdefault(rid, [])
+            for d in item.get("document_downloads") or []:
+                downloads.append(d or {})
 
-        for a in item.get("document_licensed_accesses") or []:
-            by_licensed.setdefault(rid, []).append(a or {})
+        if "document_licensed_accesses" in item:
+            licensed = by_licensed.setdefault(rid, [])
+            for a in item.get("document_licensed_accesses") or []:
+                licensed.append(a or {})
 
-        for asset in item.get("assets") or []:
-            by_assets.setdefault(rid, []).append(asset or {})
+        if "assets" in item:
+            assets = by_assets.setdefault(rid, [])
+            for asset in item.get("assets") or []:
+                assets.append(asset or {})
 
     return by_downloads, by_licensed, by_assets
 

--- a/backend/app/services/bridge_sync/repository.py
+++ b/backend/app/services/bridge_sync/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -150,6 +151,42 @@ class BridgeSyncRepository:
         )
         return dict(row) if row else None
 
+    async def list_resource_ids_for_batched_sync(
+        self,
+        *,
+        resource_scope: str = "all",
+        limit: Optional[int] = None,
+    ) -> List[str]:
+        scope = (resource_scope or "all").strip().lower()
+        if scope == "all":
+            q = select(resources.c.id).where(resources.c.id.is_not(None)).order_by(resources.c.id)
+        elif scope == "published":
+            q = (
+                select(resources.c.id)
+                .where(resources.c.id.is_not(None))
+                .where(func.coalesce(resources.c.publication_state, "") != "retired")
+                .order_by(resources.c.id)
+            )
+        elif scope == "bridge_active":
+            q = (
+                select(bridge_resource_state.c.bridge_resource_id)
+                .where(bridge_resource_state.c.bridge_retired_at.is_(None))
+                .order_by(bridge_resource_state.c.bridge_resource_id)
+            )
+        else:
+            raise ValueError("resource_scope must be one of: all, published, bridge_active")
+
+        if limit is not None:
+            q = q.limit(max(0, int(limit)))
+
+        rows = await database.fetch_all(q)
+        ids: List[str] = []
+        for row in rows:
+            value = row[0] if hasattr(row, "__getitem__") else None
+            if value:
+                ids.append(str(value))
+        return ids
+
     async def list_missing(self, limit: int = 200, offset: int = 0) -> List[Dict[str, Any]]:
         q = (
             select(bridge_resource_state)
@@ -268,6 +305,156 @@ class BridgeSyncRepository:
         )
         await database.execute(stmt)
         return len(rows)
+
+    async def mark_resources_missing(
+        self,
+        resource_ids: List[str],
+        *,
+        missing_since: datetime,
+    ) -> int:
+        rows = []
+        for resource_id in resource_ids:
+            rid = str(resource_id or "").strip()
+            if not rid:
+                continue
+            rows.append(
+                {
+                    "bridge_resource_id": rid,
+                    "bridge_first_seen_at": missing_since,
+                    "bridge_last_seen_at": missing_since,
+                    "bridge_missing_since": missing_since,
+                    "bridge_retired_at": None,
+                    "bridge_updated_at": missing_since,
+                }
+            )
+        if not rows:
+            return 0
+
+        stmt = pg_insert(bridge_resource_state).values(rows)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[bridge_resource_state.c.bridge_resource_id],
+            set_={
+                "bridge_missing_since": stmt.excluded.bridge_missing_since,
+                "bridge_updated_at": stmt.excluded.bridge_updated_at,
+            },
+        )
+        await database.execute(stmt)
+        return len(rows)
+
+    async def record_batched_batch_result(
+        self,
+        *,
+        bridge_id: int,
+        batch_stats: Dict[str, Any],
+        batch_number: Optional[int] = None,
+        task_id: Optional[str] = None,
+        failed: bool = False,
+    ) -> Dict[str, Any]:
+        async with database.transaction():
+            row = await database.fetch_one(
+                text(
+                    """
+                    SELECT bridge_status, bridge_stats_json
+                    FROM bridge_sync_runs
+                    WHERE bridge_id = :bridge_id
+                    FOR UPDATE
+                    """
+                ).bindparams(bridge_id=bridge_id),
+            )
+            if row is None:
+                raise ValueError(f"Bridge sync run {bridge_id} was not found")
+
+            current_status = str(row["bridge_status"] or "").lower()
+            stats = self._coerce_stats_json(row["bridge_stats_json"])
+            if current_status != "running":
+                return stats
+
+            for key in ("processed", "imported", "skipped", "errors", "missing", "retired"):
+                stats[key] = int(stats.get(key) or 0) + int(batch_stats.get(key) or 0)
+
+            if failed:
+                stats["batches_failed"] = int(stats.get("batches_failed") or 0) + 1
+            else:
+                stats["batches_completed"] = int(stats.get("batches_completed") or 0) + 1
+
+            total_batches = int(stats.get("total_batches") or batch_stats.get("total_batches") or 0)
+            batches_completed = int(stats.get("batches_completed") or 0)
+            batches_failed = int(stats.get("batches_failed") or 0)
+            batches_finished = batches_completed + batches_failed
+            stats["batches_finished"] = batches_finished
+            stats["stage"] = "batching"
+            stats["updated_at"] = datetime.utcnow().isoformat() + "Z"
+            stats["last_batch"] = {
+                "batch_number": batch_number,
+                "task_id": task_id,
+                "failed": failed,
+                "processed": int(batch_stats.get("processed") or 0),
+                "imported": int(batch_stats.get("imported") or 0),
+                "errors": int(batch_stats.get("errors") or 0),
+                "missing": int(batch_stats.get("missing") or 0),
+                "retired": int(batch_stats.get("retired") or 0),
+            }
+
+            self._merge_error_stats(stats, batch_stats)
+
+            values: Dict[str, Any] = {"bridge_stats_json": stats}
+            if total_batches and batches_finished >= total_batches:
+                final_status = "failed" if batches_failed else "success"
+                stats["stage"] = "failed" if batches_failed else "complete"
+                values.update(
+                    {
+                        "bridge_completed_at": datetime.utcnow(),
+                        "bridge_status": final_status,
+                    }
+                )
+                if batches_failed:
+                    values["bridge_error"] = f"{batches_failed} bridge sync batch task(s) failed"
+
+            await database.execute(
+                update(bridge_sync_runs)
+                .where(bridge_sync_runs.c.bridge_id == bridge_id)
+                .values(**values)
+            )
+            return stats
+
+    @staticmethod
+    def _coerce_stats_json(value: Any) -> Dict[str, Any]:
+        if isinstance(value, dict):
+            return dict(value)
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                return {}
+            return dict(parsed) if isinstance(parsed, dict) else {}
+        return {}
+
+    @staticmethod
+    def _merge_error_stats(stats: Dict[str, Any], batch_stats: Dict[str, Any]) -> None:
+        samples = list(stats.get("error_samples") or [])
+        for sample in batch_stats.get("error_samples") or []:
+            if len(samples) >= 20:
+                break
+            samples.append(sample)
+        if samples:
+            stats["error_samples"] = samples
+
+        counts: Dict[str, int] = {}
+        for item in stats.get("error_signatures") or []:
+            signature = item.get("signature") if isinstance(item, dict) else None
+            if signature:
+                counts[str(signature)] = counts.get(str(signature), 0) + int(item.get("count") or 0)
+        for item in batch_stats.get("error_signatures") or []:
+            signature = item.get("signature") if isinstance(item, dict) else None
+            if signature:
+                counts[str(signature)] = counts.get(str(signature), 0) + int(item.get("count") or 0)
+        if counts:
+            stats["error_signatures"] = [
+                {"signature": signature, "count": count}
+                for signature, count in sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[
+                    :10
+                ]
+            ]
 
     async def mark_missing_stale(self, run_started_at: datetime) -> List[str]:
         now = datetime.utcnow()

--- a/backend/app/services/reference_reconstruction.py
+++ b/backend/app/services/reference_reconstruction.py
@@ -24,15 +24,20 @@ def build_effective_reference_payload(
     assets: Sequence[Mapping[str, Any]] | None = None,
     reference_type_id_to_uri: Mapping[int, str] | None = None,
     asset_key_to_uri: Mapping[str, str] | None = None,
+    authoritative_uris: Iterable[str] | None = None,
 ) -> Dict[str, Any]:
     """
     Merge all known legacy/bridge reference sources into a single Aardvark payload.
 
     The result only emits scalar strings or arrays, never top-level objects, so it
     remains compatible with distribution sync code that reparses `dct_references_s`.
+    When authoritative_uris is provided, matching legacy entries are replaced by
+    the current bridge-provided nested rows instead of being merged forward.
     """
 
     grouped = _group_reference_payload(base_payload)
+    for uri in authoritative_uris or []:
+        grouped.pop(uri, None)
 
     for distribution in document_distributions or []:
         uri = _reference_uri_for_distribution(distribution, reference_type_id_to_uri)

--- a/backend/app/tasks/bridge_sync.py
+++ b/backend/app/tasks/bridge_sync.py
@@ -3,6 +3,10 @@ import logging
 import os
 from typing import Any, Coroutine, Dict, Optional
 
+from app.services.bridge_sync.batched import (
+    queue_batched_bridge_sync,
+    sync_bridge_resource_batch,
+)
 from app.services.bridge_sync.harvest import sync_bridge
 from app.services.bridge_sync.report import send_bridge_sync_report_for_run
 from app.tasks.worker import celery_app
@@ -108,3 +112,136 @@ async def _bridge_sync_all_async(
             )
             result["report"] = {"enabled": True, "sent": False, "error": str(exc)}
     return result
+
+
+@celery_app.task(
+    bind=True,
+    name="bridge_sync_enqueue_batches",
+    soft_time_limit=10 * 60,
+    time_limit=15 * 60,
+)
+def bridge_sync_enqueue_batches(
+    self,
+    trigger: str = "manual_batched",
+    batch_size: Optional[int] = None,
+    resource_scope: str = "all",
+    max_resources: Optional[int] = None,
+) -> Dict[str, Any]:
+    return _run(
+        _bridge_sync_enqueue_batches_async(
+            trigger=trigger,
+            batch_size=batch_size,
+            resource_scope=resource_scope,
+            max_resources=max_resources,
+        )
+    )
+
+
+async def _bridge_sync_enqueue_batches_async(
+    trigger: str,
+    batch_size: Optional[int],
+    resource_scope: str,
+    max_resources: Optional[int],
+) -> Dict[str, Any]:
+    if not database.is_connected:
+        await database.connect()
+
+    def _enqueue_batch(**kwargs: Any) -> Optional[str]:
+        task = bridge_sync_resource_batch.apply_async(kwargs=kwargs, ignore_result=True)
+        return str(task.id) if task.id else None
+
+    return await queue_batched_bridge_sync(
+        trigger=trigger,
+        batch_size=batch_size,
+        resource_scope=resource_scope,
+        max_resources=max_resources,
+        enqueue_batch=_enqueue_batch,
+    )
+
+
+@celery_app.task(
+    bind=True,
+    name="bridge_sync_resource_batch",
+    soft_time_limit=30 * 60,
+    time_limit=35 * 60,
+)
+def bridge_sync_resource_batch(
+    self,
+    bridge_id: int,
+    resource_ids: list[str],
+    batch_number: Optional[int] = None,
+    total_batches: Optional[int] = None,
+    trigger: str = "manual_batched",
+) -> Dict[str, Any]:
+    try:
+        return _run(
+            sync_bridge_resource_batch(
+                bridge_id=bridge_id,
+                resource_ids=resource_ids,
+                batch_number=batch_number,
+                total_batches=total_batches,
+                task_id=getattr(self.request, "id", None),
+            )
+        )
+    except Exception as exc:
+        logger.error(
+            "Bridge sync batch failed: bridge_id=%s batch_number=%s trigger=%s err=%s",
+            bridge_id,
+            batch_number,
+            trigger,
+            exc,
+            exc_info=True,
+        )
+        _run(
+            _record_failed_bridge_sync_batch(
+                bridge_id=bridge_id,
+                batch_number=batch_number,
+                total_batches=total_batches,
+                task_id=getattr(self.request, "id", None),
+                exc=exc,
+            )
+        )
+        raise
+
+
+async def _record_failed_bridge_sync_batch(
+    *,
+    bridge_id: int,
+    batch_number: Optional[int],
+    total_batches: Optional[int],
+    task_id: Optional[str],
+    exc: Exception,
+) -> None:
+    if not database.is_connected:
+        await database.connect()
+    from app.services.bridge_sync.repository import BridgeSyncRepository
+
+    repo = BridgeSyncRepository()
+    await repo.record_batched_batch_result(
+        bridge_id=bridge_id,
+        batch_number=batch_number,
+        task_id=task_id,
+        failed=True,
+        batch_stats={
+            "processed": 0,
+            "imported": 0,
+            "skipped": 0,
+            "errors": 1,
+            "missing": 0,
+            "retired": 0,
+            "total_batches": total_batches,
+            "error_samples": [
+                {
+                    "stage": "batch_task",
+                    "resource_id": None,
+                    "error": str(exc)[:500],
+                }
+            ],
+            "error_signatures": [
+                {
+                    "signature": f"{exc.__class__.__name__}: {str(exc)[:180]}",
+                    "count": 1,
+                }
+            ],
+        },
+    )

--- a/backend/scripts/bridge_status_summary.py
+++ b/backend/scripts/bridge_status_summary.py
@@ -47,6 +47,9 @@ def _stats_for_run(run: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _scope_for_stats(stats: Dict[str, Any]) -> str:
+    if stats.get("scope") == "batched_full":
+        resource_scope = str(stats.get("resource_scope") or "all").strip() or "all"
+        return f"batched:{resource_scope}"
     resource_id = (stats.get("resource_id") or "").strip()
     if resource_id:
         return f"single:{resource_id}"
@@ -157,6 +160,9 @@ def summarize_run(
     matched_page_size = _coerce_int(stats.get("matched_page_size"))
     missing = _coerce_int(stats.get("missing"))
     retired = _coerce_int(stats.get("retired"))
+    batches_completed = _coerce_int(stats.get("batches_completed"))
+    batches_failed = _coerce_int(stats.get("batches_failed"))
+    total_batches = _coerce_int(stats.get("total_batches"))
     started_at = run.get("bridge_started_at")
     elapsed_seconds = _elapsed_seconds(run, now)
     rate = (
@@ -170,7 +176,7 @@ def summarize_run(
     eta_seconds: Optional[float] = None
     if (
         status.lower() == "running"
-        and scope == "full"
+        and (scope == "full" or scope.startswith("batched:"))
         and estimated_total
         and estimated_total > 0
         and processed > 0
@@ -212,6 +218,11 @@ def summarize_run(
         parts.append(f"missing={missing}")
     if retired is not None:
         parts.append(f"retired={retired}")
+    if total_batches is not None:
+        batches_done = (batches_completed or 0) + (batches_failed or 0)
+        parts.append(f"batches={batches_done}/{total_batches}")
+    if batches_failed:
+        parts.append(f"batch_failures={batches_failed}")
     if estimated_total is not None and estimated_total > 0:
         parts.append(f"est_total~={estimated_total}")
     if progress_pct is not None:

--- a/backend/tests/api/v1/test_bridge_sync_admin.py
+++ b/backend/tests/api/v1/test_bridge_sync_admin.py
@@ -73,6 +73,35 @@ async def test_trigger_bridge_sync_enqueues_task_with_resource_id(mock_task):
 
 
 @pytest.mark.asyncio
+@patch("app.api.v1.endpoint_modules.admin.bridge_sync_enqueue_batches")
+async def test_trigger_bridge_sync_enqueues_batched_task(mock_task):
+    mock_task.delay.return_value = Mock(id="bridge-batched-task-123")
+
+    response = await trigger_bridge_sync(
+        TriggerBridgeSyncRequest(
+            bridge_trigger="manual_batched",
+            batched=True,
+            batch_size=750,
+            resource_scope="bridge_active",
+            max_resources=1500,
+        )
+    )
+
+    payload = json.loads(response.body)
+    assert payload["queued"] == "kithe_bridge_batched"
+    assert payload["task_id"] == "bridge-batched-task-123"
+    assert payload["batch_size"] == 750
+    assert payload["resource_scope"] == "bridge_active"
+    assert payload["max_resources"] == 1500
+    mock_task.delay.assert_called_once_with(
+        trigger="manual_batched",
+        batch_size=750,
+        resource_scope="bridge_active",
+        max_resources=1500,
+    )
+
+
+@pytest.mark.asyncio
 @patch("app.api.v1.endpoint_modules.admin.bridge_repo")
 async def test_list_bridge_sync_runs_returns_runs(mock_repo):
     mock_repo.list_sync_runs = AsyncMock(

--- a/backend/tests/services/test_bridge_sync_service.py
+++ b/backend/tests/services/test_bridge_sync_service.py
@@ -467,6 +467,7 @@ class TestBridgeSyncService:
                     delete(resources).where(resources.c.id.in_(["bridge-sync-a", "bridge-sync-b"]))
                 )
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass
 
     @pytest.mark.asyncio(scope="session")
@@ -681,6 +682,7 @@ class TestBridgeSyncService:
                     delete(resources).where(resources.c.id.in_(["bridge-sync-a", "bridge-sync-b"]))
                 )
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass
 
     @pytest.mark.asyncio(scope="session")
@@ -860,6 +862,7 @@ class TestBridgeSyncService:
                 )
                 await database.execute(delete(resources).where(resources.c.id == resource_id))
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass
 
     @pytest.mark.asyncio(scope="session")
@@ -962,6 +965,7 @@ class TestBridgeSyncService:
                 )
                 await database.execute(delete(resources).where(resources.c.id == resource_id))
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass
 
     @pytest.mark.asyncio(scope="session")
@@ -1139,6 +1143,7 @@ class TestBridgeSyncService:
                 )
                 await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass
 
     @pytest.mark.asyncio(scope="session")
@@ -1275,6 +1280,7 @@ class TestBridgeSyncService:
                 )
                 await database.execute(delete(resources).where(resources.c.id == resource_id))
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass
 
     @pytest.mark.asyncio(scope="session")
@@ -1415,6 +1421,7 @@ class TestBridgeSyncService:
                     delete(resources).where(resources.c.id.in_(["bridge-sync-a", "bridge-sync-b"]))
                 )
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass
 
     @pytest.mark.asyncio(scope="session")
@@ -1446,4 +1453,5 @@ class TestBridgeSyncService:
             try:
                 await database.execute(delete(bridge_sync_runs))
             except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
                 pass

--- a/backend/tests/services/test_bridge_sync_service.py
+++ b/backend/tests/services/test_bridge_sync_service.py
@@ -681,6 +681,421 @@ class TestBridgeSyncService:
                 pass
 
     @pytest.mark.asyncio(scope="session")
+    async def test_sync_bridge_prunes_deleted_distribution_urls_from_legacy_references(self):
+        repo = BridgeSyncRepository()
+        importer = BridgeResourceImporter(repo=repo)
+
+        resource_id = "bridge-sync-prune-deleted-distribution"
+        current_url = "https://example.org/current-download.zip"
+        deleted_url = "https://example.org/deleted-download.zip"
+        record = {
+            "id": resource_id,
+            "import_id": "103",
+            "publication_state": "published",
+            "dct_title_s": "Bridge Sync Prune Deleted Distribution",
+            "dct_description_sm": ["Distribution pruning test"],
+            "dct_references_s": {
+                "http://schema.org/downloadUrl": [
+                    {"url": current_url, "label": "Current download"},
+                    {"url": deleted_url, "label": "Deleted download"},
+                ],
+            },
+            "document_distributions": [
+                {
+                    "reference_type_id": 8,
+                    "url": current_url,
+                    "label": "Current download",
+                    "position": 0,
+                }
+            ],
+        }
+
+        if not database.is_connected:
+            await database.connect()
+
+        try:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id == resource_id
+                )
+            )
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(
+                delete(resource_distributions).where(
+                    resource_distributions.c.resource_id == resource_id
+                )
+            )
+            await database.execute(delete(resources).where(resources.c.id == resource_id))
+
+            client = FakeBridgeClient(
+                {
+                    "__first__": BridgePage(
+                        data=[record],
+                        next_cursor=None,
+                        has_more=False,
+                    )
+                }
+            )
+
+            result = await sync_bridge(
+                trigger="manual",
+                limit=10,
+                client=client,
+                importer=importer,
+                repo=repo,
+            )
+
+            assert result["stats"]["imported"] == 1
+
+            row = await database.fetch_one(
+                select(resources.c.id, resources.c.dct_references_s).where(
+                    resources.c.id == resource_id
+                )
+            )
+            assert row is not None
+            assert json.loads(row["dct_references_s"]) == {
+                "http://schema.org/downloadUrl": [{"url": current_url, "label": "Current download"}]
+            }
+
+            distribution_rows = await database.fetch_all(
+                select(resource_distributions.c.url, resource_distributions.c.label).where(
+                    resource_distributions.c.resource_id == resource_id
+                )
+            )
+            assert [(row["url"], row["label"]) for row in distribution_rows] == [
+                (current_url, "Current download")
+            ]
+        finally:
+            try:
+                await database.execute(
+                    delete(bridge_resource_state).where(
+                        bridge_resource_state.c.bridge_resource_id == resource_id
+                    )
+                )
+                await database.execute(delete(bridge_sync_runs))
+                await database.execute(
+                    delete(resource_distributions).where(
+                        resource_distributions.c.resource_id == resource_id
+                    )
+                )
+                await database.execute(delete(resources).where(resources.c.id == resource_id))
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_sync_bridge_real_reported_records_ignore_stale_document_downloads(self):
+        repo = BridgeSyncRepository()
+        importer = BridgeResourceImporter(repo=repo)
+
+        oneida_id = "0011D7A3-0EC0-4B1D-AF20-C055274B6DAE"
+        oneida_current = "https://web.s3.wisc.edu/parcels/pre_V1/Oneida_Parcels_2014.zip"
+        oneida_stale = "https://gisdata.wisc.edu/public/Oneida_Parcels_2014.zip"
+        michigan_id = "002a86d5-ff04-4d71-b7d2-5b4be4d79102"
+        michigan_current = (
+            "https://michigan.access.preservica.com/download/file/"
+            "IO_002a86d5-ff04-4d71-b7d2-5b4be4d79102"
+        )
+        michigan_stale = (
+            "https://michiganology.org/download/file/IO_002a86d5-ff04-4d71-b7d2-5b4be4d79102"
+        )
+        resource_ids = [oneida_id, michigan_id]
+
+        records = [
+            {
+                "id": oneida_id,
+                "import_id": "662",
+                "publication_state": "published",
+                "dct_title_s": "Parcels Oneida County, WI 2014",
+                "dct_description_sm": ["Distribution pruning test"],
+                "dct_references_s": "[]",
+                "document_distributions": [
+                    {
+                        "reference_type_id": 7,
+                        "url": "https://gis.co.oneida.wi.us/gismapping/",
+                    },
+                    {
+                        "reference_type_id": 8,
+                        "url": oneida_current,
+                        "label": "Geodatabase",
+                    },
+                    {
+                        "reference_type_id": 16,
+                        "url": (
+                            "https://web.s3.wisc.edu/rml-gisdata/metadata/Oneida_Parcels_2014.xml"
+                        ),
+                    },
+                ],
+                "document_downloads": [
+                    {
+                        "label": "Geodatabase",
+                        "value": oneida_stale,
+                    }
+                ],
+            },
+            {
+                "id": michigan_id,
+                "import_id": "664",
+                "publication_state": "published",
+                "dct_title_s": (
+                    "30N 07W - Survey Map of Kearney Township, Antrim County [Michigan]"
+                ),
+                "dct_description_sm": ["Distribution pruning test"],
+                "dct_references_s": "[]",
+                "document_distributions": [
+                    {
+                        "reference_type_id": 7,
+                        "url": (
+                            "https://michigan.access.preservica.com/uncategorized/"
+                            "IO_002a86d5-ff04-4d71-b7d2-5b4be4d79102"
+                        ),
+                    },
+                    {
+                        "reference_type_id": 8,
+                        "url": michigan_current,
+                        "label": "JPEG2000",
+                    },
+                ],
+                "document_downloads": [
+                    {
+                        "label": "JPEG2000",
+                        "value": michigan_stale,
+                    }
+                ],
+            },
+        ]
+
+        if not database.is_connected:
+            await database.connect()
+
+        try:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(
+                delete(resource_distributions).where(
+                    resource_distributions.c.resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(
+                delete(resource_downloads).where(resource_downloads.c.resource_id.in_(resource_ids))
+            )
+            await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
+
+            client = FakeBridgeClient(
+                {
+                    "__first__": BridgePage(
+                        data=records,
+                        next_cursor=None,
+                        has_more=False,
+                    )
+                }
+            )
+
+            result = await sync_bridge(
+                trigger="manual",
+                limit=10,
+                client=client,
+                importer=importer,
+                repo=repo,
+            )
+
+            assert result["stats"]["imported"] == 2
+
+            for resource_id, current_url, stale_url in (
+                (oneida_id, oneida_current, oneida_stale),
+                (michigan_id, michigan_current, michigan_stale),
+            ):
+                resource_row = await database.fetch_one(
+                    select(resources.c.dct_references_s).where(resources.c.id == resource_id)
+                )
+                assert resource_row is not None
+                references = json.loads(resource_row["dct_references_s"])
+                download_refs = references["http://schema.org/downloadUrl"]
+                assert download_refs == [
+                    {
+                        "url": current_url,
+                        "label": "Geodatabase" if resource_id == oneida_id else "JPEG2000",
+                    }
+                ]
+                assert stale_url not in json.dumps(references)
+
+                distribution_rows = await database.fetch_all(
+                    select(resource_distributions.c.url).where(
+                        resource_distributions.c.resource_id == resource_id
+                    )
+                )
+                distribution_urls = {row["url"] for row in distribution_rows}
+                assert current_url in distribution_urls
+                assert stale_url not in distribution_urls
+
+                download_rows = await database.fetch_all(
+                    select(resource_downloads).where(
+                        resource_downloads.c.resource_id == resource_id
+                    )
+                )
+                assert download_rows == []
+        finally:
+            try:
+                await database.execute(
+                    delete(bridge_resource_state).where(
+                        bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                    )
+                )
+                await database.execute(delete(bridge_sync_runs))
+                await database.execute(
+                    delete(resource_distributions).where(
+                        resource_distributions.c.resource_id.in_(resource_ids)
+                    )
+                )
+                await database.execute(
+                    delete(resource_downloads).where(
+                        resource_downloads.c.resource_id.in_(resource_ids)
+                    )
+                )
+                await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_sync_bridge_empty_nested_downloads_clear_previous_rows(self):
+        repo = BridgeSyncRepository()
+        importer = BridgeResourceImporter(repo=repo)
+
+        resource_id = "bridge-sync-clear-deleted-downloads"
+        stale_url = "https://example.org/stale-download.zip"
+        initial_record = {
+            "id": resource_id,
+            "import_id": "104",
+            "publication_state": "published",
+            "dct_title_s": "Bridge Sync Clear Deleted Downloads",
+            "dct_description_sm": ["Nested download clearing test"],
+            "dct_references_s": {},
+            "document_downloads": [
+                {
+                    "label": "Stale download",
+                    "value": stale_url,
+                    "position": 0,
+                }
+            ],
+        }
+        updated_record = {
+            "id": resource_id,
+            "import_id": "104",
+            "publication_state": "published",
+            "dct_title_s": "Bridge Sync Clear Deleted Downloads",
+            "dct_description_sm": ["Nested download clearing test"],
+            "dct_references_s": {
+                "http://schema.org/downloadUrl": [{"url": stale_url, "label": "Stale download"}],
+            },
+            "document_downloads": [],
+        }
+
+        if not database.is_connected:
+            await database.connect()
+
+        try:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id == resource_id
+                )
+            )
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(
+                delete(resource_distributions).where(
+                    resource_distributions.c.resource_id == resource_id
+                )
+            )
+            await database.execute(
+                delete(resource_downloads).where(resource_downloads.c.resource_id == resource_id)
+            )
+            await database.execute(delete(resources).where(resources.c.id == resource_id))
+
+            first_client = FakeBridgeClient(
+                {
+                    "__first__": BridgePage(
+                        data=[initial_record],
+                        next_cursor=None,
+                        has_more=False,
+                    )
+                }
+            )
+            await sync_bridge(
+                trigger="manual",
+                limit=10,
+                client=first_client,
+                importer=importer,
+                repo=repo,
+            )
+
+            seeded_downloads = await database.fetch_all(
+                select(resource_downloads.c.value).where(
+                    resource_downloads.c.resource_id == resource_id
+                )
+            )
+            assert [row["value"] for row in seeded_downloads] == [stale_url]
+
+            second_client = FakeBridgeClient(
+                {
+                    "__first__": BridgePage(
+                        data=[updated_record],
+                        next_cursor=None,
+                        has_more=False,
+                    )
+                }
+            )
+            await sync_bridge(
+                trigger="manual",
+                limit=10,
+                client=second_client,
+                importer=importer,
+                repo=repo,
+            )
+
+            row = await database.fetch_one(
+                select(resources.c.id, resources.c.dct_references_s).where(
+                    resources.c.id == resource_id
+                )
+            )
+            assert row is not None
+            assert row["dct_references_s"] is None
+
+            downloads = await database.fetch_all(
+                select(resource_downloads).where(resource_downloads.c.resource_id == resource_id)
+            )
+            assert downloads == []
+
+            distribution_rows = await database.fetch_all(
+                select(resource_distributions).where(
+                    resource_distributions.c.resource_id == resource_id
+                )
+            )
+            assert distribution_rows == []
+        finally:
+            try:
+                await database.execute(
+                    delete(bridge_resource_state).where(
+                        bridge_resource_state.c.bridge_resource_id == resource_id
+                    )
+                )
+                await database.execute(delete(bridge_sync_runs))
+                await database.execute(
+                    delete(resource_distributions).where(
+                        resource_distributions.c.resource_id == resource_id
+                    )
+                )
+                await database.execute(
+                    delete(resource_downloads).where(
+                        resource_downloads.c.resource_id == resource_id
+                    )
+                )
+                await database.execute(delete(resources).where(resources.c.id == resource_id))
+            except Exception:
+                pass
+
+    @pytest.mark.asyncio(scope="session")
     async def test_sync_bridge_resource_id_stops_on_match_without_retiring_others(self):
         repo = BridgeSyncRepository()
         importer = BridgeResourceImporter(repo=repo)

--- a/backend/tests/services/test_bridge_sync_service.py
+++ b/backend/tests/services/test_bridge_sync_service.py
@@ -8,6 +8,10 @@ import pytest
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
+from app.services.bridge_sync.batched import (
+    queue_batched_bridge_sync,
+    sync_bridge_resource_batch,
+)
 from app.services.bridge_sync.client import BridgePage
 from app.services.bridge_sync.harvest import sync_bridge
 from app.services.bridge_sync.importer import BridgeResourceImporter
@@ -53,6 +57,184 @@ class TestBridgeSyncService:
         os.environ["BRIDGE_CACHE_REFRESH_ENABLED"] = "false"
         create_bridge_sync_tables()
         create_resource_aux_tables()
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_queue_batched_bridge_sync_creates_parent_run_and_batch_jobs(self):
+        repo = BridgeSyncRepository()
+        resource_ids = [
+            "bridge-batched-queue-a",
+            "bridge-batched-queue-b",
+            "bridge-batched-queue-c",
+        ]
+
+        if not database.is_connected:
+            await database.connect()
+
+        queued_batches = []
+
+        def enqueue_batch(**kwargs):
+            queued_batches.append(kwargs)
+            return f"task-{kwargs['batch_number']}"
+
+        try:
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(delete(bridge_resource_state))
+            await database.execute(
+                pg_insert(bridge_resource_state).values(
+                    [
+                        {
+                            "bridge_resource_id": rid,
+                        }
+                        for rid in resource_ids
+                    ]
+                )
+            )
+
+            result = await queue_batched_bridge_sync(
+                trigger="manual_batched",
+                batch_size=2,
+                resource_scope="bridge_active",
+                max_resources=3,
+                enqueue_batch=enqueue_batch,
+                repo=repo,
+            )
+
+            assert result["queued_batches"] == 2
+            assert len(queued_batches) == 2
+            assert queued_batches[0]["resource_ids"] == [
+                "bridge-batched-queue-a",
+                "bridge-batched-queue-b",
+            ]
+            assert queued_batches[1]["resource_ids"] == ["bridge-batched-queue-c"]
+
+            run = await repo.get_sync_run(result["bridge_id"])
+            assert run is not None
+            assert run["bridge_status"] == "running"
+            stats = run["bridge_stats_json"]
+            assert stats["scope"] == "batched_full"
+            assert stats["resource_scope"] == "bridge_active"
+            assert stats["total_resources"] == 3
+            assert stats["total_batches"] == 2
+            assert stats["batches_queued"] == 2
+        finally:
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_sync_bridge_resource_batch_imports_missing_and_finalizes_parent_run(self):
+        repo = BridgeSyncRepository()
+        importer = BridgeResourceImporter(repo=repo)
+        found_id = "bridge-batched-found"
+        missing_id = "bridge-batched-missing"
+        resource_ids = [found_id, missing_id]
+        record = {
+            "id": found_id,
+            "import_id": "batched-1",
+            "publication_state": "published",
+            "dct_title_s": "Bridge Batched Found",
+            "dct_description_sm": ["Found record"],
+            "dct_references_s": "[]",
+        }
+
+        if not database.is_connected:
+            await database.connect()
+
+        try:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
+            await database.execute(
+                pg_insert(resources).values(
+                    {
+                        "id": missing_id,
+                        "dct_title_s": "Bridge Batched Missing",
+                        "publication_state": "published",
+                        "b1g_publication_state_s": "published",
+                    }
+                )
+            )
+
+            run_id = await repo.create_sync_run(bridge_trigger="manual_batched")
+            await repo.update_sync_run(
+                bridge_id=run_id,
+                bridge_stats_json={
+                    "scope": "batched_full",
+                    "resource_scope": "all",
+                    "stage": "batching",
+                    "estimated_total": 2,
+                    "total_resources": 2,
+                    "total_batches": 1,
+                    "batches_queued": 1,
+                    "batches_completed": 0,
+                    "batches_failed": 0,
+                    "processed": 0,
+                    "imported": 0,
+                    "skipped": 0,
+                    "errors": 0,
+                    "missing": 0,
+                    "retired": 0,
+                },
+            )
+
+            client = FakeBridgeClient({}, records={found_id: record})
+            result = await sync_bridge_resource_batch(
+                bridge_id=run_id,
+                resource_ids=resource_ids,
+                batch_number=1,
+                total_batches=1,
+                task_id="batch-task-1",
+                client=client,
+                importer=importer,
+                repo=repo,
+            )
+
+            assert result["stats"]["processed"] == 2
+            assert result["stats"]["imported"] == 1
+            assert result["stats"]["missing"] == 1
+            assert result["stats"]["retired"] == 1
+
+            run = await repo.get_sync_run(run_id)
+            assert run is not None
+            assert run["bridge_status"] == "success"
+            stats = run["bridge_stats_json"]
+            assert stats["stage"] == "complete"
+            assert stats["batches_completed"] == 1
+            assert stats["processed"] == 2
+            assert stats["imported"] == 1
+            assert stats["missing"] == 1
+            assert stats["retired"] == 1
+
+            found = await database.fetch_one(
+                select(resources.c.id, resources.c.dct_title_s).where(resources.c.id == found_id)
+            )
+            missing = await database.fetch_one(
+                select(
+                    resources.c.id,
+                    resources.c.publication_state,
+                    resources.c.b1g_publication_state_s,
+                ).where(resources.c.id == missing_id)
+            )
+            assert found is not None
+            assert found["dct_title_s"] == "Bridge Batched Found"
+            assert missing is not None
+            assert missing["publication_state"] == "retired"
+            assert missing["b1g_publication_state_s"] == "retired"
+        finally:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
 
     @pytest.mark.asyncio(scope="session")
     async def test_sync_bridge_paginates_and_retires_missing_records(self):

--- a/backend/tests/services/test_reference_reconstruction.py
+++ b/backend/tests/services/test_reference_reconstruction.py
@@ -72,6 +72,34 @@ def test_build_effective_reference_payload_merges_legacy_sources():
     ]
 
 
+def test_build_effective_reference_payload_replaces_authoritative_uris():
+    payload = build_effective_reference_payload(
+        {
+            "http://lccn.loc.gov/sh85035852": "https://example.org/reference-guide",
+            "http://schema.org/downloadUrl": [
+                {"url": "https://example.org/current.zip", "label": "Current"},
+                {"url": "https://example.org/deleted.zip", "label": "Deleted"},
+            ],
+        },
+        document_distributions=[
+            {
+                "reference_type_id": 8,
+                "url": "https://example.org/current.zip",
+                "label": "Current",
+            }
+        ],
+        reference_type_id_to_uri={8: "http://schema.org/downloadUrl"},
+        authoritative_uris={"http://schema.org/downloadUrl"},
+    )
+
+    assert payload == {
+        "http://lccn.loc.gov/sh85035852": "https://example.org/reference-guide",
+        "http://schema.org/downloadUrl": [
+            {"url": "https://example.org/current.zip", "label": "Current"}
+        ],
+    }
+
+
 def test_build_asset_record_from_kithe_model_builds_storage_backed_asset():
     file_data = {
         "storage": "store",

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,11 +181,11 @@ Run Makefile targets from the repository root.
 | Cache and visual assets | `make clear_cache`, `make clear-thumbnail-cache`, `make prime-thumbnail-cache`, `make prime-static-map-cache`, `make prime-resource-cache`, `make prime-visual-caches`, `make refresh-resource-caches`, `make visual-assets-export`, `make visual-assets-import`, `make visual-assets-stream-import`, `make visual-assets-sync-all`. |
 | Data import | `make ingest`, `make ingest-featured`, `make populate-distributions`, `make populate-data-dictionaries`, `make backfill-distributions`, `make populate-relationships`, `make resource-aux-init`. |
 | OGM | `make ogm-refresh-all`, `make ogm-refresh-repo OGM_REPO_NAME=...`, `make ogm-status`, `make ogm-status-watch`, `make ogm-failures`. |
-| Kithe bridge | `make bridge-init`, `make bridge-sync`, `make bridge-cancel`, `make bridge-status`, `make bridge-status-watch`, `make bridge-failures`. |
+| Kithe bridge | `make bridge-init`, `make bridge-sync`, `make bridge-sync-batched`, `make bridge-cancel`, `make bridge-status`, `make bridge-status-watch`, `make bridge-failures`. |
 | Blog/sitemap | `make blog-sync`, `make sitemap-generate`. |
 | Analytics | `make analytics-maintenance`, `make analytics-size-report`. |
 | Database sync | `make db-export`, `make db-import`, `make db-sync`, `make gbl-admin-db-*`. |
-| Kamal remote ops | `make kamal-reindex`, `make kamal-clear-cache`, `make kamal-verify-h3-index`, `make kamal-blog-sync`, `make kamal-purge-home-blog-cache`, `make kamal-bridge-status`, `make kamal-cron-debug`, `make kamal-worker-logs`, `make kamal-network-sanity`, plus Kamal cache priming targets. |
+| Kamal remote ops | `make kamal-reindex`, `make kamal-clear-cache`, `make kamal-verify-h3-index`, `make kamal-blog-sync`, `make kamal-purge-home-blog-cache`, `make kamal-bridge-sync-batched`, `make kamal-bridge-status`, `make kamal-cron-debug`, `make kamal-worker-logs`, `make kamal-network-sanity`, plus Kamal cache priming targets. |
 | Performance | `make k6-smoke`, `make k6-stress`, `make k6-endpoint-capacity`. |
 
 ## Kamal Deployment Model

--- a/docs/make_tasks.md
+++ b/docs/make_tasks.md
@@ -144,6 +144,7 @@ defaults to `5`.
 | --- | --- |
 | `make bridge-init` | Ensure bridge sync tables and resource aux tables exist. |
 | `make bridge-sync` | Trigger a background bridge sync. |
+| `make bridge-sync-batched` | Trigger batched full-resource bridge reconciliation. |
 | `make bridge-cancel` | Cancel all bridge syncs and queued bridge sync tasks. |
 | `make bridge-status` | Show bridge sync status. Supports `BRIDGE_RUN_ID` or `BRIDGE_RUNS_LIMIT`. |
 | `make bridge-status-watch` | Poll bridge sync status continuously. |
@@ -159,7 +160,18 @@ Useful bridge variables:
 | `BRIDGE_LIMIT` | Optional max records to sync. |
 | `BRIDGE_CHANGED_SINCE` | Optional incremental sync cutoff. |
 | `RESOURCE_ID` / `BRIDGE_RESOURCE_ID` | Single-record sync scope. |
+| `BRIDGE_BATCH_TRIGGER` | Batched reconciliation trigger label. Defaults to `manual_batched`. |
+| `BRIDGE_BATCH_SIZE` | Batched reconciliation resources per Celery task. Defaults to `500`, capped at `1000`. |
+| `BRIDGE_RESOURCE_SCOPE` | Batched reconciliation source: `all`, `published`, or `bridge_active`. Defaults to `all`. |
+| `BRIDGE_MAX_RESOURCES` | Optional cap for trial batched reconciliation runs. |
 | `BRIDGE_STATUS_POLL_SECONDS` | Defaults to `5`. |
+
+For remote reconciliation, run `make kamal-bridge-sync-batched KAMAL_DEST=dev1`
+and then monitor with `make kamal-bridge-status-watch KAMAL_DEST=dev1`. Run
+`make kamal-reindex` after the batched sync completes so Elasticsearch reflects
+the corrected database rows. The batched target reconciles existing local IDs;
+keep the normal bridge crawl/delta sync for discovering newly added Bridge
+records.
 
 ## Analytics
 


### PR DESCRIPTION
Fix for stale/deleted Kithe distributions continuing to appear after bridge sync. This work does two things:

### Corrects distribution cleanup during sync

Treats Bridge-provided document_distributions, document_downloads, and asset references as authoritative when present.
Removes stale legacy dct_references_s entries for authoritative reference URIs before rebuilding effective references.
Clears orphaned resource_downloads rows when canonical document_distributions already provide download URLs.
Adds regression coverage for the two reported resources:

- 0011D7A3-0EC0-4B1D-AF20-C055274B6DAE
- 002a86d5-ff04-4d71-b7d2-5b4be4d79102

### Adds a scalable reconciliation path for the full database

Adds batched Kithe Bridge reconciliation so we can correct all existing resources without relying on one long-running Celery task.

Creates one parent bridge sync run, snapshots local resource IDs, and queues bounded bridge_sync_resource_batch jobs.

Tracks aggregate progress in bridge_sync_runs.bridge_stats_json, including processed/imported/missing/retired counts and batch completion.

Adds local and Kamal Make targets:

- make bridge-sync-batched
- make kamal-bridge-sync-batched

Updates bridge status summaries and docs for monitoring and operation.
Validation included focused service/API tests, lint, format checks, Makefile dry runs, and targeted dev1 syncs confirming the two reported records now return only the current download URL.