### PR TITLE
Add licensed resource access UI

### DIFF
--- a/backend/app/api/v1/endpoint_modules/resources/get.py
+++ b/backend/app/api/v1/endpoint_modules/resources/get.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.sql import select
 
 from app.api.v1.utils import (
+    add_licensed_accesses_to_resource,
     add_similar_items_to_resource,
     create_jsonapi_response,
     process_resource,
@@ -72,6 +73,11 @@ async def get_resource(
                 jsonapi_resource = await add_similar_items_to_resource(
                     jsonapi_resource,
                     resource_dict,
+                    session,
+                )
+                jsonapi_resource = await add_licensed_accesses_to_resource(
+                    jsonapi_resource,
+                    id,
                     session,
                 )
 

--- a/backend/app/api/v1/endpoint_modules/search.py
+++ b/backend/app/api/v1/endpoint_modules/search.py
@@ -38,6 +38,10 @@ from app.services.distribution_repository import (
     fetch_distribution_context_map,
 )
 from app.services.download_service import fetch_bridge_asset_download_rows_map
+from app.services.licensed_access_repository import (
+    fetch_resource_licensed_accesses_map,
+    serialize_resource_licensed_accesses,
+)
 from app.services.relationship_service import RelationshipService
 from app.services.resource_representation_cache import (
     RESOURCE_SEARCH_RESULT_REPRESENTATION_PROFILE,
@@ -129,6 +133,17 @@ def _serialize_data_dictionaries_by_id(data_dictionaries_by_id: dict) -> dict[st
             continue
         payloads[str(resource_id)] = sanitize_for_json(
             serialize_resource_data_dictionaries(dictionaries)
+        )
+    return payloads
+
+
+def _serialize_licensed_accesses_by_id(licensed_accesses_by_id: dict) -> dict[str, list[dict]]:
+    payloads: dict[str, list[dict]] = {}
+    for resource_id, accesses in licensed_accesses_by_id.items():
+        if not accesses:
+            continue
+        payloads[str(resource_id)] = sanitize_for_json(
+            serialize_resource_licensed_accesses(accesses)
         )
     return payloads
 
@@ -541,6 +556,13 @@ async def _handle_search(request: Request, params: dict) -> JSONResponse:
                 data_dictionary_payloads_by_id = _serialize_data_dictionaries_by_id(
                     data_dictionaries_by_id
                 )
+                licensed_accesses_by_id = await fetch_resource_licensed_accesses_map(
+                    missing_resource_ids,
+                    session=processing_session,
+                )
+                licensed_access_payloads_by_id = _serialize_licensed_accesses_by_id(
+                    licensed_accesses_by_id
+                )
                 relationship_summaries_by_id = (
                     await RelationshipService.get_resource_relationship_summaries_map(
                         missing_resource_ids,
@@ -572,6 +594,7 @@ async def _handle_search(request: Request, params: dict) -> JSONResponse:
                         ui_relationship_browse_links=relationship_summary.get("browse_links"),
                         allmaps_attributes=allmaps_attributes_by_id.get(resource_id),
                         data_dictionaries_payload=data_dictionary_payloads_by_id.get(resource_id),
+                        licensed_accesses_payload=licensed_access_payloads_by_id.get(resource_id),
                         thumbnail_asset_url=thumbnail_asset_urls_by_id.get(resource_id),
                     )
                 miss_build_ms = (time.perf_counter() - miss_build_started_at) * 1000

--- a/backend/app/api/v1/utils.py
+++ b/backend/app/api/v1/utils.py
@@ -19,6 +19,10 @@ from app.services.distribution_repository import (
     build_distribution_context,
     fetch_distribution_context,
 )
+from app.services.licensed_access_repository import (
+    fetch_resource_licensed_accesses,
+    serialize_resource_licensed_accesses,
+)
 from app.services.ogm_field_mapper import OGMFieldMapper
 from db.database import database
 from db.models import resource_assets
@@ -397,6 +401,7 @@ def create_jsonapi_resource(resource_data, request_url=None):
         "ui_citation",
         "ui_citations",
         "ui_downloads",
+        "ui_licensed_accesses",
         "ui_links",
         "ui_viewer_protocol",
         "ui_viewer_endpoint",
@@ -468,6 +473,8 @@ def create_jsonapi_resource(resource_data, request_url=None):
         restructured_ui["citations"] = ui_fields["ui_citations"]
     if "ui_downloads" in ui_fields:
         restructured_ui["downloads"] = ui_fields["ui_downloads"]
+    if "ui_licensed_accesses" in ui_fields:
+        restructured_ui["licensed_accesses"] = ui_fields["ui_licensed_accesses"]
     if "ui_links" in ui_fields:
         restructured_ui["links"] = ui_fields["ui_links"]
     if "ui_relationships" in ui_fields:
@@ -728,6 +735,7 @@ async def process_resource(
     distribution_context: DistributionContext | None = None,
     ui_downloads: list[dict[str, Any]] | None = None,
     bridge_asset_download_rows: Any = None,
+    licensed_accesses_payload: list[dict[str, Any]] | None | object = _UNSET,
     ui_relationships: dict[str, Any] | None = None,
     ui_relationship_counts: dict[str, int] | None = None,
     ui_relationship_browse_links: dict[str, str] | None = None,
@@ -838,6 +846,23 @@ async def process_resource(
     elif data_dictionaries_payload:
         attributes["data_dictionaries"] = sanitize_for_json(data_dictionaries_payload)
 
+    if licensed_accesses_payload is _UNSET:
+        try:
+            licensed_accesses = await fetch_resource_licensed_accesses(
+                resource_dict["id"], session=session
+            )
+            licensed_accesses_payload = serialize_resource_licensed_accesses(licensed_accesses)
+        except Exception as e:
+            logger.warning(
+                "Failed to load licensed accesses for resource %s: %s",
+                resource_dict.get("id"),
+                str(e),
+            )
+            licensed_accesses_payload = None
+
+    if licensed_accesses_payload:
+        attributes["ui_licensed_accesses"] = sanitize_for_json(licensed_accesses_payload)
+
     # Regenerate dct_references_s from resource_distributions for OGM Aardvark compatibility
     try:
         legacy_refs = distribution_context.legacy_reference_payload
@@ -902,6 +927,29 @@ async def process_resource(
 
     if include_similar_items:
         resource = await add_similar_items_to_resource(resource, resource_dict, session)
+
+    return resource
+
+
+async def add_licensed_accesses_to_resource(
+    resource: dict[str, Any],
+    resource_id: str,
+    session,
+) -> dict[str, Any]:
+    """Attach current licensed access rows to a JSON:API resource."""
+    try:
+        licensed_accesses = await fetch_resource_licensed_accesses(resource_id, session=session)
+        payload = sanitize_for_json(serialize_resource_licensed_accesses(licensed_accesses))
+    except Exception as e:
+        logger.warning("Failed to load licensed accesses for resource %s: %s", resource_id, str(e))
+        return resource
+
+    resource.setdefault("meta", {})
+    resource["meta"].setdefault("ui", {})
+    if payload:
+        resource["meta"]["ui"]["licensed_accesses"] = payload
+    else:
+        resource["meta"]["ui"].pop("licensed_accesses", None)
 
     return resource
 

--- a/backend/app/services/licensed_access_repository.py
+++ b/backend/app/services/licensed_access_repository.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import resource_licensed_accesses
+
+INSTITUTION_CODE_LABELS: dict[str, str] = {
+    "01": "Indiana University",
+    "02": "University of Illinois Urbana-Champaign",
+    "03": "University of Iowa",
+    "04": "University of Maryland",
+    "05": "University of Minnesota",
+    "06": "Michigan State University",
+    "07": "University of Michigan",
+    "08": "Purdue University",
+    "09": "Pennsylvania State University",
+    "10": "University of Wisconsin-Madison",
+    "11": "The Ohio State University",
+    "12": "University of Chicago",
+    "13": "University of Nebraska-Lincoln",
+    "14": "Rutgers University-New Brunswick",
+    "IU": "Indiana University",
+    "INDIANA": "Indiana University",
+    "UIUC": "University of Illinois Urbana-Champaign",
+    "ILLINOIS": "University of Illinois Urbana-Champaign",
+    "IOWA": "University of Iowa",
+    "UMD": "University of Maryland",
+    "MARYLAND": "University of Maryland",
+    "UMN": "University of Minnesota",
+    "MINN": "University of Minnesota",
+    "MSU": "Michigan State University",
+    "MICHIGAN_STATE": "Michigan State University",
+    "UMICH": "University of Michigan",
+    "MICH": "University of Michigan",
+    "PURDUE": "Purdue University",
+    "PU": "Purdue University",
+    "PSU": "Pennsylvania State University",
+    "PENN_STATE": "Pennsylvania State University",
+    "WISC": "University of Wisconsin-Madison",
+    "WISCONSIN": "University of Wisconsin-Madison",
+    "OSU": "The Ohio State University",
+    "OHIO_STATE": "The Ohio State University",
+    "UCHICAGO": "University of Chicago",
+    "CHICAGO": "University of Chicago",
+    "UNL": "University of Nebraska-Lincoln",
+    "NEBRASKA": "University of Nebraska-Lincoln",
+    "RUTGERS": "Rutgers University",
+    "RUTGERS_NEW_BRUNSWICK": "Rutgers University-New Brunswick",
+    "RU": "Rutgers University",
+    "NU": "Northwestern University",
+    "NORTHWESTERN": "Northwestern University",
+    "UO": "University of Oregon",
+    "OREGON": "University of Oregon",
+    "UWASH": "University of Washington",
+    "WASHINGTON": "University of Washington",
+}
+
+
+@dataclass(frozen=True)
+class ResourceLicensedAccessRecord:
+    id: int
+    resource_id: str
+    institution_code: str
+    access_url: str
+    legacy_friendlier_id: Optional[str]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+
+
+def institution_name_for_code(institution_code: str | None) -> str | None:
+    if not institution_code:
+        return None
+
+    normalized = str(institution_code).strip()
+    if not normalized:
+        return None
+
+    upper = normalized.upper().replace("-", "_").replace(" ", "_")
+    return INSTITUTION_CODE_LABELS.get(normalized) or INSTITUTION_CODE_LABELS.get(upper)
+
+
+async def fetch_resource_licensed_accesses(
+    resource_id: str, *, session: AsyncSession
+) -> List[ResourceLicensedAccessRecord]:
+    accesses_map = await fetch_resource_licensed_accesses_map([resource_id], session=session)
+    return accesses_map.get(resource_id, [])
+
+
+async def fetch_resource_licensed_accesses_map(
+    resource_ids: Iterable[str], *, session: AsyncSession
+) -> Dict[str, List[ResourceLicensedAccessRecord]]:
+    ids = list(dict.fromkeys(str(resource_id) for resource_id in resource_ids if resource_id))
+    if not ids:
+        return {}
+
+    stmt = (
+        select(resource_licensed_accesses)
+        .where(resource_licensed_accesses.c.resource_id.in_(ids))
+        .order_by(
+            resource_licensed_accesses.c.resource_id,
+            resource_licensed_accesses.c.institution_code,
+            resource_licensed_accesses.c.id,
+        )
+    )
+    result = await session.execute(stmt)
+
+    accesses_by_resource_id: Dict[str, List[ResourceLicensedAccessRecord]] = {}
+    for row in result.fetchall():
+        mapping = row._mapping
+        access_url = mapping["access_url"]
+        institution_code = mapping["institution_code"]
+        if not access_url or not institution_code:
+            continue
+
+        record = ResourceLicensedAccessRecord(
+            id=mapping["id"],
+            resource_id=mapping["resource_id"],
+            institution_code=institution_code,
+            access_url=access_url,
+            legacy_friendlier_id=mapping["legacy_friendlier_id"],
+            created_at=mapping["created_at"],
+            updated_at=mapping["updated_at"],
+        )
+        accesses_by_resource_id.setdefault(record.resource_id, []).append(record)
+
+    return accesses_by_resource_id
+
+
+def serialize_resource_licensed_accesses(
+    accesses: List[ResourceLicensedAccessRecord],
+) -> List[dict]:
+    return [
+        {
+            "institution_code": access.institution_code,
+            "institution_name": institution_name_for_code(access.institution_code),
+            "access_url": access.access_url,
+            "legacy_friendlier_id": access.legacy_friendlier_id,
+        }
+        for access in accesses
+    ]

--- a/backend/tests/api/v1/test_resource_endpoints.py
+++ b/backend/tests/api/v1/test_resource_endpoints.py
@@ -648,10 +648,14 @@ class TestResourceEndpointsEnhanced:
     @patch("app.api.v1.utils.add_thumbnail_url")
     @patch("app.api.v1.utils.serialize_resource_data_dictionaries")
     @patch("app.api.v1.utils.fetch_resource_data_dictionaries", new_callable=AsyncMock)
+    @patch("app.api.v1.utils.serialize_resource_licensed_accesses")
+    @patch("app.api.v1.utils.fetch_resource_licensed_accesses", new_callable=AsyncMock)
     @patch("app.api.v1.endpoint_modules.resources.async_session")
     def test_get_resource_includes_json_safe_data_dictionaries(
         self,
         mock_session,
+        mock_fetch_resource_licensed_accesses,
+        mock_serialize_resource_licensed_accesses,
         mock_fetch_resource_data_dictionaries,
         mock_serialize_resource_data_dictionaries,
         mock_add_thumbnail_url,
@@ -718,17 +722,29 @@ class TestResourceEndpointsEnhanced:
                 ],
             }
         ]
+        mock_fetch_resource_licensed_accesses.return_value = [object()]
+        mock_serialize_resource_licensed_accesses.return_value = [
+            {
+                "institution_code": "01",
+                "institution_name": "Indiana University",
+                "access_url": "https://example.com/iu",
+                "legacy_friendlier_id": "test-resource-dictionaries",
+            }
+        ]
 
         response = client.get("/api/v1/resources/test-resource-dictionaries?cachebust=1")
         assert response.status_code == 200
 
         payload = response.json()
         dictionaries = payload["data"]["attributes"]["b1g"]["data_dictionaries"]
+        licensed_accesses = payload["data"]["meta"]["ui"]["licensed_accesses"]
         assert len(dictionaries) == 1
         assert dictionaries[0]["name"] == "Attributes"
         assert dictionaries[0]["created_at"] == "2026-01-01T00:00:00"
         assert dictionaries[0]["entries"][0]["resource_data_dictionary_id"] == 1
         assert dictionaries[0]["entries"][0]["created_at"] == "2026-01-03T00:00:00"
+        assert licensed_accesses[0]["institution_name"] == "Indiana University"
+        assert licensed_accesses[0]["access_url"] == "https://example.com/iu"
 
     @patch("app.api.v1.endpoint_modules.resources.async_session")
     def test_get_resource_not_found(self, mock_session):

--- a/backend/tests/api/v1/test_search_endpoints.py
+++ b/backend/tests/api/v1/test_search_endpoints.py
@@ -176,6 +176,7 @@ async def test_handle_search_builds_and_stores_missing_resource_representation()
     relationship_browse_links = {"same_as": "/search?include_filters[same_as_agg][]=test-doc"}
     allmaps_payload = {"allmaps_id": "abc123"}
     data_dictionary_payload = [{"id": 1, "name": "Fields"}]
+    licensed_access_payload = [{"institution_code": "01", "access_url": "https://example.com/iu"}]
     bridge_download_rows = [{"label": "Download", "file_url": "https://example.com/file.zip"}]
     thumbnail_asset_url = "https://example.com/thumb.jpg"
 
@@ -222,6 +223,14 @@ async def test_handle_search_builds_and_stores_missing_resource_representation()
         patch(
             "app.api.v1.endpoint_modules.search._serialize_data_dictionaries_by_id",
             return_value={"test-doc": data_dictionary_payload},
+        ),
+        patch(
+            "app.api.v1.endpoint_modules.search.fetch_resource_licensed_accesses_map",
+            new=AsyncMock(return_value={"test-doc": ["ignored"]}),
+        ),
+        patch(
+            "app.api.v1.endpoint_modules.search._serialize_licensed_accesses_by_id",
+            return_value={"test-doc": licensed_access_payload},
         ),
         patch(
             "app.api.v1.endpoint_modules.search.RelationshipService.get_resource_relationship_summaries_map",
@@ -285,6 +294,10 @@ async def test_handle_search_builds_and_stores_missing_resource_representation()
     assert (
         mock_process_resource.await_args.kwargs["data_dictionaries_payload"]
         == data_dictionary_payload
+    )
+    assert (
+        mock_process_resource.await_args.kwargs["licensed_accesses_payload"]
+        == licensed_access_payload
     )
     assert mock_process_resource.await_args.kwargs["thumbnail_asset_url"] == thumbnail_asset_url
     mock_store_resource_representations.assert_awaited_once_with(
@@ -508,6 +521,10 @@ async def test_handle_search_falls_back_to_database_when_search_hit_lacks_attrib
         ),
         patch(
             "app.api.v1.endpoint_modules.search.fetch_resource_data_dictionaries_map",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "app.api.v1.endpoint_modules.search.fetch_resource_licensed_accesses_map",
             new=AsyncMock(return_value={}),
         ),
         patch(

--- a/backend/tests/api/v1/test_utils.py
+++ b/backend/tests/api/v1/test_utils.py
@@ -636,6 +636,32 @@ class TestCreateJsonapiResource:
         assert result["type"] == "resource"
         assert "ogm" in result["attributes"]
 
+    def test_create_jsonapi_resource_with_licensed_accesses(self):
+        """Test that licensed accesses are exposed in meta.ui."""
+        resource_data = {
+            "id": "999-0001",
+            "dct_title_s": "Social Explorer",
+            "ui_licensed_accesses": [
+                {
+                    "institution_code": "01",
+                    "institution_name": "Indiana University",
+                    "access_url": "https://example.com/iu",
+                    "legacy_friendlier_id": "999-0001",
+                }
+            ],
+        }
+        result = create_jsonapi_resource(resource_data)
+
+        assert result["meta"]["ui"]["licensed_accesses"] == [
+            {
+                "institution_code": "01",
+                "institution_name": "Indiana University",
+                "access_url": "https://example.com/iu",
+                "legacy_friendlier_id": "999-0001",
+            }
+        ]
+        assert "ui_licensed_accesses" not in result["attributes"].get("b1g", {})
+
     def test_create_jsonapi_resource_ogm_and_b1g_separation(self):
         """Test that OGM Aardvark fields are separated from B1G fields."""
         resource_data = {

--- a/backend/tests/services/test_licensed_access_repository.py
+++ b/backend/tests/services/test_licensed_access_repository.py
@@ -1,0 +1,41 @@
+from app.services.licensed_access_repository import (
+    ResourceLicensedAccessRecord,
+    institution_name_for_code,
+    serialize_resource_licensed_accesses,
+)
+
+
+def test_institution_name_for_legacy_numeric_code():
+    assert institution_name_for_code("01") == "Indiana University"
+    assert institution_name_for_code("11") == "The Ohio State University"
+    assert institution_name_for_code("14") == "Rutgers University-New Brunswick"
+
+
+def test_institution_name_for_short_code():
+    assert institution_name_for_code("MSU") == "Michigan State University"
+    assert institution_name_for_code("rutgers") == "Rutgers University"
+
+
+def test_serialize_resource_licensed_accesses_includes_school_name():
+    payload = serialize_resource_licensed_accesses(
+        [
+            ResourceLicensedAccessRecord(
+                id=1,
+                resource_id="999-0001",
+                institution_code="01",
+                access_url="https://example.com/iu",
+                legacy_friendlier_id="999-0001",
+                created_at=None,
+                updated_at=None,
+            )
+        ]
+    )
+
+    assert payload == [
+        {
+            "institution_code": "01",
+            "institution_name": "Indiana University",
+            "access_url": "https://example.com/iu",
+            "legacy_friendlier_id": "999-0001",
+        }
+    ]

--- a/frontend/src/__tests__/components/ResourceView.test.tsx
+++ b/frontend/src/__tests__/components/ResourceView.test.tsx
@@ -6,6 +6,7 @@ import { ResourceView } from '../../pages/ResourceView';
 import { ApiProvider } from '../../context/ApiContext';
 import { DebugProvider } from '../../context/DebugContext';
 import { vi } from 'vitest';
+import type { Mock } from 'vitest';
 import type { GeoDocument } from '../../types/api';
 
 vi.mock('../../services/analytics', () => ({
@@ -298,6 +299,23 @@ const mockResourceWithDataDictionary: GeoDocument = {
   },
 };
 
+const mockResourceWithLicensedAccesses: GeoDocument = {
+  ...mockResourceData,
+  meta: {
+    ui: {
+      ...mockResourceData.meta?.ui,
+      licensed_accesses: [
+        {
+          institution_code: '01',
+          institution_name: 'Indiana University',
+          access_url: 'https://example.com/iu-access',
+          legacy_friendlier_id: '999-0001',
+        },
+      ],
+    },
+  },
+};
+
 const mockSearchState = {
   searchResults: realFixtureData.map((fixture) => ({ id: fixture.id })),
   currentIndex: 0,
@@ -327,8 +345,8 @@ const TestWrapper = ({
 );
 
 describe('ResourceView Component', () => {
-  let fetchResourceDetails: any;
-  let fetchSearchResults: any;
+  let fetchResourceDetails: Mock;
+  let fetchSearchResults: Mock;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -949,6 +967,29 @@ describe('ResourceView Component', () => {
 
       // DownloadsTable should be rendered
       expect(screen.getByText('PDF Download')).toBeInTheDocument();
+    });
+
+    it('renders LicensedAccessesTable when licensed accesses are available', async () => {
+      fetchResourceDetails.mockResolvedValue(mockResourceWithLicensedAccesses);
+
+      render(
+        <TestWrapper>
+          <ResourceView />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', {
+            name: 'Nondigitized paper map with library catalog link',
+          })
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Licensed Resource')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /Indiana University/i })
+      ).toHaveAttribute('href', 'https://example.com/iu-access');
     });
 
     it('renders LinksTable when links are available', async () => {

--- a/frontend/src/__tests__/components/resource/LicensedAccessesTable.test.tsx
+++ b/frontend/src/__tests__/components/resource/LicensedAccessesTable.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import {
+  LicensedAccessesTable,
+  type LicensedAccessItem,
+} from '../../../components/resource/LicensedAccessesTable';
+import { scheduleAnalyticsBatch } from '../../../services/analytics';
+
+vi.mock('../../../services/analytics', () => ({
+  scheduleAnalyticsBatch: vi.fn(),
+}));
+
+describe('LicensedAccessesTable', () => {
+  const licensedAccesses: LicensedAccessItem[] = [
+    {
+      institution_code: '01',
+      institution_name: 'Indiana University',
+      access_url: 'https://example.com/iu',
+      legacy_friendlier_id: '999-0001',
+    },
+    {
+      institution_code: 'MSU',
+      institution_name: 'Michigan State University',
+      access_url: 'https://example.com/msu',
+      legacy_friendlier_id: '999-0001',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders licensed institution links', () => {
+    render(<LicensedAccessesTable licensedAccesses={licensedAccesses} />);
+
+    expect(screen.getByText('Licensed Resource')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Indiana University/i })
+    ).toHaveAttribute('href', 'https://example.com/iu');
+    expect(
+      screen.getByRole('link', { name: /Michigan State University/i })
+    ).toHaveAttribute('href', 'https://example.com/msu');
+  });
+
+  it('tracks licensed access clicks', () => {
+    render(
+      <LicensedAccessesTable
+        licensedAccesses={licensedAccesses}
+        resourceId="999-0001"
+        searchId="search-123"
+      />
+    );
+
+    const accessLink = screen.getByRole('link', {
+      name: /Indiana University/i,
+    });
+    accessLink.addEventListener('click', (event) => event.preventDefault());
+    fireEvent.click(accessLink);
+
+    expect(scheduleAnalyticsBatch).toHaveBeenCalledWith({
+      events: [
+        expect.objectContaining({
+          event_type: 'licensed_access_click',
+          search_id: 'search-123',
+          resource_id: '999-0001',
+          label: 'Indiana University',
+          destination_url: 'https://example.com/iu',
+          source_component: 'LicensedAccessesTable',
+        }),
+      ],
+    });
+  });
+
+  it('does not render without licensed accesses', () => {
+    const { container } = render(
+      <LicensedAccessesTable licensedAccesses={[]} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/resource/LicensedAccessesTable.tsx
+++ b/frontend/src/components/resource/LicensedAccessesTable.tsx
@@ -1,0 +1,107 @@
+import { ExternalLink, LockKeyhole, University } from 'lucide-react';
+import { scheduleAnalyticsBatch } from '../../services/analytics';
+import { getProviderIconSlug } from '../../utils/providerIcons';
+
+export interface LicensedAccessItem {
+  institution_code: string;
+  institution_name?: string | null;
+  access_url: string;
+  legacy_friendlier_id?: string | null;
+}
+
+interface LicensedAccessesTableProps {
+  licensedAccesses: LicensedAccessItem[];
+  resourceId?: string;
+  searchId?: string;
+}
+
+function InstitutionIcon({ name }: { name: string }) {
+  const iconSlug = getProviderIconSlug(name);
+
+  if (iconSlug) {
+    return (
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center border border-gray-200 bg-white">
+        <img
+          src={`/icons/${iconSlug}.svg`}
+          alt=""
+          aria-hidden="true"
+          className="h-5 w-5 object-contain"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center border border-gray-200 bg-gray-50 text-gray-500">
+      <University className="h-4 w-4" aria-hidden="true" />
+    </span>
+  );
+}
+
+export function LicensedAccessesTable({
+  licensedAccesses,
+  resourceId,
+  searchId,
+}: LicensedAccessesTableProps) {
+  if (!licensedAccesses || licensedAccesses.length === 0) return null;
+
+  const trackAccessClick = (access: LicensedAccessItem, label: string) => {
+    scheduleAnalyticsBatch({
+      events: [
+        {
+          event_type: 'licensed_access_click',
+          search_id: searchId,
+          resource_id: resourceId,
+          label,
+          destination_url: access.access_url,
+          source_component: 'LicensedAccessesTable',
+          properties: {
+            institution_code: access.institution_code,
+            legacy_friendlier_id: access.legacy_friendlier_id,
+          },
+        },
+      ],
+    });
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden">
+      <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
+        <div className="flex items-center gap-2">
+          <LockKeyhole className="h-5 w-5 text-gray-500" aria-hidden="true" />
+          <h2 className="text-lg font-semibold text-gray-900">
+            Licensed Resource
+          </h2>
+        </div>
+      </div>
+      <div className="divide-y divide-gray-200">
+        {licensedAccesses.map((access, index) => {
+          const label =
+            access.institution_name?.trim() ||
+            access.institution_code?.trim() ||
+            'Institutional access';
+
+          return (
+            <a
+              key={`${access.institution_code}-${access.access_url}-${index}`}
+              href={access.access_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackAccessClick(access, label)}
+              className="flex items-center gap-3 px-6 py-4 hover:bg-gray-50 group"
+            >
+              <InstitutionIcon name={label} />
+              <span className="min-w-0 flex-1 text-sm font-medium text-gray-900 break-words group-hover:text-blue-600">
+                {label}
+              </span>
+              <ExternalLink
+                className="h-4 w-4 shrink-0 text-gray-400 group-hover:text-blue-500"
+                aria-hidden="true"
+              />
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ResourceView.tsx
+++ b/frontend/src/pages/ResourceView.tsx
@@ -21,6 +21,7 @@ import { CitationTable } from '../components/resource/CitationTable';
 import { FullDetailsTable } from '../components/resource/FullDetailsTable';
 import { LocationMap } from '../components/resource/LocationMap';
 import { DownloadsTable } from '../components/resource/DownloadsTable';
+import { LicensedAccessesTable } from '../components/resource/LicensedAccessesTable';
 import { LinksTable } from '../components/resource/LinksTable';
 import { SimilarItemsCarousel } from '../components/resource/SimilarItemsCarousel';
 import { EnvironmentNavButtons } from '../components/resource/EnvironmentNavButtons';
@@ -66,6 +67,12 @@ interface ResourceData extends GeoDocument {
         generated?: boolean;
         generation_path?: string;
         download_type?: string;
+      }>;
+      licensed_accesses?: Array<{
+        institution_code: string;
+        institution_name?: string | null;
+        access_url: string;
+        legacy_friendlier_id?: string | null;
       }>;
       citation?: string;
       thumbnail_url?: string;
@@ -648,6 +655,16 @@ export function ResourceView({
                       data.meta.ui.downloads.length > 0 && (
                         <DownloadsTable
                           downloads={data.meta.ui.downloads}
+                          resourceId={data.id}
+                          searchId={searchState?.searchId}
+                        />
+                      )}
+
+                    {/* Licensed access section */}
+                    {data?.meta?.ui?.licensed_accesses &&
+                      data.meta.ui.licensed_accesses.length > 0 && (
+                        <LicensedAccessesTable
+                          licensedAccesses={data.meta.ui.licensed_accesses}
                           resourceId={data.id}
                           searchId={searchState?.searchId}
                         />

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -99,6 +99,12 @@ export interface GeoDocument {
         generation_path?: string;
         download_type?: string;
       }>;
+      licensed_accesses?: Array<{
+        institution_code: string;
+        institution_name?: string | null;
+        access_url: string;
+        legacy_friendlier_id?: string | null;
+      }>;
       links?: Record<
         string,
         Array<{

--- a/frontend/src/utils/providerIcons.ts
+++ b/frontend/src/utils/providerIcons.ts
@@ -61,6 +61,8 @@ const PROVIDER_OVERRIDES: Record<string, string | null> = {
   'university of california, berkeley': 'uc_berkeley',
   'university of illinois at urbana champaign':
     'university_of_illinois_urbana_champaign',
+  'rutgers university-new brunswick': 'rutgers_university',
+  'rutgers university new brunswick': 'rutgers_university',
   'uw madison': 'university_of_wisconsin_madison',
   'university of wisconsin madison': 'university_of_wisconsin_madison',
   'university of nebraska lincoln': 'university_of_nebraska_lincoln',


### PR DESCRIPTION
## Summary

Adds licensed resource access support end to end for records with rows in `resource_licensed_accesses`.

- Exposes licensed access links in the resource API under `data.meta.ui.licensed_accesses`
- Adds institution-code label mapping for legacy numeric codes and common short codes
- Prefetches licensed access rows for search-result resource representations
- Adds a new resource sidebar card, “Licensed Resource,” showing institution-specific access links
- Tracks licensed access clicks through analytics
- Adds backend and frontend test coverage

## Verification

- `python -m pytest backend/tests/services/test_licensed_access_repository.py backend/tests/api/v1/test_utils.py::TestCreateJsonapiResource::test_create_jsonapi_resource_with_licensed_accesses backend/tests/api/v1/test_resource_endpoints.py::TestResourceEndpointsEnhanced::test_get_resource_includes_json_safe_data_dictionaries backend/tests/api/v1/test_search_endpoints.py::test_handle_search_builds_and_stores_missing_resource_representation backend/tests/api/v1/test_search_endpoints.py::test_handle_search_falls_back_to_database_when_search_hit_lacks_attributes`
- `cd frontend && npm test -- --run src/__tests__/components/resource/LicensedAccessesTable.test.tsx src/__tests__/components/ResourceView.test.tsx`
- Targeted Ruff and ESLint checks passed
- Local API check confirmed `999-0001` returns 12 `meta.ui.licensed_accesses` rows

Fixes #181 