### PR TITLE
fix: update desktop filter rail position and overflow behavior

### DIFF
--- a/frontend/src/__tests__/pages/SearchPage.test.tsx
+++ b/frontend/src/__tests__/pages/SearchPage.test.tsx
@@ -267,6 +267,21 @@ describe('SearchPage Logic', () => {
     expect(panel).toHaveClass('hidden');
   });
 
+  it('lets the desktop filter rail scroll with the page', async () => {
+    const results = createMockApiResponse(mockResults.slice(0, 20));
+    renderWithRouter('/search?view=list', results);
+
+    const panel = document.getElementById('search-filters-panel') as HTMLElement;
+    expect(panel).toHaveClass('z-50');
+    expect(panel).toHaveClass('lg:z-10');
+    expect(panel).toHaveClass('lg:top-40');
+    expect(panel).not.toHaveClass('lg:top-24');
+    expect(panel).toHaveClass('overflow-y-auto');
+    expect(panel).toHaveClass('lg:overflow-visible');
+    expect(panel).not.toHaveClass('lg:overflow-y-auto');
+    expect(panel.className).not.toContain('lg:max-h-');
+  });
+
   it('hides stale client results while a new query is loading', async () => {
     const mockFetchSearchResults = vi.mocked(fetchSearchResults);
     const oldResults = createMockApiResponse(

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -615,7 +615,7 @@ function SearchContent({
               aria-label="Filter results"
               className={`${
                 isFilterDrawerOpen ? 'block' : 'hidden'
-              } fixed inset-y-0 left-0 z-50 w-[min(92vw,24rem)] overflow-y-auto bg-white px-4 py-4 shadow-xl lg:sticky lg:inset-auto lg:top-24 lg:col-span-3 lg:block lg:max-h-[calc(100vh-7rem)] lg:w-auto lg:self-start lg:overflow-y-auto lg:bg-transparent lg:p-0 lg:shadow-none`}
+              } fixed inset-y-0 left-0 z-50 w-[min(92vw,24rem)] overflow-y-auto bg-white px-4 py-4 shadow-xl lg:sticky lg:inset-auto lg:top-40 lg:z-10 lg:col-span-3 lg:block lg:w-auto lg:self-start lg:overflow-visible lg:bg-transparent lg:p-0 lg:shadow-none`}
             >
               <div className="mb-4 flex items-center justify-between lg:hidden">
                 <h2 className="text-base font-semibold text-gray-900">


### PR DESCRIPTION
## Summary

Fixes the responsive search facet sidebar behavior introduced with the offcanvas filter work.

On desktop-width layouts, the facet rail should behave as part of the page layout, not as a nested scrolling drawer. This PR keeps the mobile/offcanvas behavior intact while correcting the desktop breakpoint styles so the sidebar no longer scrolls independently or stacks over the sticky header/logo.

## Changes

- Keeps the filter sidebar scrollable only for the mobile offcanvas drawer.
- Removes the desktop `max-height` / `overflow-y-auto` behavior that caused a separate facet scrollbar.
- Lowers the desktop facet rail z-index so it cannot overlay the sticky header branding.
- Adjusts the desktop sticky offset to sit below the taller search header area.
- Adds regression coverage for the responsive sidebar classes.

## Testing

- `npm test -- --run src/__tests__/pages/SearchPage.test.tsx`
- `./node_modules/.bin/eslint src/pages/SearchPage.tsx src/__tests__/pages/SearchPage.test.tsx`
- `git diff --check -- frontend/src/pages/SearchPage.tsx frontend/src/__tests__/pages/SearchPage.test.tsx`