### PR TITLE
[ebot] Redirect old catalog URLs to resources

### DIFF
--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -8,6 +8,8 @@ export default [
   route("feedback", "routes/feedback.tsx"),
   route("search", "routes/search.tsx"),
   route("search/results", "routes/search.results.ts"),
+  route("catalog/:id", "routes/catalog.$id.ts"),
+  route("catalog/:id/*", "routes/catalog.$id.splat.ts"),
   route("resources/:id", "routes/resources.$id.tsx"),
   route("mirador", "routes/mirador.tsx"),
   // Resource routes (return non-HTML responses via loaders)

--- a/frontend/app/routes/__tests__/catalog.redirect.test.ts
+++ b/frontend/app/routes/__tests__/catalog.redirect.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { LoaderFunctionArgs } from 'react-router';
+import { loader } from '../catalog.$id';
+
+describe('catalog legacy redirect loader', () => {
+  it('permanently redirects old catalog URLs to resource URLs', () => {
+    const response = loader({
+      params: { id: 'a10a0f50-994e-0134-2096-0050569601ca-c' },
+      request: new Request(
+        'https://geo.btaa.org/catalog/a10a0f50-994e-0134-2096-0050569601ca-c'
+      ),
+    } as LoaderFunctionArgs);
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(
+      '/resources/a10a0f50-994e-0134-2096-0050569601ca-c'
+    );
+  });
+
+  it('preserves query params on redirected catalog URLs', () => {
+    const response = loader({
+      params: { id: 'p16022coll583:2574' },
+      request: new Request(
+        'https://geo.btaa.org/catalog/p16022coll583:2574?utm_source=legacy'
+      ),
+    } as LoaderFunctionArgs);
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(
+      '/resources/p16022coll583:2574?utm_source=legacy'
+    );
+  });
+
+  it('sends old catalog child URLs to the resource detail page', () => {
+    const response = loader({
+      params: { id: 'a10a0f50-994e-0134-2096-0050569601ca-c', '*': 'raw' },
+      request: new Request(
+        'https://geo.btaa.org/catalog/a10a0f50-994e-0134-2096-0050569601ca-c/raw'
+      ),
+    } as LoaderFunctionArgs);
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe(
+      '/resources/a10a0f50-994e-0134-2096-0050569601ca-c'
+    );
+  });
+
+  it('returns a bad request when a catalog URL has no resource ID', () => {
+    expect(() =>
+      loader({
+        params: {},
+        request: new Request('https://geo.btaa.org/catalog/'),
+      } as LoaderFunctionArgs)
+    ).toThrow(Response);
+  });
+});

--- a/frontend/app/routes/catalog.$id.splat.ts
+++ b/frontend/app/routes/catalog.$id.splat.ts
@@ -1,0 +1,1 @@
+export { loader } from './catalog.$id';

--- a/frontend/app/routes/catalog.$id.ts
+++ b/frontend/app/routes/catalog.$id.ts
@@ -1,0 +1,13 @@
+import type { LoaderFunctionArgs } from 'react-router';
+import { redirect } from 'react-router';
+
+export function loader({ params, request }: LoaderFunctionArgs) {
+  const { id } = params;
+
+  if (!id) {
+    throw new Response('Resource ID is required', { status: 400 });
+  }
+
+  const url = new URL(request.url);
+  return redirect(`/resources/${id}${url.search}`, 301);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate } from 'react-router';
+import { Routes, Route, Navigate, useLocation, useParams } from 'react-router';
 import { Application } from '@hotwired/stimulus';
 import { SearchPage } from './pages/SearchPage';
 import { ResourceView } from './pages/ResourceView';
@@ -23,6 +23,18 @@ import 'leaflet/dist/leaflet.css';
 const application = Application.start();
 (window as typeof window & { Stimulus: Application }).Stimulus = application;
 
+function CatalogRedirect() {
+  const { id } = useParams();
+  const location = useLocation();
+
+  return (
+    <Navigate
+      to={`/resources/${id ?? ''}${location.search}${location.hash}`}
+      replace
+    />
+  );
+}
+
 function App() {
   const [searchParams] = useSearchParams();
   const hasSearchParams = Array.from(searchParams.entries()).length > 0;
@@ -40,6 +52,8 @@ function App() {
           <Route path="/feedback" element={<FeedbackPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/bookmarks" element={<BookmarksPage />} />
+          <Route path="/catalog/:id" element={<CatalogRedirect />} />
+          <Route path="/catalog/:id/*" element={<CatalogRedirect />} />
           <Route path="/resources/:id" element={<ResourceView />} />
           <Route
             path="/test/fixtures/providers"


### PR DESCRIPTION
## Summary

- Add React Router server routes for legacy /catalog/:id and /catalog/:id/* URLs.
- Permanently redirect old GeoBlacklight URLs to the new /resources/:id detail URLs while preserving query params.
- Mirror the redirect in the legacy SPA route table for non-framework/local fallback paths.
- Add focused loader tests for plain catalog URLs, query params, child paths, and missing IDs.

## Why

Fixes #81. The old Geoportal used /catalog/... URLs, while the new RUI Geoportal uses /resources/.... This keeps old bookmarked and indexed resource links working cleanly when production traffic moves over.

## Validation

- npm test -- --run app/routes/__tests__/catalog.redirect.test.ts
- npm run build
- ./node_modules/.bin/eslint src/App.tsx
- Local smoke tests confirmed HTTP/1.1 301 for /catalog/:id?... and /catalog/:id/raw?... with Location: /resources/:id?...