### PR TITLE
feat: Implement PostgreSQL and Elasticsearch backup scripts with S3 i…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,30 @@ ELASTICSEARCH_URL=http://localhost:9200
 ELASTICSEARCH_INDEX=btaa_geospatial_api
 
 # =============================================================================
+# Production disaster recovery backups (Kamal prd)
+# =============================================================================
+
+# Shared guard. Keep false locally/dev; prd deploy config defaults this true.
+BACKUP_ENABLED=false
+BACKUP_REQUIRED_DEST=prd
+BACKUP_RETENTION_COUNT=3
+BACKUP_S3_BUCKET=
+BACKUP_S3_PREFIX=btaa-geospatial-api
+BACKUP_S3_REGION=us-east-2
+AWS_REGION=us-east-2
+AWS_DEFAULT_REGION=us-east-2
+AWS_ACCESS_KEY_ID="<secret>"
+AWS_SECRET_ACCESS_KEY="<secret>"
+
+# Elasticsearch snapshots can use fs locally or s3 in prd.
+ELASTICSEARCH_SNAPSHOT_REPOSITORY=btaa_geoportal_snapshots
+ELASTICSEARCH_SNAPSHOT_REPOSITORY_TYPE=fs
+ELASTICSEARCH_SNAPSHOT_S3_BASE_PATH=btaa-geospatial-api/prd/elasticsearch
+# Optional, e.g. standard_ia. Leave empty for the Elasticsearch default.
+ELASTICSEARCH_SNAPSHOT_S3_STORAGE_CLASS=
+ELASTICSEARCH_SNAPSHOT_S3_SERVER_SIDE_ENCRYPTION=true
+
+# =============================================================================
 # Redis (shared: endpoint caching + other features)
 # =============================================================================
 

--- a/Dockerfile.kamal
+++ b/Dockerfile.kamal
@@ -79,17 +79,31 @@ WORKDIR /app
 
 # Runtime deps only. Build tooling lives in python_deps/frontend_* stages so it
 # does not inflate the deploy image that must be pushed to GHCR and pulled by dev1.
+# Add PGDG so the backup cron container has a pg_dump client compatible with
+# the ParadeDB/PostgreSQL 17 runtime image.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    bash \
+    && install -d -m 0755 /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg \
+    && . /etc/os-release \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+      > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 \
+    awscli \
     cron \
     tzdata \
     libcairo2 \
     gdal-bin \
     nginx \
     msmtp-mta \
-    curl \
     ca-certificates \
     git \
+    postgresql-client-17 \
     bash \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help lint lint-check format test lint-test test-coverage-compare wait-local-db clear-thumbnail-cache thumbnail-completeness-report prime-thumbnail-cache prime-static-map-cache prime-resource-cache prime-visual-caches visual-assets-export visual-assets-import visual-assets-stream-import visual-assets-sync-all db-export db-import db-sync gbl-admin-db-download gbl-admin-db-unzip gbl-admin-db-restore gbl-admin-db-sync gbl-admin-db-add-latest-btaa-fields gbl-admin-db-import-resources populate-distributions backfill-distributions populate-data-dictionaries gbl-admin-db-import-all reindex reindex-benchmark local-clear-search-cache sitemap-generate analytics-maintenance analytics-size-report es-unblock populate-relationships verify-h3-index kamal-reindex kamal-verify-h3-index kamal-clear-cache kamal-prime-thumbnail-cache kamal-prime-static-map-cache kamal-prime-visual-caches kamal-prime-resource-cache kamal-thumbnail-completeness-report kamal-api-response-cache-init kamal-api-response-cache-prune refresh-resource-caches kamal-refresh-resource-caches clear_cache frontend-reset ogm-refresh ogm-refresh-all ogm-refresh-repo ogm-status ogm-status-watch ogm-failures resource-aux-init resource-cache-init api-response-cache-init api-response-cache-prune bridge-init bridge-sync bridge-sync-batched bridge-cancel bridge-status bridge-status-watch bridge-failures blog-sync
-.PHONY: kamal-blog-sync kamal-purge-home-blog-cache kamal-bridge-sync-batched kamal-bridge-status kamal-bridge-status-watch kamal-cron-debug kamal-cron-test-bridge kamal-worker-logs kamal-network-sanity docs-serve docs-build k6-run k6-smoke k6-stress k6-endpoint-capacity cli-test cli-lint cli-format cli-build cli-man
+.PHONY: kamal-blog-sync kamal-purge-home-blog-cache kamal-bridge-sync-batched kamal-bridge-status kamal-bridge-status-watch kamal-backup-postgres kamal-backup-elasticsearch kamal-backup-list-elasticsearch kamal-cron-debug kamal-cron-test-bridge kamal-worker-logs kamal-network-sanity docs-serve docs-build k6-run k6-smoke k6-stress k6-endpoint-capacity cli-test cli-lint cli-format cli-build cli-man
 
 # Load environment variables from .env file if it exists
 -include .env
@@ -92,6 +92,7 @@ KAMAL_REINDEX_REMOVE_LEGACY_INDEX ?= true
 # If unset, the target falls back to APPLICATION_URL from Kamal env.
 KAMAL_API_URL ?=
 KAMAL_CACHE_TYPE ?= search
+KAMAL_BACKUP_RETAIN_COUNT ?= 3
 KAMAL_NETWORK_SELF_URL ?=
 KAMAL_NETWORK_EXTERNAL_URLS ?= https://api.github.com https://raw.githubusercontent.com https://gin.btaa.org http://example.com
 KAMAL_NETWORK_CONNECT_TIMEOUT ?= 5
@@ -1602,6 +1603,34 @@ kamal-blog-sync: ## Trigger home page blog sync on Kamal (RUN_NOW=1 for inline)
 	@echo
 	@echo "GIN blog sync request submitted (Kamal)."
 
+# Manually run the production-gated Postgres backup from the cron container.
+# Usage: make kamal-backup-postgres KAMAL_DEST=prd
+kamal-backup-postgres: ## Run production-gated Postgres S3 backup on Kamal
+	@echo "Running Postgres backup on Kamal cron container (KAMAL_DEST=$(KAMAL_DEST))..."
+	@if [ -z "$$KAMAL_SSH_USER" ] || [ -z "$$KAMAL_HOST" ]; then \
+		echo "ERROR: KAMAL_SSH_USER and KAMAL_HOST must be set. $(KAMAL_DEST_HELP)"; \
+		exit 1; \
+	fi
+	@kamal app exec -d $(KAMAL_DEST) --roles cron --reuse "bash -lc '/opt/venv/bin/python3 /app/scripts/backup_postgres_to_s3.py'"
+
+# Manually run the production-gated Elasticsearch snapshot from the cron container.
+# Usage: make kamal-backup-elasticsearch KAMAL_DEST=prd [KAMAL_BACKUP_RETAIN_COUNT=3]
+kamal-backup-elasticsearch: ## Run production-gated Elasticsearch S3 snapshot on Kamal
+	@echo "Running Elasticsearch snapshot on Kamal cron container (KAMAL_DEST=$(KAMAL_DEST))..."
+	@if [ -z "$$KAMAL_SSH_USER" ] || [ -z "$$KAMAL_HOST" ]; then \
+		echo "ERROR: KAMAL_SSH_USER and KAMAL_HOST must be set. $(KAMAL_DEST_HELP)"; \
+		exit 1; \
+	fi
+	@kamal app exec -d $(KAMAL_DEST) --roles cron --reuse "bash -lc '/opt/venv/bin/python3 /app/scripts/backup_elasticsearch.py --scheduled --create --wait --retain-count $${BACKUP_RETENTION_COUNT:-$(KAMAL_BACKUP_RETAIN_COUNT)}'"
+
+kamal-backup-list-elasticsearch: ## List Elasticsearch snapshots on Kamal
+	@echo "Listing Elasticsearch snapshots on Kamal (KAMAL_DEST=$(KAMAL_DEST))..."
+	@if [ -z "$$KAMAL_SSH_USER" ] || [ -z "$$KAMAL_HOST" ]; then \
+		echo "ERROR: KAMAL_SSH_USER and KAMAL_HOST must be set. $(KAMAL_DEST_HELP)"; \
+		exit 1; \
+	fi
+	@kamal app exec -d $(KAMAL_DEST) --roles cron --reuse "bash -lc '/opt/venv/bin/python3 /app/scripts/backup_elasticsearch.py --list'"
+
 # Purge cached homepage blog response after a blog sync or other content change.
 kamal-purge-home-blog-cache: ## Purge home_blog/home endpoint cache on Kamal
 	@echo "Purging homepage blog cache on Kamal via $(KAMAL_API_URL)..."
@@ -1645,7 +1674,7 @@ kamal-cron-debug: ## Debug cron container: crontab, timezone, env
 	@kamal app exec -d $(KAMAL_DEST) --roles cron --reuse "bash -lc 'echo APPLICATION_URL=\$$APPLICATION_URL; echo REDIS_HOST=\$$REDIS_HOST; if [ -n \"\$$DATABASE_URL\" ]; then echo DATABASE_URL_SET=yes; else echo DATABASE_URL_SET=no; fi; echo PYTHONPATH=\$$PYTHONPATH; echo TZ=\$$TZ'"
 	@echo ""
 	@echo "--- 4. Script + cron bootstrap ---"
-	@kamal app exec -d $(KAMAL_DEST) --roles cron --reuse "bash -lc 'ls -la /app/scripts/trigger_bridge_sync_cron.py /app/scripts/cron_env.sh 2>/dev/null; env -i SHELL=/bin/bash BASH_ENV=/app/scripts/cron_env.sh /bin/bash -lc \"echo REDIS_HOST=\\\$$REDIS_HOST; if [ -n \\\\\"\\\$$DATABASE_URL\\\\\" ]; then echo DATABASE_URL_SET=yes; else echo DATABASE_URL_SET=no; fi; echo PYTHONPATH=\\\$$PYTHONPATH; echo BRIDGE_SYNC_LOCAL_TIMEZONE=\\\$$BRIDGE_SYNC_LOCAL_TIMEZONE\"'"
+	@kamal app exec -d $(KAMAL_DEST) --roles cron --reuse "bash -lc 'ls -la /app/scripts/trigger_bridge_sync_cron.py /app/scripts/cron_env.sh /tmp/cron-container-env.sh 2>/dev/null; env -i SHELL=/bin/bash BASH_ENV=/app/scripts/cron_env.sh /bin/bash -lc \"echo REDIS_HOST=\\\$$REDIS_HOST; if [ -n \\\\\"\\\$$DATABASE_URL\\\\\" ]; then echo DATABASE_URL_SET=yes; else echo DATABASE_URL_SET=no; fi; echo PYTHONPATH=\\\$$PYTHONPATH; echo BRIDGE_SYNC_LOCAL_TIMEZONE=\\\$$BRIDGE_SYNC_LOCAL_TIMEZONE\"'"
 
 # Manually run bridge sync trigger from cron container (same as 2 AM job).
 # Usage: make kamal-cron-test-bridge [KAMAL_DEST=prd] [CHANGED_SINCE=2026-04-23T00:00:00Z]

--- a/backend/scripts/backup_elasticsearch.py
+++ b/backend/scripts/backup_elasticsearch.py
@@ -35,11 +35,13 @@ load_dotenv()
 ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL", "http://localhost:9200")
 INDEX_NAME = os.getenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
 
-# Snapshot repository configuration
-REPOSITORY_NAME = "backup_repository"
-# Default backup location (inside ES container)
-# For Kamal, this should be mapped to a persistent volume
-REPOSITORY_PATH = "/usr/share/elasticsearch/backups"
+# Snapshot repository configuration. The historical default is a filesystem
+# repository; production can switch to an S3 repository through environment.
+REPOSITORY_NAME = os.getenv("ELASTICSEARCH_SNAPSHOT_REPOSITORY", "backup_repository")
+REPOSITORY_TYPE = os.getenv("ELASTICSEARCH_SNAPSHOT_REPOSITORY_TYPE", "fs").strip().lower()
+REPOSITORY_PATH = os.getenv("ELASTICSEARCH_SNAPSHOT_PATH", "/usr/share/elasticsearch/backups")
+BACKUP_REQUIRED_DEST = os.getenv("BACKUP_REQUIRED_DEST", "prd").strip()
+BACKUP_S3_PREFIX = os.getenv("BACKUP_S3_PREFIX", "btaa-geospatial-api").strip("/")
 
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -83,6 +85,89 @@ def print_info(text: str):
     print(f"{Colors.BLUE}ℹ{Colors.RESET} {text}")
 
 
+def env_bool(name: str, default: bool = False) -> bool:
+    """Read a boolean-ish environment variable."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def repository_body() -> Optional[Dict[str, Any]]:
+    """Build the Elasticsearch snapshot repository body."""
+    if REPOSITORY_TYPE == "fs":
+        return {
+            "type": "fs",
+            "settings": {
+                "location": REPOSITORY_PATH,
+                "compress": True,
+            },
+        }
+
+    if REPOSITORY_TYPE != "s3":
+        print_error(
+            "Unsupported ELASTICSEARCH_SNAPSHOT_REPOSITORY_TYPE="
+            f"{REPOSITORY_TYPE!r}; expected 'fs' or 's3'"
+        )
+        return None
+
+    bucket = os.getenv("ELASTICSEARCH_SNAPSHOT_S3_BUCKET") or os.getenv("BACKUP_S3_BUCKET")
+    if not bucket:
+        print_error(
+            "BACKUP_S3_BUCKET or ELASTICSEARCH_SNAPSHOT_S3_BUCKET is required "
+            "for S3 Elasticsearch snapshots"
+        )
+        return None
+
+    base_path = (
+        os.getenv("ELASTICSEARCH_SNAPSHOT_S3_BASE_PATH")
+        or f"{BACKUP_S3_PREFIX}/{os.getenv('KAMAL_DEST', 'unknown')}/elasticsearch"
+    ).strip("/")
+
+    settings: Dict[str, Any] = {
+        "bucket": bucket,
+        "base_path": base_path,
+        "client": os.getenv("ELASTICSEARCH_SNAPSHOT_S3_CLIENT", "default"),
+        "compress": True,
+    }
+
+    storage_class = os.getenv("ELASTICSEARCH_SNAPSHOT_S3_STORAGE_CLASS")
+    if storage_class:
+        settings["storage_class"] = storage_class
+
+    if env_bool("ELASTICSEARCH_SNAPSHOT_S3_SERVER_SIDE_ENCRYPTION", default=False):
+        settings["server_side_encryption"] = True
+
+    return {
+        "type": "s3",
+        "settings": settings,
+    }
+
+
+def scheduled_skip_reason() -> Optional[str]:
+    """Return why a scheduled backup should skip, or None when it should run."""
+    if not env_bool("BACKUP_ENABLED", default=False):
+        return "BACKUP_ENABLED is not true"
+
+    destination = os.getenv("KAMAL_DEST", "").strip()
+    if BACKUP_REQUIRED_DEST and destination != BACKUP_REQUIRED_DEST:
+        return (
+            f"KAMAL_DEST={destination or '(unset)'} does not match "
+            f"BACKUP_REQUIRED_DEST={BACKUP_REQUIRED_DEST}"
+        )
+
+    return None
+
+
+def managed_snapshot(snapshot: Dict[str, Any]) -> bool:
+    """Limit retention cleanup to snapshots produced by this script/index."""
+    name = str(snapshot.get("snapshot", ""))
+    metadata = snapshot.get("metadata") or {}
+    if isinstance(metadata, dict) and metadata.get("index") == INDEX_NAME:
+        return True
+    return name.startswith(f"{INDEX_NAME}_snapshot_")
+
+
 async def ensure_repository(client: AsyncElasticsearch) -> bool:
     """Ensure snapshot repository exists, create if it doesn't."""
     try:
@@ -92,24 +177,37 @@ async def ensure_repository(client: AsyncElasticsearch) -> bool:
         return True
     except NotFoundError:
         # Repository doesn't exist, create it
-        print_info(f"Creating repository '{REPOSITORY_NAME}' at {REPOSITORY_PATH}")
+        body = repository_body()
+        if body is None:
+            return False
+
+        if REPOSITORY_TYPE == "fs":
+            print_info(f"Creating repository '{REPOSITORY_NAME}' at {REPOSITORY_PATH}")
+        else:
+            settings = body["settings"]
+            print_info(
+                f"Creating S3 repository '{REPOSITORY_NAME}' at "
+                f"s3://{settings['bucket']}/{settings.get('base_path', '')}"
+            )
         try:
             await client.snapshot.create_repository(
                 name=REPOSITORY_NAME,
-                body={
-                    "type": "fs",
-                    "settings": {
-                        "location": REPOSITORY_PATH,
-                        "compress": True,
-                    },
-                },
+                body=body,
             )
             print_success(f"Repository '{REPOSITORY_NAME}' created successfully")
             return True
         except RequestError as e:
             print_error(f"Failed to create repository: {str(e)}")
-            print_warning("Note: The backup directory must exist and be writable by Elasticsearch")
-            print_warning(f"Ensure {REPOSITORY_PATH} exists in the ES container or is mounted")
+            if REPOSITORY_TYPE == "fs":
+                print_warning(
+                    "Note: The backup directory must exist and be writable by Elasticsearch"
+                )
+                print_warning(f"Ensure {REPOSITORY_PATH} exists in the ES container or is mounted")
+            else:
+                print_warning(
+                    "For S3 repositories, ensure repository-s3 support is available and "
+                    "S3 credentials are configured for the Elasticsearch node"
+                )
             return False
     except Exception as e:
         print_error(f"Error checking repository: {str(e)}")
@@ -140,6 +238,8 @@ async def create_snapshot(
                     "taken_by": "backup_script",
                     "taken_because": "scheduled_backup",
                     "index": INDEX_NAME,
+                    "destination": os.getenv("KAMAL_DEST", "unknown"),
+                    "repository_type": REPOSITORY_TYPE,
                 },
             },
             wait_for_completion=False,  # Don't wait, return immediately
@@ -254,7 +354,9 @@ async def cleanup_old_snapshots(client: AsyncElasticsearch, keep_days: int = 7) 
     cutoff_date = datetime.now() - timedelta(days=keep_days)
     cutoff_timestamp = int(cutoff_date.timestamp() * 1000)
 
-    snapshots = await list_snapshots(client)
+    snapshots = [
+        snapshot for snapshot in await list_snapshots(client) if managed_snapshot(snapshot)
+    ]
     deleted_count = 0
 
     for snapshot in snapshots:
@@ -274,6 +376,29 @@ async def cleanup_old_snapshots(client: AsyncElasticsearch, keep_days: int = 7) 
                 f"Keeping snapshot: {snapshot_name} "
                 f"(from {snapshot_date.strftime('%Y-%m-%d %H:%M:%S')})"
             )
+
+    return deleted_count
+
+
+async def cleanup_snapshots_by_count(client: AsyncElasticsearch, retain_count: int) -> int:
+    """Keep only the newest N completed snapshots produced by this script."""
+    if retain_count < 1:
+        raise ValueError("retain_count must be at least 1")
+
+    print_info(f"Keeping newest {retain_count} managed snapshot(s)")
+    snapshots = [
+        snapshot
+        for snapshot in await list_snapshots(client)
+        if managed_snapshot(snapshot) and snapshot.get("state") != "IN_PROGRESS"
+    ]
+    snapshots.sort(key=lambda x: x.get("start_time_in_millis", 0), reverse=True)
+
+    deleted_count = 0
+    for snapshot in snapshots[retain_count:]:
+        snapshot_name = snapshot.get("snapshot", "unknown")
+        print_info(f"Deleting snapshot outside retain-count window: {snapshot_name}")
+        if await delete_snapshot(client, snapshot_name):
+            deleted_count += 1
 
     return deleted_count
 
@@ -314,7 +439,7 @@ def format_snapshot_info(snapshot: Dict[str, Any]) -> str:
     )
 
 
-async def main():
+async def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(description="Elasticsearch backup and restore utility")
     parser.add_argument("--create", action="store_true", help="Create a new snapshot")
@@ -328,19 +453,45 @@ async def main():
     parser.add_argument(
         "--keep-days", type=int, default=7, help="Days to keep snapshots (default: 7)"
     )
+    parser.add_argument(
+        "--retain-count",
+        type=int,
+        help="Keep only the newest N managed snapshots after create/cleanup",
+    )
+    parser.add_argument(
+        "--scheduled",
+        action="store_true",
+        help="Apply BACKUP_ENABLED and KAMAL_DEST production guard before running",
+    )
     parser.add_argument("--wait", action="store_true", help="Wait for snapshot/restore to complete")
 
     args = parser.parse_args()
 
     # If no action specified, show help
-    if not any([args.create, args.list, args.status, args.restore, args.delete, args.cleanup]):
+    if not any(
+        [
+            args.create,
+            args.list,
+            args.status,
+            args.restore,
+            args.delete,
+            args.cleanup,
+            args.retain_count,
+        ]
+    ):
         parser.print_help()
-        return
+        return 0
+
+    if args.scheduled:
+        skip_reason = scheduled_skip_reason()
+        if skip_reason:
+            print_info(f"Skipping Elasticsearch snapshot: {skip_reason}")
+            return 0
 
     print_header("Elasticsearch Backup Utility")
     print_info(f"Elasticsearch URL: {ELASTICSEARCH_URL}")
     print_info(f"Index: {INDEX_NAME}")
-    print_info(f"Repository: {REPOSITORY_NAME}\n")
+    print_info(f"Repository: {REPOSITORY_NAME} ({REPOSITORY_TYPE})\n")
 
     client = AsyncElasticsearch(
         hosts=[ELASTICSEARCH_URL],
@@ -358,11 +509,14 @@ async def main():
         # Ensure repository exists (needed for most operations)
         if not await ensure_repository(client):
             print_error("Cannot proceed without repository")
-            return
+            return 1
 
         # Handle different operations
         if args.create:
             snapshot_name = await create_snapshot(client, args.name)
+            snapshot_finished_successfully = snapshot_name is not None and not args.wait
+            if snapshot_name is None:
+                return 1
             if snapshot_name and args.wait:
                 print_info("Waiting for snapshot to complete...")
                 # Poll for completion
@@ -370,20 +524,30 @@ async def main():
 
                 while True:
                     status = await get_snapshot_status(client, snapshot_name)
-                    if status:
-                        state = status.get("state", "UNKNOWN")
-                        if state == "SUCCESS":
-                            print_success("Snapshot completed successfully")
-                            break
-                        elif state == "FAILED":
-                            print_error("Snapshot failed")
-                            break
-                        elif state in ["IN_PROGRESS", "INIT"]:
-                            print_info(f"Snapshot in progress... ({state})")
-                            time.sleep(5)
-                        else:
-                            print_info(f"Snapshot state: {state}")
-                            time.sleep(5)
+                    if not status:
+                        snapshot_finished_successfully = False
+                        break
+                    state = status.get("state", "UNKNOWN")
+                    if state == "SUCCESS":
+                        print_success("Snapshot completed successfully")
+                        snapshot_finished_successfully = True
+                        break
+                    elif state == "FAILED":
+                        print_error("Snapshot failed")
+                        snapshot_finished_successfully = False
+                        break
+                    elif state in ["IN_PROGRESS", "INIT"]:
+                        print_info(f"Snapshot in progress... ({state})")
+                        time.sleep(5)
+                    else:
+                        print_info(f"Snapshot state: {state}")
+                        time.sleep(5)
+
+            if args.retain_count and snapshot_finished_successfully:
+                deleted = await cleanup_snapshots_by_count(client, args.retain_count)
+                print_success(f"Retain-count cleanup deleted {deleted} old snapshot(s)")
+            elif args.wait and not snapshot_finished_successfully:
+                return 1
 
         elif args.list:
             print_header("Available Snapshots")
@@ -405,25 +569,39 @@ async def main():
 
         elif args.restore:
             restore_index = args.restore_to if args.restore_to else None
-            await restore_snapshot(
+            restored = await restore_snapshot(
                 client, args.restore, rename_index=restore_index, wait_for_completion=args.wait
             )
+            if not restored:
+                return 1
 
         elif args.delete:
-            await delete_snapshot(client, args.delete)
+            deleted = await delete_snapshot(client, args.delete)
+            if not deleted:
+                return 1
 
         elif args.cleanup:
-            deleted = await cleanup_old_snapshots(client, args.keep_days)
+            if args.retain_count:
+                deleted = await cleanup_snapshots_by_count(client, args.retain_count)
+            else:
+                deleted = await cleanup_old_snapshots(client, args.keep_days)
             print_success(f"Cleaned up {deleted} old snapshot(s)")
+
+        elif args.retain_count:
+            deleted = await cleanup_snapshots_by_count(client, args.retain_count)
+            print_success(f"Retain-count cleanup deleted {deleted} old snapshot(s)")
+
+        return 0
 
     except Exception as e:
         print_error(f"Unexpected error: {str(e)}")
         import traceback
 
         traceback.print_exc()
+        return 1
     finally:
         await client.close()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(asyncio.run(main()))

--- a/backend/scripts/backup_postgres_to_s3.py
+++ b/backend/scripts/backup_postgres_to_s3.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Create a production PostgreSQL/ParadeDB dump and upload it to S3.
+
+The script is designed for the Kamal cron container. It is intentionally
+production-gated so dev destinations do not start producing backups just
+because the cron entry exists in the shared image.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import urlsplit, urlunsplit
+
+DEFAULT_DATABASE_NAME = "btaa_geospatial_api"
+DEFAULT_PREFIX = "btaa-geospatial-api"
+DEFAULT_REQUIRED_DEST = "prd"
+DEFAULT_RETENTION_COUNT = 3
+
+
+@dataclass(frozen=True)
+class BackupConfig:
+    destination: str
+    bucket: str
+    prefix: str
+    retention_count: int
+    database_url: str
+    work_dir: Path
+    sse: str | None = None
+    sse_kms_key_id: str | None = None
+    storage_class: str | None = None
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {value!r}") from exc
+
+
+def _normalize_database_url(database_url: str) -> str:
+    """Convert SQLAlchemy asyncpg URLs to libpq-compatible PostgreSQL URLs."""
+    split = urlsplit(database_url)
+    if split.scheme == "postgresql+asyncpg":
+        return urlunsplit(("postgresql", split.netloc, split.path, split.query, split.fragment))
+    if split.scheme == "postgresql+psycopg2":
+        return urlunsplit(("postgresql", split.netloc, split.path, split.query, split.fragment))
+    return database_url
+
+
+def _s3_key(*parts: str) -> str:
+    return "/".join(part.strip("/") for part in parts if part and part.strip("/"))
+
+
+def _aws_extra_upload_args(config: BackupConfig) -> list[str]:
+    args: list[str] = []
+    if config.sse:
+        args.extend(["--sse", config.sse])
+    if config.sse_kms_key_id:
+        args.extend(["--sse-kms-key-id", config.sse_kms_key_id])
+    if config.storage_class:
+        args.extend(["--storage-class", config.storage_class])
+    return args
+
+
+def _run(args: list[str], *, capture_json: bool = False) -> dict[str, object] | None:
+    try:
+        result = subprocess.run(
+            args,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        message = (exc.stderr or exc.stdout or f"{args[0]} failed").strip()
+        raise RuntimeError(message) from exc
+
+    if not capture_json:
+        return None
+    stdout = result.stdout.strip()
+    return json.loads(stdout) if stdout else {}
+
+
+def _require_command(command: str) -> None:
+    if not shutil.which(command):
+        raise RuntimeError(f"Required command not found on PATH: {command}")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _build_config() -> BackupConfig:
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL is required")
+
+    bucket = os.getenv("BACKUP_S3_BUCKET", "").strip()
+    if not bucket:
+        raise RuntimeError("BACKUP_S3_BUCKET is required when backups are enabled")
+
+    destination = os.getenv("KAMAL_DEST", "unknown").strip() or "unknown"
+    prefix = os.getenv("BACKUP_S3_PREFIX", DEFAULT_PREFIX).strip("/")
+    retention_count = _env_int("BACKUP_RETENTION_COUNT", DEFAULT_RETENTION_COUNT)
+    if retention_count < 1:
+        raise RuntimeError("BACKUP_RETENTION_COUNT must be at least 1")
+
+    return BackupConfig(
+        destination=destination,
+        bucket=bucket,
+        prefix=prefix,
+        retention_count=retention_count,
+        database_url=_normalize_database_url(database_url),
+        work_dir=Path(os.getenv("BACKUP_WORK_DIR", "/tmp/btaa-geospatial-api-backups")),
+        sse=os.getenv("BACKUP_S3_SSE") or None,
+        sse_kms_key_id=os.getenv("BACKUP_S3_SSE_KMS_KEY_ID") or None,
+        storage_class=os.getenv("BACKUP_S3_STORAGE_CLASS") or None,
+    )
+
+
+def _should_skip_scheduled_backup(force: bool) -> str | None:
+    if force:
+        return None
+
+    if not _env_bool("BACKUP_ENABLED", default=False):
+        return "BACKUP_ENABLED is not true"
+
+    destination = os.getenv("KAMAL_DEST", "").strip()
+    required = os.getenv("BACKUP_REQUIRED_DEST", DEFAULT_REQUIRED_DEST).strip()
+    if required and destination != required:
+        return (
+            f"KAMAL_DEST={destination or '(unset)'} does not match BACKUP_REQUIRED_DEST={required}"
+        )
+
+    return None
+
+
+def _create_pg_dump(config: BackupConfig, output_path: Path) -> None:
+    _require_command("pg_dump")
+    _require_command("pg_restore")
+
+    _run(
+        [
+            "pg_dump",
+            "--dbname",
+            config.database_url,
+            "--format",
+            "custom",
+            "-Z",
+            "9",
+            "--no-owner",
+            "--no-acl",
+            "--file",
+            str(output_path),
+        ]
+    )
+
+    # Fast archive sanity check before the artifact leaves the box.
+    _run(["pg_restore", "--list", str(output_path)])
+
+
+def _upload_file(config: BackupConfig, source: Path, key: str, metadata: dict[str, str]) -> None:
+    _require_command("aws")
+
+    metadata_arg = ",".join(f"{name}={value}" for name, value in metadata.items())
+    command = [
+        "aws",
+        "s3",
+        "cp",
+        str(source),
+        f"s3://{config.bucket}/{key}",
+        "--only-show-errors",
+    ]
+    if metadata_arg:
+        command.extend(["--metadata", metadata_arg])
+    command.extend(_aws_extra_upload_args(config))
+    _run(command)
+
+
+def _head_object(config: BackupConfig, key: str) -> dict[str, object]:
+    _require_command("aws")
+    result = _run(
+        [
+            "aws",
+            "s3api",
+            "head-object",
+            "--bucket",
+            config.bucket,
+            "--key",
+            key,
+        ],
+        capture_json=True,
+    )
+    return result or {}
+
+
+def _list_objects(config: BackupConfig, prefix: str) -> list[dict[str, object]]:
+    _require_command("aws")
+    objects: list[dict[str, object]] = []
+    token: str | None = None
+
+    while True:
+        command = [
+            "aws",
+            "s3api",
+            "list-objects-v2",
+            "--bucket",
+            config.bucket,
+            "--prefix",
+            prefix,
+        ]
+        if token:
+            command.extend(["--continuation-token", token])
+        payload = _run(command, capture_json=True) or {}
+        objects.extend(payload.get("Contents", []))  # type: ignore[arg-type]
+        if not payload.get("IsTruncated"):
+            break
+        token = str(payload.get("NextContinuationToken") or "")
+        if not token:
+            break
+
+    return objects
+
+
+def _delete_object(config: BackupConfig, key: str) -> None:
+    _run(["aws", "s3", "rm", f"s3://{config.bucket}/{key}", "--only-show-errors"])
+
+
+def _prune_old_backups(config: BackupConfig, backup_prefix: str) -> list[str]:
+    objects = [
+        obj
+        for obj in _list_objects(config, backup_prefix)
+        if str(obj.get("Key", "")).endswith(".dump")
+    ]
+    objects.sort(key=lambda obj: str(obj.get("LastModified", "")), reverse=True)
+
+    deleted: list[str] = []
+    for obj in objects[config.retention_count :]:
+        key = str(obj["Key"])
+        manifest_key = f"{key}.manifest.json"
+        _delete_object(config, key)
+        deleted.append(key)
+        _delete_object(config, manifest_key)
+        deleted.append(manifest_key)
+
+    return deleted
+
+
+def create_backup(config: BackupConfig) -> dict[str, object]:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    filename = f"{DEFAULT_DATABASE_NAME}_{config.destination}_{timestamp}.dump"
+    backup_prefix = _s3_key(config.prefix, config.destination, "postgres")
+    backup_key = _s3_key(backup_prefix, filename)
+    manifest_key = f"{backup_key}.manifest.json"
+
+    config.work_dir.mkdir(parents=True, exist_ok=True)
+    with TemporaryDirectory(prefix="postgres-", dir=str(config.work_dir)) as tmpdir:
+        dump_path = Path(tmpdir) / filename
+        manifest_path = Path(tmpdir) / f"{filename}.manifest.json"
+
+        print(f"Creating PostgreSQL dump: {filename}", flush=True)
+        _create_pg_dump(config, dump_path)
+
+        sha256 = _sha256(dump_path)
+        size_bytes = dump_path.stat().st_size
+        created_at = datetime.now(UTC).isoformat()
+
+        manifest = {
+            "artifact": "postgres",
+            "database": DEFAULT_DATABASE_NAME,
+            "destination": config.destination,
+            "created_at": created_at,
+            "s3_bucket": config.bucket,
+            "s3_key": backup_key,
+            "filename": filename,
+            "size_bytes": size_bytes,
+            "sha256": sha256,
+            "format": "pg_dump custom",
+            "retention_count": config.retention_count,
+        }
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+        metadata = {
+            "artifact": "postgres",
+            "destination": config.destination,
+            "sha256": sha256,
+        }
+        print(f"Uploading dump to s3://{config.bucket}/{backup_key}", flush=True)
+        _upload_file(config, dump_path, backup_key, metadata)
+        _upload_file(config, manifest_path, manifest_key, metadata)
+
+        head = _head_object(config, backup_key)
+        if int(head.get("ContentLength", -1)) != size_bytes:
+            raise RuntimeError(
+                f"S3 object size mismatch for {backup_key}: "
+                f"expected={size_bytes} actual={head.get('ContentLength')}"
+            )
+
+    deleted = _prune_old_backups(config, f"{backup_prefix}/")
+    print(
+        f"PostgreSQL backup complete: s3://{config.bucket}/{backup_key} "
+        f"(retention deleted {len(deleted)} object(s))",
+        flush=True,
+    )
+
+    return {
+        "backup_key": backup_key,
+        "manifest_key": manifest_key,
+        "deleted": deleted,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Back up PostgreSQL/ParadeDB to S3")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Run even when BACKUP_ENABLED/KAMAL_DEST gating would normally skip",
+    )
+    args = parser.parse_args()
+
+    skip_reason = _should_skip_scheduled_backup(force=args.force)
+    if skip_reason:
+        print(f"Skipping PostgreSQL backup: {skip_reason}", flush=True)
+        return 0
+
+    try:
+        config = _build_config()
+        create_backup(config)
+        return 0
+    except Exception as exc:
+        print(f"PostgreSQL backup failed: {exc}", file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/render_cron_env.py
+++ b/backend/scripts/render_cron_env.py
@@ -23,6 +23,8 @@ ALLOWED_EXACT_KEYS = {
 ALLOWED_PREFIXES = (
     "ADMIN_",
     "APP_",
+    "AWS_",
+    "BACKUP_",
     "BRIDGE_",
     "CACHE_",
     "CELERY_",

--- a/backend/tests/scripts/test_backup_elasticsearch.py
+++ b/backend/tests/scripts/test_backup_elasticsearch.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from scripts import backup_elasticsearch as backup
+
+
+def test_repository_body_builds_s3_settings(monkeypatch):
+    monkeypatch.setattr(backup, "REPOSITORY_TYPE", "s3")
+    monkeypatch.setattr(backup, "BACKUP_S3_PREFIX", "btaa-geospatial-api")
+    monkeypatch.setenv("BACKUP_S3_BUCKET", "geoportal-dr")
+    monkeypatch.setenv("KAMAL_DEST", "prd")
+    monkeypatch.setenv("ELASTICSEARCH_SNAPSHOT_S3_STORAGE_CLASS", "STANDARD_IA")
+    monkeypatch.setenv("ELASTICSEARCH_SNAPSHOT_S3_SERVER_SIDE_ENCRYPTION", "true")
+
+    body = backup.repository_body()
+
+    assert body == {
+        "type": "s3",
+        "settings": {
+            "bucket": "geoportal-dr",
+            "base_path": "btaa-geospatial-api/prd/elasticsearch",
+            "client": "default",
+            "compress": True,
+            "storage_class": "STANDARD_IA",
+            "server_side_encryption": True,
+        },
+    }
+
+
+def test_repository_body_builds_fs_settings(monkeypatch):
+    monkeypatch.setattr(backup, "REPOSITORY_TYPE", "fs")
+    monkeypatch.setattr(backup, "REPOSITORY_PATH", "/usr/share/elasticsearch/backups")
+
+    assert backup.repository_body() == {
+        "type": "fs",
+        "settings": {
+            "location": "/usr/share/elasticsearch/backups",
+            "compress": True,
+        },
+    }
+
+
+def test_scheduled_skip_reason_requires_enabled(monkeypatch):
+    monkeypatch.setenv("BACKUP_ENABLED", "false")
+    monkeypatch.setenv("KAMAL_DEST", "prd")
+
+    assert backup.scheduled_skip_reason() == "BACKUP_ENABLED is not true"
+
+
+def test_managed_snapshot_uses_metadata_or_name():
+    assert backup.managed_snapshot({"snapshot": "other", "metadata": {"index": backup.INDEX_NAME}})
+    assert backup.managed_snapshot({"snapshot": f"{backup.INDEX_NAME}_snapshot_20260520_053000"})
+    assert not backup.managed_snapshot({"snapshot": "unrelated_snapshot"})

--- a/backend/tests/scripts/test_backup_postgres_to_s3.py
+++ b/backend/tests/scripts/test_backup_postgres_to_s3.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import backup_postgres_to_s3 as backup
+
+
+def test_normalize_database_url_strips_async_driver():
+    assert (
+        backup._normalize_database_url(
+            "postgresql+asyncpg://postgres:secret@paradedb:5432/btaa_geospatial_api"
+        )
+        == "postgresql://postgres:secret@paradedb:5432/btaa_geospatial_api"
+    )
+
+
+def test_s3_key_joins_and_strips_slashes():
+    assert (
+        backup._s3_key("/btaa-geospatial-api/", "prd", "/postgres/", "dump.dump")
+        == "btaa-geospatial-api/prd/postgres/dump.dump"
+    )
+
+
+def test_scheduled_backup_skips_when_disabled(monkeypatch):
+    monkeypatch.setenv("BACKUP_ENABLED", "false")
+    monkeypatch.setenv("KAMAL_DEST", "prd")
+
+    assert backup._should_skip_scheduled_backup(force=False) == "BACKUP_ENABLED is not true"
+
+
+def test_scheduled_backup_skips_non_required_destination(monkeypatch):
+    monkeypatch.setenv("BACKUP_ENABLED", "true")
+    monkeypatch.setenv("BACKUP_REQUIRED_DEST", "prd")
+    monkeypatch.setenv("KAMAL_DEST", "dev2")
+
+    assert (
+        backup._should_skip_scheduled_backup(force=False)
+        == "KAMAL_DEST=dev2 does not match BACKUP_REQUIRED_DEST=prd"
+    )
+
+
+def test_prune_old_backups_keeps_newest_count(monkeypatch, tmp_path: Path):
+    config = backup.BackupConfig(
+        destination="prd",
+        bucket="bucket",
+        prefix="btaa-geospatial-api",
+        retention_count=3,
+        database_url="postgresql://postgres:secret@db/example",
+        work_dir=tmp_path,
+    )
+    objects = [
+        {"Key": "prefix/backup-1.dump", "LastModified": "2026-05-20T05:30:01Z"},
+        {"Key": "prefix/backup-2.dump", "LastModified": "2026-05-20T05:30:02Z"},
+        {"Key": "prefix/backup-3.dump", "LastModified": "2026-05-20T05:30:03Z"},
+        {"Key": "prefix/backup-4.dump", "LastModified": "2026-05-20T05:30:04Z"},
+        {"Key": "prefix/backup-4.dump.manifest.json", "LastModified": "2026-05-20T05:30:04Z"},
+    ]
+    deleted: list[str] = []
+
+    monkeypatch.setattr(backup, "_list_objects", lambda _config, _prefix: objects)
+    monkeypatch.setattr(backup, "_delete_object", lambda _config, key: deleted.append(key))
+
+    assert backup._prune_old_backups(config, "prefix/") == [
+        "prefix/backup-1.dump",
+        "prefix/backup-1.dump.manifest.json",
+    ]
+    assert deleted == [
+        "prefix/backup-1.dump",
+        "prefix/backup-1.dump.manifest.json",
+    ]

--- a/backend/tests/scripts/test_render_cron_env.py
+++ b/backend/tests/scripts/test_render_cron_env.py
@@ -11,6 +11,8 @@ def test_render_cron_env_exports_filters_and_quotes_values():
             "DATABASE_URL": "postgresql://user:p@ss word@db.example/btaa",
             "REDIS_HOST": "redis.internal",
             "BRIDGE_SYNC_LOCAL_TIMEZONE": "America/Chicago",
+            "BACKUP_ENABLED": "true",
+            "AWS_ACCESS_KEY_ID": "example-key",
             "UNRELATED_KEY": "ignore-me",
         }
     )
@@ -18,6 +20,8 @@ def test_render_cron_env_exports_filters_and_quotes_values():
     assert "export DATABASE_URL='postgresql://user:p@ss word@db.example/btaa'" in rendered
     assert "export REDIS_HOST=redis.internal" in rendered
     assert "export BRIDGE_SYNC_LOCAL_TIMEZONE=America/Chicago" in rendered
+    assert "export BACKUP_ENABLED=true" in rendered
+    assert "export AWS_ACCESS_KEY_ID=example-key" in rendered
     assert "UNRELATED_KEY" not in rendered
 
 

--- a/config/crontab
+++ b/config/crontab
@@ -31,6 +31,12 @@ TZ=America/Chicago
 # Daily 4:45 AM: roll up analytics, create future partitions, and drop expired raw partitions.
 45 4 * * * /opt/venv/bin/python3 /app/backend/scripts/manage_analytics_storage.py --mode maintenance >> /proc/1/fd/1 2>> /proc/1/fd/2
 
+# Daily 5:30 AM: production-gated PostgreSQL/ParadeDB dump to S3.
+30 5 * * * /opt/venv/bin/python3 /app/scripts/backup_postgres_to_s3.py >> /proc/1/fd/1 2>> /proc/1/fd/2
+
+# Daily 5:45 AM: production-gated Elasticsearch snapshot to S3.
+45 5 * * * /opt/venv/bin/python3 /app/scripts/backup_elasticsearch.py --scheduled --create --wait --retain-count ${BACKUP_RETENTION_COUNT:-3} >> /proc/1/fd/1 2>> /proc/1/fd/2
+
 # Hourly: prune expired durable API response cache rows so the Postgres L2 cache
 # stays bounded even if Redis is cold or search traffic is high.
 17 * * * * /opt/venv/bin/python3 /app/backend/scripts/prune_generated_api_response_cache.py >> /proc/1/fd/1 2>> /proc/1/fd/2

--- a/config/deploy.prd.yml
+++ b/config/deploy.prd.yml
@@ -75,9 +75,23 @@ env:
     WEB_UVICORN_WORKERS: "4"
     WEB_INTERNAL_UVICORN_WORKERS: "6"
     WEB_SSR_WORKERS: "4"
+    BACKUP_ENABLED: "<%= ENV.fetch('BACKUP_ENABLED', 'true') %>"
+    BACKUP_REQUIRED_DEST: prd
+    BACKUP_RETENTION_COUNT: "<%= ENV.fetch('BACKUP_RETENTION_COUNT', '3') %>"
+    BACKUP_S3_BUCKET: "<%= ENV.fetch('BACKUP_S3_BUCKET', '') %>"
+    BACKUP_S3_PREFIX: "<%= ENV.fetch('BACKUP_S3_PREFIX', 'btaa-geospatial-api') %>"
+    BACKUP_S3_REGION: "<%= ENV.fetch('BACKUP_S3_REGION', ENV.fetch('AWS_REGION', 'us-east-2')) %>"
+    AWS_REGION: "<%= ENV.fetch('AWS_REGION', ENV.fetch('BACKUP_S3_REGION', 'us-east-2')) %>"
+    AWS_DEFAULT_REGION: "<%= ENV.fetch('AWS_DEFAULT_REGION', ENV.fetch('AWS_REGION', ENV.fetch('BACKUP_S3_REGION', 'us-east-2'))) %>"
+    ELASTICSEARCH_SNAPSHOT_REPOSITORY: btaa_geoportal_snapshots
+    ELASTICSEARCH_SNAPSHOT_REPOSITORY_TYPE: s3
+    ELASTICSEARCH_SNAPSHOT_S3_BASE_PATH: "<%= ENV.fetch('ELASTICSEARCH_SNAPSHOT_S3_BASE_PATH', 'btaa-geospatial-api/prd/elasticsearch') %>"
+    ELASTICSEARCH_SNAPSHOT_S3_STORAGE_CLASS: "<%= ENV.fetch('ELASTICSEARCH_SNAPSHOT_S3_STORAGE_CLASS', '') %>"
+    ELASTICSEARCH_SNAPSHOT_S3_SERVER_SIDE_ENCRYPTION: "<%= ENV.fetch('ELASTICSEARCH_SNAPSHOT_S3_SERVER_SIDE_ENCRYPTION', 'true') %>"
   secret:
     # Destination secret lists replace the base list rather than appending.
-    # Keep this in sync with config/deploy.yml when adding prod-only secrets.
+    # Keep the shared entries in sync with config/deploy.yml; prod-only backup
+    # secrets are listed at the end.
     - REDIS_PASSWORD
     - POSTGRES_PASSWORD
     - DATABASE_URL
@@ -90,9 +104,14 @@ env:
     - TURNSTILE_SECRET_KEY
     - APPSIGNAL_PUSH_API_KEY
     - SLACK_SIGNING_SECRET
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
 
 accessories:
   elasticsearch:
     env:
       clear:
         ES_JAVA_OPTS: "-Xms4g -Xmx4g"
+      secret:
+        - AWS_ACCESS_KEY_ID
+        - AWS_SECRET_ACCESS_KEY

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -138,6 +138,17 @@ env:
     SMTP_HOST:             "<%= ENV.fetch('SMTP_HOST', '') %>"
     SMTP_PORT:             "<%= ENV.fetch('SMTP_PORT', '587') %>"
     SMTP_STARTTLS:         "<%= ENV.fetch('SMTP_STARTTLS', 'true') %>"
+    BACKUP_ENABLED:        "false"
+    BACKUP_REQUIRED_DEST:  "prd"
+    BACKUP_RETENTION_COUNT: "3"
+    BACKUP_S3_BUCKET:      "<%= ENV.fetch('BACKUP_S3_BUCKET', '') %>"
+    BACKUP_S3_PREFIX:      "<%= ENV.fetch('BACKUP_S3_PREFIX', 'btaa-geospatial-api') %>"
+    BACKUP_S3_REGION:      "<%= ENV.fetch('BACKUP_S3_REGION', ENV.fetch('AWS_REGION', 'us-east-2')) %>"
+    AWS_REGION:            "<%= ENV.fetch('AWS_REGION', ENV.fetch('BACKUP_S3_REGION', 'us-east-2')) %>"
+    AWS_DEFAULT_REGION:    "<%= ENV.fetch('AWS_DEFAULT_REGION', ENV.fetch('AWS_REGION', ENV.fetch('BACKUP_S3_REGION', 'us-east-2'))) %>"
+    ELASTICSEARCH_SNAPSHOT_REPOSITORY: "btaa_geoportal_snapshots"
+    ELASTICSEARCH_SNAPSHOT_REPOSITORY_TYPE: "fs"
+    ELASTICSEARCH_SNAPSHOT_S3_CLIENT: "default"
 
   secret:
     - REDIS_PASSWORD
@@ -166,10 +177,12 @@ accessories:
         cluster.routing.allocation.disk.watermark.low: "85%"
         cluster.routing.allocation.disk.watermark.high: "90%"
         cluster.routing.allocation.disk.watermark.flood_stage: "95%"
+        path.repo: /usr/share/elasticsearch/backups
     # Optional: expose on host loopback for debugging from the VM
     port: "127.0.0.1:9200:9200"
     directories:
       - /var/lib/btaa-geospatial-api/elasticsearch:/usr/share/elasticsearch/data
+      - /var/lib/btaa-geospatial-api/elasticsearch-backups:/usr/share/elasticsearch/backups
 
   paradedb:
     image: paradedb/paradedb:0.18.11

--- a/docs/README.md
+++ b/docs/README.md
@@ -185,7 +185,7 @@ Run Makefile targets from the repository root.
 | Blog/sitemap | `make blog-sync`, `make sitemap-generate`. |
 | Analytics | `make analytics-maintenance`, `make analytics-size-report`. |
 | Database sync | `make db-export`, `make db-import`, `make db-sync`, `make gbl-admin-db-*`. |
-| Kamal remote ops | `make kamal-reindex`, `make kamal-clear-cache`, `make kamal-verify-h3-index`, `make kamal-blog-sync`, `make kamal-purge-home-blog-cache`, `make kamal-bridge-sync-batched`, `make kamal-bridge-status`, `make kamal-cron-debug`, `make kamal-worker-logs`, `make kamal-network-sanity`, plus Kamal cache priming targets. |
+| Kamal remote ops | `make kamal-reindex`, `make kamal-clear-cache`, `make kamal-verify-h3-index`, `make kamal-blog-sync`, `make kamal-purge-home-blog-cache`, `make kamal-backup-postgres`, `make kamal-backup-elasticsearch`, `make kamal-bridge-sync-batched`, `make kamal-bridge-status`, `make kamal-cron-debug`, `make kamal-worker-logs`, `make kamal-network-sanity`, plus Kamal cache priming targets. |
 | Performance | `make k6-smoke`, `make k6-stress`, `make k6-endpoint-capacity`. |
 
 ## Kamal Deployment Model
@@ -343,6 +343,7 @@ Chapter 4, ingest, migration, and operations:
 Chapter 5, deployment and recovery:
 
 - [backend/kamal_deployment.md](backend/kamal_deployment.md)
+- [backend/disaster_recovery.md](backend/disaster_recovery.md)
 - [production_server_requirements.md](production_server_requirements.md)
 - [backend/vm_memory_recovery.md](backend/vm_memory_recovery.md)
 - [backend/IP_WHITELISTING_RECOMMENDATIONS.md](backend/IP_WHITELISTING_RECOMMENDATIONS.md)

--- a/docs/backend/disaster_recovery.md
+++ b/docs/backend/disaster_recovery.md
@@ -1,0 +1,157 @@
+# Disaster Recovery Backups
+
+This runbook covers the production backup path for the BTAA Geospatial API
+single-host Kamal deployment.
+
+## Scope
+
+- `prd` gets nightly disaster-recovery backups.
+- `dev1` and `dev2` are not backed up by default. The cron entries exist in the
+  shared image, but both backup scripts exit cleanly unless `BACKUP_ENABLED=true`
+  and `KAMAL_DEST` matches `BACKUP_REQUIRED_DEST`.
+- Retention is count-based: keep the latest three successful Postgres dumps and
+  the latest three managed Elasticsearch snapshots.
+
+## Schedule
+
+The Kamal cron container runs:
+
+- 5:30 AM America/Chicago: `backup_postgres_to_s3.py`
+- 5:45 AM America/Chicago: `backup_elasticsearch.py --scheduled --create --wait --retain-count ${BACKUP_RETENTION_COUNT:-3}`
+
+These run after the bridge sync, blog sync, sitemap generation, and analytics
+maintenance jobs in `config/crontab`.
+
+## S3 Layout
+
+Default keys use:
+
+```text
+s3://<BACKUP_S3_BUCKET>/<BACKUP_S3_PREFIX>/prd/postgres/*.dump
+s3://<BACKUP_S3_BUCKET>/<BACKUP_S3_PREFIX>/prd/postgres/*.dump.manifest.json
+s3://<BACKUP_S3_BUCKET>/<BACKUP_S3_PREFIX>/prd/elasticsearch/<snapshot-repository-objects>
+```
+
+The default `BACKUP_S3_PREFIX` is `btaa-geospatial-api`.
+
+Do not use S3 lifecycle expiration directly under the Elasticsearch snapshot
+prefix. Elasticsearch snapshot repositories maintain metadata across objects;
+delete old snapshots through the Elasticsearch snapshot API, which the script
+does with `--retain-count`.
+
+## Required Production Settings
+
+Set these for `prd` before enabling backups:
+
+```bash
+BACKUP_ENABLED=true
+BACKUP_S3_BUCKET=<bucket-name>
+BACKUP_S3_PREFIX=btaa-geospatial-api
+BACKUP_S3_REGION=us-east-2
+AWS_ACCESS_KEY_ID=<secret>
+AWS_SECRET_ACCESS_KEY=<secret>
+```
+
+`config/deploy.prd.yml` defaults `BACKUP_ENABLED` to true, but the jobs will
+fail until `BACKUP_S3_BUCKET` and usable AWS credentials exist.
+
+The IAM principal needs at least list/read/write/delete permission for:
+
+```text
+arn:aws:s3:::<bucket-name>/<BACKUP_S3_PREFIX>/prd/*
+```
+
+## One-Time Elasticsearch S3 Setup
+
+The Postgres backup uses the AWS CLI in the cron container. Elasticsearch S3
+snapshots are written by the Elasticsearch node itself, so its S3 client must
+also have credentials.
+
+If the production host has an AWS instance profile or another supported ambient
+credential source, use that. Otherwise, after the AWS secrets are available to
+the Elasticsearch accessory, add them to the Elasticsearch keystore:
+
+```bash
+kamal accessory exec -d prd elasticsearch \
+  "bash -lc 'printf %s \"\$AWS_ACCESS_KEY_ID\" | bin/elasticsearch-keystore add -x -f s3.client.default.access_key'"
+
+kamal accessory exec -d prd elasticsearch \
+  "bash -lc 'printf %s \"\$AWS_SECRET_ACCESS_KEY\" | bin/elasticsearch-keystore add -x -f s3.client.default.secret_key'"
+
+kamal accessory reboot -d prd elasticsearch
+```
+
+After restart, create/test the repository with:
+
+```bash
+make kamal-backup-elasticsearch KAMAL_DEST=prd
+make kamal-backup-list-elasticsearch KAMAL_DEST=prd
+```
+
+## Manual Backup Commands
+
+Run these from the repository root:
+
+```bash
+make kamal-backup-postgres KAMAL_DEST=prd
+make kamal-backup-elasticsearch KAMAL_DEST=prd
+make kamal-backup-list-elasticsearch KAMAL_DEST=prd
+```
+
+## Restore Outline
+
+Prefer restoring into a throwaway environment first so the archive and
+procedure are tested without extending an outage.
+
+### Postgres
+
+1. Stop app writers (`web`, `worker`, and `cron`) or otherwise hold writes.
+2. Download the selected `.dump` artifact from S3 to the host.
+3. Restore it into the ParadeDB container:
+
+   ```bash
+   docker exec -i btaa-geospatial-api-paradedb pg_restore \
+     -U postgres \
+     -d btaa_geospatial_api \
+     --clean \
+     --if-exists \
+     --no-owner \
+     --no-acl \
+     < /var/tmp/<backup>.dump
+   ```
+
+4. Run a health check, then rebuild/search-verify Elasticsearch if needed:
+
+   ```bash
+   make kamal-reindex KAMAL_DEST=prd
+   make kamal-verify-h3-index KAMAL_DEST=prd
+   ```
+
+### Elasticsearch
+
+When the database is intact, the safest Elasticsearch recovery is usually:
+
+```bash
+make kamal-reindex KAMAL_DEST=prd
+```
+
+Use an Elasticsearch snapshot when reindexing is unavailable or too slow:
+
+```bash
+make kamal-backup-list-elasticsearch KAMAL_DEST=prd
+
+kamal app exec -d prd --roles cron --reuse \
+  "bash -lc '/opt/venv/bin/python3 /app/scripts/backup_elasticsearch.py --restore <snapshot-name> --wait'"
+```
+
+If the existing index blocks restore, stop app traffic and delete or close the
+corrupt index/alias target first.
+
+## Restore Drill
+
+At least monthly:
+
+1. Restore the latest Postgres dump to a temporary database.
+2. Confirm `pg_restore --list` succeeds and spot-check key tables.
+3. Confirm the newest Elasticsearch snapshot lists as `SUCCESS`.
+4. Document the selected backup keys, restore duration, and any manual fixes.

--- a/docs/backend/elasticsearch_production.md
+++ b/docs/backend/elasticsearch_production.md
@@ -191,13 +191,25 @@ cluster.initial_master_nodes: ["node1", "node2", "node3"]
 
 ### Backup Strategy
 
-We use Elasticsearch snapshots for backups. The backup script is located at `scripts/backup_elasticsearch.py`.
+We use Elasticsearch snapshots for backups. The backup script is located at
+`scripts/backup_elasticsearch.py`.
+
+Production snapshots use the S3 repository configured by
+`ELASTICSEARCH_SNAPSHOT_REPOSITORY_TYPE=s3`, `BACKUP_S3_BUCKET`, and the
+`BACKUP_S3_PREFIX/prd/elasticsearch` base path. Local/dev environments keep the
+filesystem repository default for manual testing, but scheduled backups are
+gated by `BACKUP_ENABLED` and `KAMAL_DEST`. See
+[disaster_recovery.md](disaster_recovery.md) for the current production
+runbook.
 
 #### Creating Backups
 
 ```bash
 # Create a snapshot (auto-named with timestamp)
 python scripts/backup_elasticsearch.py --create
+
+# Create a scheduled production-gated snapshot and keep only the newest 3
+python scripts/backup_elasticsearch.py --scheduled --create --wait --retain-count 3
 
 # Create a named snapshot
 python scripts/backup_elasticsearch.py --create --name my_backup
@@ -241,12 +253,20 @@ python scripts/backup_elasticsearch.py --cleanup --keep-days 30
 
 ### Backup Repository
 
-The backup repository is automatically created on first use. It's configured as a filesystem repository at:
+The backup repository is automatically created on first use.
+
+For local/dev filesystem snapshots, it is configured as:
 - **Path**: `/usr/share/elasticsearch/backups` (inside container)
 - **Type**: Filesystem (fs)
 - **Compression**: Enabled
 
-**For Kamal deployments**, ensure the backup directory is persisted:
+For S3 snapshots in production:
+- **Bucket**: `BACKUP_S3_BUCKET`
+- **Base path**: `BACKUP_S3_PREFIX/prd/elasticsearch`
+- **Repository type**: `s3`
+- **Retention**: count-based via `--retain-count 3`
+
+**For filesystem Kamal testing**, ensure the backup directory is persisted:
 ```yaml
 directories:
   - esdata:/usr/share/elasticsearch/data
@@ -255,15 +275,13 @@ directories:
 
 ### Backup Schedule
 
-Recommended backup schedule:
-- **Daily**: Full snapshot (keep 7 days)
-- **Weekly**: Full snapshot (keep 4 weeks)
-- **Monthly**: Full snapshot (keep 12 months)
+Current production backup schedule:
+- **Daily**: Full snapshot at 5:45 AM America/Chicago.
+- **Retention**: keep the latest 3 managed snapshots.
 
-Example cron job (on server):
+Cron entry:
 ```bash
-# Daily backup at 2 AM
-0 2 * * * kamal app exec "python scripts/backup_elasticsearch.py --create"
+45 5 * * * /opt/venv/bin/python3 /app/scripts/backup_elasticsearch.py --scheduled --create --wait --retain-count ${BACKUP_RETENTION_COUNT:-3}
 ```
 
 ### Disaster Recovery Procedure
@@ -498,4 +516,3 @@ curl http://localhost:9200/btaa_geospatial_api/_settings?pretty
 - [Elasticsearch Snapshot and Restore](https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html)
 - [Elasticsearch Index Settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html)
 - [Elasticsearch Performance Tuning](https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-search-speed.html)
-

--- a/docs/backend/scripts.md
+++ b/docs/backend/scripts.md
@@ -205,6 +205,42 @@ make analytics-maintenance
 make analytics-size-report
 ```
 
+### 11. `backup_postgres_to_s3.py`
+
+**Purpose**: Creates a production-gated PostgreSQL/ParadeDB `pg_dump` custom
+archive and uploads it to S3 with a JSON manifest.
+
+**Usage**:
+```bash
+python scripts/backup_postgres_to_s3.py
+```
+
+From the project root you can run against Kamal production:
+```bash
+make kamal-backup-postgres KAMAL_DEST=prd
+```
+
+### 12. `backup_elasticsearch.py`
+
+**Purpose**: Manages Elasticsearch snapshots for disaster recovery. It supports
+the historical filesystem repository and the production S3 repository.
+
+**Usage**:
+```bash
+python scripts/backup_elasticsearch.py --create --wait --retain-count 3
+python scripts/backup_elasticsearch.py --list
+python scripts/backup_elasticsearch.py --restore <snapshot-name> --wait
+```
+
+From the project root you can run against Kamal production:
+```bash
+make kamal-backup-elasticsearch KAMAL_DEST=prd
+make kamal-backup-list-elasticsearch KAMAL_DEST=prd
+```
+
+See [disaster_recovery.md](disaster_recovery.md) for S3 configuration,
+retention, and restore procedures.
+
 ## Common Features
 
 All scripts share some common features:
@@ -219,6 +255,9 @@ Several scripts require specific environment variables:
 
 - `OPENAI_API_KEY`: Required by `generate_fast_embeddings.py`
 - `REDIS_HOST` and `REDIS_PORT`: Used by `clear_cache.py`
+- `BACKUP_ENABLED`, `BACKUP_S3_BUCKET`, `BACKUP_S3_PREFIX`,
+  `BACKUP_RETENTION_COUNT`, and AWS credentials: used by the disaster recovery
+  backup scripts.
 
 ### API rate limiting and service tiers
 

--- a/docs/make_tasks.md
+++ b/docs/make_tasks.md
@@ -214,6 +214,9 @@ Set `KAMAL_DEST=dev1`, `dev2`, or `prd`. The default is `dev1`.
 | `make kamal-clear-cache` | Clear remote cache. `KAMAL_CACHE_TYPE=search|resource|suggest|map|all`. |
 | `make kamal-blog-sync` | Trigger remote home page blog sync. Use `RUN_NOW=1` for inline execution. |
 | `make kamal-purge-home-blog-cache` | Purge home blog/home endpoint cache remotely. |
+| `make kamal-backup-postgres` | Run the production-gated Postgres S3 backup in the cron container. |
+| `make kamal-backup-elasticsearch` | Run the production-gated Elasticsearch S3 snapshot in the cron container. |
+| `make kamal-backup-list-elasticsearch` | List Elasticsearch snapshots for the target destination. |
 | `make kamal-bridge-status` | Show bridge status remotely. |
 | `make kamal-bridge-status-watch` | Poll remote bridge status. |
 | `make kamal-cron-debug` | Inspect cron container crontab, timezone, and env. |
@@ -230,6 +233,8 @@ Set `KAMAL_DEST=dev1`, `dev2`, or `prd`. The default is `dev1`.
 | `make kamal-refresh-resource-caches` | Purge and rehydrate selected remote resource/API caches. |
 
 Kamal reindex knobs mirror local reindexing with the `KAMAL_REINDEX_*` prefix.
+`make kamal-backup-elasticsearch` uses `KAMAL_BACKUP_RETAIN_COUNT` as a manual
+fallback when the destination environment does not set `BACKUP_RETENTION_COUNT`.
 
 ## Performance Tests
 


### PR DESCRIPTION
…ntegration

- Add `backup_postgres_to_s3.py` for creating production-gated PostgreSQL dumps and uploading them to S3.
- Update cron jobs to schedule daily backups for PostgreSQL and Elasticsearch.
- Enhance environment variable handling for backup configurations in `render_cron_env.py`.
- Create tests for PostgreSQL backup functionality and Elasticsearch backup management.
- Document disaster recovery procedures and backup strategies in the README and new `disaster_recovery.md`.
- Update deployment configurations to include necessary backup environment variables.
- Ensure proper retention policies for backups and implement pruning of old backups.