### PR TITLE
[codex] Harden public API contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,66 @@ workflows, and future agent-facing discovery tools.
 - `Makefile`: Main developer/operator entry point for linting, tests, ingest,
   reindexing, cache work, docs, and deployment-support tasks.
 
+## Local Proxy
+
+The local browser-facing proxy is provided by the React Router frontend dev
+server at `http://localhost:3000`. It is not a separate service: start the
+normal Docker stack and open the frontend URL.
+
+```bash
+cp .env.example .env
+docker compose up -d
+```
+
+The backend API remains available directly at `http://localhost:8000/api/v1`,
+but the frontend uses same-origin proxy routes for request paths that should run
+through server-side loaders, carry the server-side API key, or avoid browser
+CORS/rate-limit surprises. Common local proxy routes include:
+
+- `http://localhost:3000/search/results` -> `/api/v1/search`
+- `http://localhost:3000/search/facets/:facetName` ->
+  `/api/v1/search/facets/:facetName`
+- `http://localhost:3000/map/h3` -> `/api/v1/map/h3`
+- `http://localhost:3000/home/blog-posts` -> `/api/v1/home/blog-posts`
+- `http://localhost:3000/places/suggest` -> `/api/v1/places/suggest`
+- `http://localhost:3000/resources/:id/thumbnail` ->
+  `/api/v1/resources/:id/thumbnail`
+- `http://localhost:3000/resources/:id/static-map` ->
+  `/api/v1/resources/:id/static-map`
+- `http://localhost:3000/static-maps/...` and
+  `http://localhost:3000/thumbnails/...` for generated map and thumbnail assets
+
+There are two API base URLs to keep straight in local development:
+
+- `VITE_API_BASE_URL` is compiled into browser code. Docker sets it to
+  `http://localhost:8000/api/v1` so direct browser API calls use the host port.
+- `API_BASE_URL` is read by React Router server-side loaders. Docker sets it to
+  `http://api:8000/api/v1` because the frontend container reaches the API by
+  service name on the Docker network.
+
+If you run the frontend outside Docker, point the server-side proxy back at the
+host API:
+
+```bash
+cd frontend
+API_BASE_URL=http://localhost:8000/api/v1 npm run dev
+```
+
+Set `BTAA_GEOSPATIAL_API_KEY` when you want local proxy requests to forward an
+API key as `X-API-Key`; otherwise they use the public/anonymous API behavior.
+Localhost skips the frontend Turnstile gate by default. To exercise that flow
+locally, set `VITE_TURNSTILE_ENABLE_LOCAL=true` along with the Turnstile test
+configuration.
+
+If proxy requests fail, first check that the API is reachable from the frontend
+server context: use `http://api:8000/api/v1` from Docker and
+`http://localhost:8000/api/v1` from host-run dev servers. Useful commands:
+
+```bash
+docker compose logs -f frontend api
+make frontend-reset
+```
+
 ## Documentation
 
 Setup, development, and operations notes live in `docs/`:

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from fastapi import Request
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -25,12 +26,56 @@ class APIErrorResponse(BaseModel):
     errors: list[APIError] = Field(..., min_length=1)
 
 
-COMMON_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
-    500: {
-        "model": APIErrorResponse,
-        "description": "Internal server error",
-    },
+_ERROR_TITLES: dict[int, str] = {
+    400: "Bad request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not found",
+    422: "Validation error",
+    429: "Rate limit exceeded",
+    500: "Internal server error",
+    502: "Upstream service failed",
+    503: "Service unavailable",
 }
+
+_ERROR_CODES: dict[int, str] = {
+    400: "bad_request",
+    401: "unauthorized",
+    403: "forbidden",
+    404: "not_found",
+    422: "validation_error",
+    429: "rate_limit_exceeded",
+    500: "internal_server_error",
+    502: "upstream_service_failed",
+    503: "service_unavailable",
+}
+
+
+def _openapi_error_response(description: str) -> dict[str, Any]:
+    return {
+        "model": APIErrorResponse,
+        "description": description,
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/APIErrorResponse"},
+            }
+        },
+    }
+
+
+PUBLIC_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    400: _openapi_error_response("Bad request"),
+    401: _openapi_error_response("Unauthorized"),
+    403: _openapi_error_response("Forbidden"),
+    404: _openapi_error_response("Not found"),
+    422: _openapi_error_response("Validation error"),
+    429: _openapi_error_response("Rate limit exceeded"),
+    500: _openapi_error_response("Internal server error"),
+    502: _openapi_error_response("Upstream service failed"),
+    503: _openapi_error_response("Service unavailable"),
+}
+
+COMMON_ERROR_RESPONSES = PUBLIC_ERROR_RESPONSES
 
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
@@ -112,5 +157,61 @@ def internal_server_error_response(request: Request) -> JSONResponse:
         code="internal_server_error",
         title="Internal server error",
         detail="An unexpected error occurred.",
+        request_id=get_request_id(request),
+    )
+
+
+def _safe_detail(status_code: int, detail: Any) -> str | None:
+    if status_code >= 500:
+        if status_code == 502:
+            return "An upstream service failed."
+        if status_code == 503:
+            return "The service is temporarily unavailable."
+        return "An unexpected error occurred."
+
+    if detail is None:
+        return None
+    if isinstance(detail, str):
+        return detail
+    if isinstance(detail, dict):
+        for key in ("detail", "message"):
+            value = detail.get(key)
+            if isinstance(value, str):
+                return value
+    return "Request validation failed." if status_code == 422 else str(detail)
+
+
+def _error_code(status_code: int, detail: Any) -> str:
+    if isinstance(detail, dict) and isinstance(detail.get("code"), str):
+        return detail["code"]
+    return _ERROR_CODES.get(status_code, "http_error")
+
+
+def _error_title(status_code: int, detail: Any) -> str:
+    if isinstance(detail, dict) and isinstance(detail.get("title"), str):
+        return detail["title"]
+    return _ERROR_TITLES.get(status_code, "HTTP error")
+
+
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    return api_error_response(
+        status_code=exc.status_code,
+        code=_error_code(exc.status_code, exc.detail),
+        title=_error_title(exc.status_code, exc.detail),
+        detail=_safe_detail(exc.status_code, exc.detail),
+        request_id=get_request_id(request),
+        headers=exc.headers,
+    )
+
+
+async def validation_exception_handler(
+    request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    return api_error_response(
+        status_code=422,
+        code="validation_error",
+        title="Validation error",
+        detail="Request validation failed.",
         request_id=get_request_id(request),
     )

--- a/backend/app/api/ogc/endpoints.py
+++ b/backend/app/api/ogc/endpoints.py
@@ -3,6 +3,17 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
+from app.api.schemas import (
+    OGCCollectionResponse,
+    OGCCollectionsResponse,
+    OGCConformanceResponse,
+    OGCFeatureCollectionResponse,
+    OGCFeatureResponse,
+    OGCLandingPageResponse,
+    OGCQueryablesResponse,
+    OGCSortablesResponse,
+)
 from app.api.v1.shared import SortOption
 from app.services.ogc_projector import OGCResponseProjector
 from app.services.search_service import SearchService
@@ -57,42 +68,58 @@ def parse_bbox_to_fq(bbox: Optional[str]) -> Optional[Dict]:
     return None
 
 
-@router.get("/")
+@router.get("/", response_model=OGCLandingPageResponse, responses=PUBLIC_ERROR_RESPONSES)
 async def get_landing_page(request: Request) -> Dict[str, Any]:
     url = str(request.url)
     return OGCResponseProjector.build_landing_page(url)
 
 
-@router.get("/conformance")
+@router.get("/conformance", response_model=OGCConformanceResponse, responses=PUBLIC_ERROR_RESPONSES)
 async def get_conformance() -> Dict[str, Any]:
     return OGCResponseProjector.build_conformance()
 
 
-@router.get("/collections")
+@router.get("/collections", response_model=OGCCollectionsResponse, responses=PUBLIC_ERROR_RESPONSES)
 async def get_collections(request: Request) -> Dict[str, Any]:
     url = str(request.url)
     return OGCResponseProjector.build_collections(url)
 
 
-@router.get("/collections/btaa-records")
+@router.get(
+    "/collections/btaa-records",
+    response_model=OGCCollectionResponse,
+    responses=PUBLIC_ERROR_RESPONSES,
+)
 async def get_collection(request: Request) -> Dict[str, Any]:
     url = str(request.url)
     return OGCResponseProjector.build_collection(url, "btaa-records")
 
 
-@router.get("/collections/btaa-records/queryables")
+@router.get(
+    "/collections/btaa-records/queryables",
+    response_model=OGCQueryablesResponse,
+    responses=PUBLIC_ERROR_RESPONSES,
+)
 async def get_queryables(request: Request) -> Dict[str, Any]:
     url = str(request.url)
     return OGCResponseProjector.build_queryables(url)
 
 
-@router.get("/collections/btaa-records/sortables")
+@router.get(
+    "/collections/btaa-records/sortables",
+    response_model=OGCSortablesResponse,
+    responses=PUBLIC_ERROR_RESPONSES,
+)
 async def get_sortables(request: Request) -> Dict[str, Any]:
     url = str(request.url)
     return OGCResponseProjector.build_sortables(url)
 
 
-@router.get("/collections/btaa-records/items")
+@router.get(
+    "/collections/btaa-records/items",
+    response_model=OGCFeatureCollectionResponse,
+    responses=PUBLIC_ERROR_RESPONSES,
+)
 async def get_items(
     request: Request,
     q: Optional[str] = Query(None, description="Keyword search query"),
@@ -126,7 +153,11 @@ async def get_items(
     return OGCResponseProjector.build_items_response(url, results, page, limit, "btaa-records")
 
 
-@router.get("/collections/btaa-records/items/{recordId}")
+@router.get(
+    "/collections/btaa-records/items/{recordId}",
+    response_model=OGCFeatureResponse,
+    responses=PUBLIC_ERROR_RESPONSES,
+)
 async def get_item(
     request: Request,
     recordId: str,

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+
+
+class PublicAPIModel(BaseModel):
+    """Permissive public API schema used to document stable envelopes."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class JSONAPIResource(PublicAPIModel):
+    type: str
+    id: str | None = None
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    links: dict[str, Any] | None = None
+    meta: dict[str, Any] | None = None
+    relationships: dict[str, Any] | None = None
+
+
+class JSONAPIResponse(PublicAPIModel):
+    jsonapi: dict[str, Any] | None = None
+    links: dict[str, Any] | None = None
+    meta: dict[str, Any] | None = None
+    data: JSONAPIResource | list[JSONAPIResource] | dict[str, Any] | list[dict[str, Any]] | None = (
+        None
+    )
+    included: list[dict[str, Any]] | None = None
+
+
+class APIInfoAttributes(PublicAPIModel):
+    api: str
+    version: str
+    description: str
+    endpoints: list[str] = Field(default_factory=list)
+
+
+class APIInfoResource(JSONAPIResource):
+    type: Literal["api_info"] = "api_info"
+    id: str = "root"
+    attributes: APIInfoAttributes
+
+
+class APIRootResponse(JSONAPIResponse):
+    data: APIInfoResource
+
+
+class ResourceResponse(JSONAPIResponse):
+    data: JSONAPIResource
+
+
+class ResourceCollectionResponse(JSONAPIResponse):
+    data: list[JSONAPIResource] = Field(default_factory=list)
+
+
+class SearchMeta(PublicAPIModel):
+    totalCount: int | None = None
+    totalPages: int | None = None
+    currentPage: int | None = None
+    perPage: int | None = None
+    query: str | None = None
+    sort: str | None = None
+    queryTime: dict[str, Any] | None = None
+    spellingSuggestions: list[Any] = Field(default_factory=list)
+
+
+class SearchResponse(JSONAPIResponse):
+    meta: SearchMeta | None = None
+    data: list[JSONAPIResource] = Field(default_factory=list)
+
+
+class SuggestionAttributes(PublicAPIModel):
+    text: str
+    score: float | int | None = None
+
+
+class SuggestionResource(JSONAPIResource):
+    type: Literal["suggestion"] = "suggestion"
+    id: str
+    attributes: SuggestionAttributes
+
+
+class SuggestResponse(JSONAPIResponse):
+    data: list[SuggestionResource] = Field(default_factory=list)
+
+
+class FacetValueAttributes(PublicAPIModel):
+    value: str | int | float | bool | None = None
+    hits: int = 0
+
+
+class FacetValueResource(JSONAPIResource):
+    type: Literal["facet_value"] = "facet_value"
+    id: str
+    attributes: FacetValueAttributes
+
+
+class FacetMeta(PublicAPIModel):
+    totalCount: int
+    totalPages: int
+    currentPage: int
+    perPage: int
+    facetName: str
+    sort: str
+
+
+class FacetResponse(JSONAPIResponse):
+    meta: FacetMeta
+    data: list[FacetValueResource] = Field(default_factory=list)
+
+
+class HomeBlogPost(PublicAPIModel):
+    slug: str | None = None
+    url: str | None = None
+    title: str | None = None
+    excerpt: str | None = None
+    published_at: datetime | str | None = None
+    category: str | None = None
+    authors: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    image_url: str | None = None
+    image_alt: str | None = None
+
+
+class HomeBlogMeta(PublicAPIModel):
+    pinned_slugs: list[str] = Field(default_factory=list)
+    total_count: int = 0
+    fetched_at: datetime | str | None = None
+
+
+class HomeBlogPostsResponse(PublicAPIModel):
+    data: list[HomeBlogPost] = Field(default_factory=list)
+    meta: HomeBlogMeta = Field(default_factory=HomeBlogMeta)
+
+
+class MapH3Response(PublicAPIModel):
+    resolution: int
+    hexes: list[tuple[str, int]] = Field(default_factory=list)
+    globalCount: int = 0
+
+
+class CitationStyles(PublicAPIModel):
+    apa: str
+    mla: str
+    chicago: str
+
+
+class ResourceCitationResponse(PublicAPIModel):
+    id: str
+    citation: str
+    citations: CitationStyles
+
+
+class SchemaOrgEntity(PublicAPIModel):
+    context: str | None = Field(default=None, alias="@context")
+    type: str | None = Field(default=None, alias="@type")
+    id: str | None = Field(default=None, alias="@id")
+
+
+class SchemaOrgCitationResponse(SchemaOrgEntity):
+    url: str | list[str] | None = None
+    name: str | None = None
+    description: str | None = None
+    datePublished: str | None = None
+    keywords: str | None = None
+    spatialCoverage: list[dict[str, Any]] | None = None
+    temporalCoverage: str | None = None
+    inLanguage: str | None = None
+    license: str | None = None
+    identifier: str | list[str] | None = None
+    author: list[dict[str, Any]] | None = None
+    publisher: dict[str, Any] | None = None
+    encodingFormat: str | None = None
+    accessMode: str | None = None
+    includedInDataCatalog: dict[str, Any] | None = None
+    distribution: list[dict[str, Any]] | None = None
+
+
+class DownloadOption(PublicAPIModel):
+    label: str | None = None
+    url: str | None = None
+    type: str | None = None
+    format: str | None = None
+    generated: bool | None = None
+    download_type: str | None = None
+    generation_path: str | None = None
+
+
+class ResourceDownloadsResponse(PublicAPIModel):
+    id: str
+    downloads: list[DownloadOption] = Field(default_factory=list)
+
+
+class GeneratedDownloadResponse(PublicAPIModel):
+    download_type: str
+    file_name: str
+    file_path: str
+    content_type: str
+    download_url: str
+
+
+class DistributionRecord(PublicAPIModel):
+    id: int | None = None
+    resource_id: str | None = None
+    url: str | None = None
+    label: str | None = None
+    position: int | None = None
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+    import_distribution_id: str | int | None = None
+    distribution_type_id: int | None = None
+    distribution_type_name: str | None = None
+    distribution_type: str | None = None
+    distribution_uri: str | None = None
+    distribution_note: str | None = None
+
+
+class ResourceDistributionsResponse(PublicAPIModel):
+    id: str
+    distributions: list[DistributionRecord] = Field(default_factory=list)
+
+
+class ResourceLink(PublicAPIModel):
+    label: str | None = None
+    url: str | None = None
+    format: str | None = None
+    service_type: str | None = None
+
+
+class ResourceLinksResponse(PublicAPIModel):
+    id: str
+    links: dict[str, list[ResourceLink]] = Field(default_factory=dict)
+
+
+class ResourceRelationship(PublicAPIModel):
+    resource_id: str
+    resource_title: str | None = None
+    link: str | None = None
+
+
+class ResourceRelationshipsResponse(PublicAPIModel):
+    id: str
+    relationships: dict[str, list[ResourceRelationship]] = Field(default_factory=dict)
+
+
+class SimilarItem(PublicAPIModel):
+    id: str
+    title: str | None = None
+    temporal_coverage: list[str] = Field(default_factory=list)
+    thumbnail_url: str | None = None
+    gbl_indexYear_im: list[int] = Field(default_factory=list)
+    gbl_resourceClass_sm: list[str] = Field(default_factory=list)
+
+
+class ResourceSimilarItemsResponse(PublicAPIModel):
+    id: str
+    similar_items: list[SimilarItem] = Field(default_factory=list)
+
+
+class ResourceSpatialFacetsResponse(PublicAPIModel):
+    id: str
+    spatial_facets: dict[str, Any] = Field(default_factory=dict)
+
+
+class ResourceViewer(PublicAPIModel):
+    protocol: str | None = None
+    endpoint: str | None = None
+    geometry: Any | None = None
+
+
+class ResourceViewerResponse(PublicAPIModel):
+    id: str
+    viewer: ResourceViewer | None = None
+
+
+class ResourceMetadataResponse(PublicAPIModel):
+    ogm: dict[str, Any] | None = None
+    b1g: dict[str, Any] | None = None
+
+
+class MetadataBlockResponse(RootModel[dict[str, Any]]):
+    """Extensible OGM or B1G metadata field block."""
+
+
+class DataDictionaryEntry(PublicAPIModel):
+    id: int
+    resource_data_dictionary_id: int
+    friendlier_id: str
+    field_name: str
+    field_type: str | None = None
+    values: str | None = None
+    definition: str | None = None
+    definition_source: str | None = None
+    parent_field_name: str | None = None
+    position: int = 0
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+
+
+class DataDictionary(PublicAPIModel):
+    id: int
+    friendlier_id: str
+    name: str | None = None
+    description: str | None = None
+    staff_notes: str | None = None
+    tags: str = ""
+    position: int = 0
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+    entries: list[DataDictionaryEntry] = Field(default_factory=list)
+
+
+class DataDictionaryListResponse(RootModel[list[DataDictionary]]):
+    """Resource data dictionary list."""
+
+
+class OGCLink(PublicAPIModel):
+    href: str
+    rel: str
+    type: str | None = None
+    title: str | None = None
+
+
+class OGCLandingPageResponse(PublicAPIModel):
+    title: str
+    description: str
+    links: list[OGCLink] = Field(default_factory=list)
+
+
+class OGCConformanceResponse(PublicAPIModel):
+    conformsTo: list[str] = Field(default_factory=list)
+
+
+class OGCCollectionResponse(PublicAPIModel):
+    id: str
+    title: str
+    description: str | None = None
+    itemType: str | None = None
+    links: list[OGCLink] = Field(default_factory=list)
+
+
+class OGCCollectionsResponse(PublicAPIModel):
+    collections: list[OGCCollectionResponse] = Field(default_factory=list)
+    links: list[OGCLink] = Field(default_factory=list)
+
+
+class OGCQueryablesResponse(PublicAPIModel):
+    schema_: str = Field(alias="$schema")
+    id_: str = Field(alias="$id")
+    type: Literal["object"] = "object"
+    title: str
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class OGCSortablesResponse(OGCQueryablesResponse):
+    pass
+
+
+class OGCFeatureProperties(PublicAPIModel):
+    id: str | None = None
+    title: str | None = None
+    description: str | None = None
+    resourceClass: list[str] = Field(default_factory=list)
+    resourceType: list[str] = Field(default_factory=list)
+    provider: str | None = None
+    spatial: list[str] = Field(default_factory=list)
+    subject: list[str] = Field(default_factory=list)
+    accessRights: str | None = None
+    modified: datetime | str | None = None
+    dateAccessioned: str | None = None
+    publicationState: str | None = None
+    accrualMethod: str | None = None
+
+
+class OGCFeatureResponse(PublicAPIModel):
+    type: Literal["Feature"] = "Feature"
+    id: str | None = None
+    geometry: dict[str, Any] | None = None
+    properties: OGCFeatureProperties
+    links: list[OGCLink] = Field(default_factory=list)
+
+
+class OGCFeatureCollectionResponse(PublicAPIModel):
+    type: Literal["FeatureCollection"] = "FeatureCollection"
+    timeStamp: datetime | str | int | float | None = None
+    numberMatched: int = 0
+    numberReturned: int = 0
+    features: list[OGCFeatureResponse] = Field(default_factory=list)
+    links: list[OGCLink] = Field(default_factory=list)
+
+
+class OGMRepoSummary(PublicAPIModel):
+    ogm_repo_name: str | None = None
+    ogm_enabled: bool | None = None
+    ogm_watch_mode: str | None = None
+    last_crawl_started_at: datetime | str | None = None
+    last_crawl_completed_at: datetime | str | None = None
+    last_crawl_status: str | None = None
+    last_run_id: int | None = None
+    harvested_success_count: int = 0
+    harvested_failure_count: int = 0
+    harvest_failure_samples: list[Any] = Field(default_factory=list)
+
+
+class OGMRepoSummariesResponse(PublicAPIModel):
+    repos: list[OGMRepoSummary] = Field(default_factory=list)
+
+
+class OGMHarvestFailure(PublicAPIModel):
+    ogm_id: int | None = None
+    ogm_repo_name: str | None = None
+    ogm_trigger: str | None = None
+    ogm_started_at: datetime | str | None = None
+    ogm_completed_at: datetime | str | None = None
+    ogm_status: str | None = None
+    ogm_stats_json: dict[str, Any] | None = None
+    ogm_dump_dir: str | None = None
+    ogm_error: str | None = None
+    import_error_count: int = 0
+    imported_count: int = 0
+    error_samples: list[Any] = Field(default_factory=list)
+    error_signatures: list[Any] = Field(default_factory=list)
+    failure_reason: str | None = None
+
+
+class OGMHarvestFailuresResponse(PublicAPIModel):
+    failures: list[OGMHarvestFailure] = Field(default_factory=list)
+    repo_name: str | None = None
+    include_with_errors: bool
+
+
+class MCPInfoConnection(PublicAPIModel):
+    type: str
+    command: str | None = None
+    args: list[str] | None = None
+    url: str | None = None
+
+
+class MCPInfoResponse(PublicAPIModel):
+    name: str
+    version: str
+    description: str
+    protocol: str
+    transports: list[str] = Field(default_factory=list)
+    capabilities: dict[str, Any] = Field(default_factory=dict)
+    connections: dict[str, MCPInfoConnection] = Field(default_factory=dict)
+    documentation: dict[str, Any] = Field(default_factory=dict)
+
+
+class JSONRPCError(PublicAPIModel):
+    code: int
+    message: str
+
+
+class JSONRPCResponse(PublicAPIModel):
+    jsonrpc: Literal["2.0"] = "2.0"
+    id: str | int | None = None
+    result: dict[str, Any] | None = None
+    error: JSONRPCError | None = None
+
+
+class GenericObjectResponse(RootModel[dict[str, Any]]):
+    """Compatibility JSON object for non-public or intentionally opaque responses."""
+
+
+class GenericArrayResponse(RootModel[list[dict[str, Any]]]):
+    """Compatibility JSON array for non-public or intentionally opaque responses."""

--- a/backend/app/api/v1/endpoint_modules/gazetteer.py
+++ b/backend/app/api/v1/endpoint_modules/gazetteer.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy import and_, func, or_, select
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
+from app.api.schemas import GenericObjectResponse, JSONAPIResponse
 from app.api.v1.strong_params import GAZETTEER_ALLOWED_PARAMS
 from app.api.v1.utils import (
     create_gazetteer_meta_and_links,
@@ -36,7 +38,7 @@ from db.models import (
 # Load environment variables from .env file
 load_dotenv()
 
-router = APIRouter()
+router = APIRouter(responses=PUBLIC_ERROR_RESPONSES)
 logger = logging.getLogger(__name__)
 
 # Cache TTL for gazetteer endpoints (1 hour)
@@ -44,7 +46,7 @@ GAZETTEER_CACHE_TTL = int(os.getenv("GAZETTEER_CACHE_TTL", 3600))
 NOMINATIM_CACHE_TTL = int(os.getenv("NOMINATIM_CACHE_TTL", 30 * 24 * 60 * 60))
 
 
-@router.get("/gazetteers")
+@router.get("/gazetteers", response_model=JSONAPIResponse)
 @cached_endpoint(ttl=GAZETTEER_CACHE_TTL)
 async def list_gazetteers(
     request: Request,
@@ -129,7 +131,7 @@ async def list_gazetteers(
         raise HTTPException(status_code=500, detail="Failed to list gazetteers") from e
 
 
-@router.get("/gazetteers/search")
+@router.get("/gazetteers/search", response_model=GenericObjectResponse)
 @cached_endpoint(ttl=GAZETTEER_CACHE_TTL)
 async def search_all_gazetteers(
     request: Request,
@@ -177,7 +179,7 @@ async def search_all_gazetteers(
         raise HTTPException(status_code=500, detail="Failed to search gazetteers") from e
 
 
-@router.get("/gazetteers/nominatim/search")
+@router.get("/gazetteers/nominatim/search", response_model=JSONAPIResponse)
 @cached_endpoint(ttl=NOMINATIM_CACHE_TTL, tags=["suggest", "gazetteer", "nominatim"])
 async def search_nominatim(
     request: Request,
@@ -212,7 +214,7 @@ async def search_nominatim(
         raise HTTPException(status_code=502, detail="Nominatim request failed") from exc
 
 
-@router.get("/gazetteers/btaa/search")
+@router.get("/gazetteers/btaa/search", response_model=JSONAPIResponse)
 @cached_endpoint(ttl=GAZETTEER_CACHE_TTL)
 async def search_btaa(
     request: Request,
@@ -286,7 +288,7 @@ async def search_btaa(
         raise HTTPException(status_code=500, detail="Failed to search BTAA") from e
 
 
-@router.get("/gazetteers/geonames/search")
+@router.get("/gazetteers/geonames/search", response_model=JSONAPIResponse)
 @cached_endpoint(ttl=GAZETTEER_CACHE_TTL)
 async def search_geonames(
     request: Request,
@@ -368,7 +370,7 @@ async def search_geonames(
         raise HTTPException(status_code=500, detail="Failed to search GeoNames") from e
 
 
-@router.get("/gazetteers/wof/search")
+@router.get("/gazetteers/wof/search", response_model=JSONAPIResponse)
 @cached_endpoint(ttl=GAZETTEER_CACHE_TTL)
 async def search_wof(
     request: Request,
@@ -582,4 +584,4 @@ async def search_wof(
     except Exception as e:
         error_msg = str(e)
         logger.error(f"Error searching WOF: {error_msg}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to search WOF: {error_msg}") from e
+        raise HTTPException(status_code=500, detail="Failed to search WOF") from e

--- a/backend/app/api/v1/endpoint_modules/home.py
+++ b/backend/app/api/v1/endpoint_modules/home.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from fastapi import APIRouter, Query, Request
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
+from app.api.schemas import HomeBlogPostsResponse
 from app.api.v1.utils import create_response
 from app.services.cache_service import cached_endpoint
 from app.services.gin_blog_service import GINBlogService
@@ -23,7 +25,11 @@ def _empty_home_blog_payload() -> dict:
     }
 
 
-@router.get("/home/blog-posts")
+@router.get(
+    "/home/blog-posts",
+    response_model=HomeBlogPostsResponse,
+    responses=PUBLIC_ERROR_RESPONSES,
+)
 @cached_endpoint(ttl=HOME_BLOG_CACHE_TTL, tags=["home", "home_blog"])
 async def list_home_blog_posts(
     request: Request,

--- a/backend/app/api/v1/endpoint_modules/map.py
+++ b/backend/app/api/v1/endpoint_modules/map.py
@@ -5,6 +5,8 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
+from app.api.schemas import MapH3Response
 from app.api.v1.advanced_search_utils import validate_adv_q
 from app.elasticsearch.search import map_h3_aggregation
 from app.services.cache_service import cached_endpoint
@@ -18,7 +20,7 @@ router = APIRouter()
 MAP_H3_CACHE_TTL = 7200  # 2 hours
 
 
-@router.get("/map/h3")
+@router.get("/map/h3", response_model=MapH3Response, responses=PUBLIC_ERROR_RESPONSES)
 @cached_endpoint(ttl=MAP_H3_CACHE_TTL, tags=["map"])
 async def map_h3(
     request: Request,
@@ -46,12 +48,9 @@ async def map_h3(
         try:
             parsed_adv_q = validate_adv_q(json.loads(adv_q))
         except json.JSONDecodeError:
-            return JSONResponse(
-                content={"error": "Invalid JSON in adv_q parameter"},
-                status_code=400,
-            )
-        except HTTPException as exc:
-            return JSONResponse(content={"error": exc.detail}, status_code=exc.status_code)
+            raise HTTPException(status_code=400, detail="Invalid JSON in adv_q parameter") from None
+        except HTTPException:
+            raise
 
     try:
         raw = (
@@ -77,7 +76,4 @@ async def map_h3(
     except Exception as e:
         logger.exception("map/h3 failed: %s", e)
         # Return 5xx so cached_endpoint does not cache error responses
-        return JSONResponse(
-            content={"resolution": resolution, "hexes": [], "globalCount": 0},
-            status_code=500,
-        )
+        raise HTTPException(status_code=500, detail="Failed to build map aggregates") from e

--- a/backend/app/api/v1/endpoint_modules/mcp.py
+++ b/backend/app/api/v1/endpoint_modules/mcp.py
@@ -3,19 +3,21 @@ import logging
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, Response
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
+from app.api.schemas import JSONRPCResponse, MCPInfoResponse
 from app.services.mcp_service import get_mcp_service_info, handle_mcp_message
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/mcp")
+@router.get("/mcp", response_model=MCPInfoResponse, responses=PUBLIC_ERROR_RESPONSES)
 async def mcp_endpoint():
     """Return MCP service information and connection details."""
     return JSONResponse(content=get_mcp_service_info())
 
 
-@router.post("/mcp")
+@router.post("/mcp", response_model=JSONRPCResponse, responses=PUBLIC_ERROR_RESPONSES)
 async def mcp_http_transport(request: Request):
     """Handle JSON-RPC-over-HTTP requests for MCP bridge compatibility."""
     try:

--- a/backend/app/api/v1/endpoint_modules/ogm.py
+++ b/backend/app/api/v1/endpoint_modules/ogm.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 from fastapi import APIRouter, Query
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
+from app.api.schemas import OGMHarvestFailuresResponse, OGMRepoSummariesResponse
 from app.api.v1.utils import create_response
 from app.services.ogm_harvest.repository import OGMHarvestRepository
 
@@ -9,7 +11,7 @@ router = APIRouter()
 ogm_repo = OGMHarvestRepository()
 
 
-@router.get("/ogm/repos")
+@router.get("/ogm/repos", response_model=OGMRepoSummariesResponse, responses=PUBLIC_ERROR_RESPONSES)
 async def list_public_ogm_repos():
     """
     Public OGM repo summaries with latest crawl status and harvest counts.
@@ -18,7 +20,11 @@ async def list_public_ogm_repos():
     return create_response({"repos": repos})
 
 
-@router.get("/ogm/harvest/failures")
+@router.get(
+    "/ogm/harvest/failures",
+    response_model=OGMHarvestFailuresResponse,
+    responses=PUBLIC_ERROR_RESPONSES,
+)
 async def list_public_ogm_harvest_failures(
     repo_name: Optional[str] = Query(None, description="Filter by a single ogm_repo_name"),
     include_with_errors: bool = Query(

--- a/backend/app/api/v1/endpoint_modules/resources/__init__.py
+++ b/backend/app/api/v1/endpoint_modules/resources/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional
 from dotenv import load_dotenv
 from fastapi import APIRouter
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
 from db.session import async_engine as engine
 from db.session import async_session
 
@@ -12,7 +13,7 @@ from db.session import async_session
 load_dotenv()
 
 # Create router
-router = APIRouter()
+router = APIRouter(responses=PUBLIC_ERROR_RESPONSES)
 
 # Logger
 logger = logging.getLogger(__name__)

--- a/backend/app/api/v1/endpoint_modules/resources/citation.py
+++ b/backend/app/api/v1/endpoint_modules/resources/citation.py
@@ -1,10 +1,11 @@
 import os
 from typing import Optional
 
-from fastapi import Query, Request
+from fastapi import HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlalchemy.sql import select
 
+from app.api.schemas import ResourceCitationResponse, SchemaOrgCitationResponse
 from app.api.v1.utils import create_response, sanitize_for_json
 from app.services.citation_formats_service import CitationFormatsService
 from app.services.citation_service import CitationService
@@ -26,7 +27,7 @@ def _geoportal_base_url() -> str:
     return app_url
 
 
-@router.get("/resources/{id}/citation")
+@router.get("/resources/{id}/citation", response_model=ResourceCitationResponse)
 async def get_resource_citation(
     request: Request,
     id: str,
@@ -41,7 +42,7 @@ async def get_resource_citation(
             row = result.fetchone()
 
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
 
             resource_dict = sanitize_for_json(dict(row._mapping))
 
@@ -57,12 +58,14 @@ async def get_resource_citation(
         }
 
         return create_response(response_payload, callback)
+    except HTTPException:
+        raise
     except Exception:
         logger.error("Error getting citation for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get citation"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get citation") from None
 
 
-@router.get("/resources/{id}/citation/json-ld")
+@router.get("/resources/{id}/citation/json-ld", response_model=SchemaOrgCitationResponse)
 async def get_resource_citation_json_ld(id: str):
     """Get Schema.org JSON-LD metadata for citation tools (Zotero, Google Dataset Search)."""
     try:
@@ -71,7 +74,7 @@ async def get_resource_citation_json_ld(id: str):
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
             resource_dict = sanitize_for_json(dict(row._mapping))
         distribution_context = await fetch_distribution_context(id)
         service = CitationFormatsService(
@@ -81,12 +84,14 @@ async def get_resource_citation_json_ld(id: str):
         )
         ld = service.to_json_ld(id)
         return JSONResponse(content=ld, media_type="application/ld+json")
+    except HTTPException:
+        raise
     except Exception:
         logger.error("Error getting JSON-LD for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get citation metadata"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get citation metadata") from None
 
 
-@router.get("/resources/{id}/citation/ris")
+@router.get("/resources/{id}/citation/ris", response_class=PlainTextResponse)
 async def get_resource_citation_ris(id: str):
     """Get RIS format for EndNote, Zotero, Mendeley import."""
     try:
@@ -95,7 +100,7 @@ async def get_resource_citation_ris(id: str):
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
             resource_dict = sanitize_for_json(dict(row._mapping))
         distribution_context = await fetch_distribution_context(id)
         service = CitationFormatsService(
@@ -109,12 +114,14 @@ async def get_resource_citation_ris(id: str):
             media_type="application/x-research-info-systems",
             headers={"Content-Disposition": f'attachment; filename="{id}.ris"'},
         )
+    except HTTPException:
+        raise
     except Exception:
         logger.error("Error getting RIS for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get RIS citation"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get RIS citation") from None
 
 
-@router.get("/resources/{id}/citation/bibtex")
+@router.get("/resources/{id}/citation/bibtex", response_class=PlainTextResponse)
 async def get_resource_citation_bibtex(id: str):
     """Get BibTeX format for LaTeX and citation tools."""
     try:
@@ -123,7 +130,7 @@ async def get_resource_citation_bibtex(id: str):
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
             resource_dict = sanitize_for_json(dict(row._mapping))
         distribution_context = await fetch_distribution_context(id)
         service = CitationFormatsService(
@@ -137,6 +144,8 @@ async def get_resource_citation_bibtex(id: str):
             media_type="application/x-bibtex",
             headers={"Content-Disposition": f'attachment; filename="{id}.bib"'},
         )
+    except HTTPException:
+        raise
     except Exception:
         logger.error("Error getting BibTeX for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get BibTeX citation"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get BibTeX citation") from None

--- a/backend/app/api/v1/endpoint_modules/resources/data_dictionaries.py
+++ b/backend/app/api/v1/endpoint_modules/resources/data_dictionaries.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
+from app.api.schemas import DataDictionaryListResponse
 from app.api.v1.utils import sanitize_for_json
 from app.services.data_dictionary_repository import (
     fetch_resource_data_dictionaries,
@@ -10,7 +11,7 @@ from app.services.data_dictionary_repository import (
 from . import get_async_session, logger, router
 
 
-@router.get("/resources/{id}/data-dictionaries")
+@router.get("/resources/{id}/data-dictionaries", response_model=DataDictionaryListResponse)
 async def get_resource_data_dictionaries(id: str):
     """Get data dictionaries for a single resource."""
     try:
@@ -22,4 +23,4 @@ async def get_resource_data_dictionaries(id: str):
         raise
     except Exception:
         logger.error("Error getting data dictionaries for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get data dictionaries"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get data dictionaries") from None

--- a/backend/app/api/v1/endpoint_modules/resources/distributions.py
+++ b/backend/app/api/v1/endpoint_modules/resources/distributions.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
 from fastapi import HTTPException, Query, Request
-from fastapi.responses import JSONResponse
 from sqlalchemy import text
 from sqlalchemy.sql import select
 
+from app.api.schemas import ResourceDistributionsResponse
 from app.api.v1.utils import create_response, sanitize_for_json
 from app.services.cache_service import cached_endpoint
 from db.models import resources
@@ -12,7 +12,7 @@ from db.models import resources
 from . import RESOURCE_CACHE_TTL, async_session, logger, router
 
 
-@router.get("/resources/{id}/distributions")
+@router.get("/resources/{id}/distributions", response_model=ResourceDistributionsResponse)
 @cached_endpoint(ttl=RESOURCE_CACHE_TTL)
 async def get_resource_distributions(
     request: Request,
@@ -28,7 +28,7 @@ async def get_resource_distributions(
             resource_row = resource_result.fetchone()
 
             if not resource_row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
 
             # Get distributions with distribution type information
             distributions_query = text("""
@@ -68,6 +68,8 @@ async def get_resource_distributions(
 
             return create_response(response_payload, callback)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Error getting distributions for resource %s", id, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to get distributions") from e

--- a/backend/app/api/v1/endpoint_modules/resources/downloads.py
+++ b/backend/app/api/v1/endpoint_modules/resources/downloads.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from sqlalchemy.sql import select
 
+from app.api.schemas import GeneratedDownloadResponse, ResourceDownloadsResponse
 from app.api.v1.utils import create_response, sanitize_for_json
 from app.services.distribution_repository import fetch_distribution_context
 from app.services.download_service import DownloadService
@@ -13,7 +14,7 @@ from db.models import resources
 from . import async_session, logger, router
 
 
-@router.get("/resources/{id}/downloads")
+@router.get("/resources/{id}/downloads", response_model=ResourceDownloadsResponse)
 async def get_resource_downloads(
     request: Request,
     id: str,
@@ -28,7 +29,7 @@ async def get_resource_downloads(
             row = result.fetchone()
 
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
 
             resource_dict = sanitize_for_json(dict(row._mapping))
 
@@ -43,12 +44,17 @@ async def get_resource_downloads(
         }
 
         return create_response(response_payload, callback)
+    except HTTPException:
+        raise
     except Exception:
         logger.error("Error getting downloads for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get downloads"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get downloads") from None
 
 
-@router.get("/resources/{id}/downloads/generated/{download_type}")
+@router.get(
+    "/resources/{id}/downloads/generated/{download_type}",
+    response_model=GeneratedDownloadResponse,
+)
 async def prepare_generated_download(id: str, download_type: str):
     """Prepare a generated download and return its API file URL."""
     try:
@@ -57,7 +63,7 @@ async def prepare_generated_download(id: str, download_type: str):
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
             resource_dict = sanitize_for_json(dict(row._mapping))
 
         distribution_context = await fetch_distribution_context(id)
@@ -65,7 +71,7 @@ async def prepare_generated_download(id: str, download_type: str):
         payload = await download_service.ensure_generated_download(download_type)
         return JSONResponse(content=payload)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail="Invalid generated download request") from exc
     except requests.HTTPError as exc:
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         raise HTTPException(
@@ -82,7 +88,7 @@ async def prepare_generated_download(id: str, download_type: str):
         raise HTTPException(status_code=500, detail="Failed to prepare generated download") from exc
 
 
-@router.get("/resources/{id}/downloads/generated/{download_type}/file")
+@router.get("/resources/{id}/downloads/generated/{download_type}/file", response_class=FileResponse)
 async def fetch_generated_download_file(id: str, download_type: str):
     """
     Return the generated file. If it does not exist yet, generate it first.
@@ -93,7 +99,7 @@ async def fetch_generated_download_file(id: str, download_type: str):
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
             resource_dict = sanitize_for_json(dict(row._mapping))
 
         distribution_context = await fetch_distribution_context(id)
@@ -112,7 +118,7 @@ async def fetch_generated_download_file(id: str, download_type: str):
             filename=file_name,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail="Invalid generated download request") from exc
     except requests.HTTPError as exc:
         status_code = getattr(getattr(exc, "response", None), "status_code", 502)
         raise HTTPException(

--- a/backend/app/api/v1/endpoint_modules/resources/get.py
+++ b/backend/app/api/v1/endpoint_modules/resources/get.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.sql import select
 
+from app.api.schemas import ResourceResponse
 from app.api.v1.utils import (
     add_licensed_accesses_to_resource,
     add_similar_items_to_resource,
@@ -19,7 +20,7 @@ from db.models import resources
 from . import RESOURCE_CACHE_TTL, filter_resource_fields, get_async_session, logger, router
 
 
-@router.get("/resources/{id}")
+@router.get("/resources/{id}", response_model=ResourceResponse)
 @cached_endpoint(ttl=RESOURCE_CACHE_TTL)
 async def get_resource(
     request: Request,
@@ -42,7 +43,7 @@ async def get_resource(
             row = result.fetchone()
 
         if not row:
-            return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+            raise HTTPException(status_code=404, detail="Resource not found")
 
         # Convert to dict and sanitize for JSON serialization after releasing the row
         # fetch connection. Resource rendering performs its own short DB lookups.
@@ -94,4 +95,4 @@ async def get_resource(
         raise
     except Exception:
         logger.error("Error getting resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get resource"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get resource") from None

--- a/backend/app/api/v1/endpoint_modules/resources/links.py
+++ b/backend/app/api/v1/endpoint_modules/resources/links.py
@@ -1,15 +1,15 @@
 from typing import Optional
 
-from fastapi import Query
-from fastapi.responses import JSONResponse
+from fastapi import HTTPException, Query
 
+from app.api.schemas import ResourceLinksResponse
 from app.api.v1.utils import create_response
 from app.services.link_service import LinkService
 
 from . import logger, router
 
 
-@router.get("/resources/{id}/links")
+@router.get("/resources/{id}/links", response_model=ResourceLinksResponse)
 async def get_resource_links(
     id: str,
     callback: Optional[str] = Query(None, description="JSONP callback name"),
@@ -26,4 +26,4 @@ async def get_resource_links(
         return create_response(response_payload, callback)
     except Exception:
         logger.error("Error getting links for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get links"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get links") from None

--- a/backend/app/api/v1/endpoint_modules/resources/list.py
+++ b/backend/app/api/v1/endpoint_modules/resources/list.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.sql import select
 
+from app.api.schemas import ResourceCollectionResponse
 from app.api.v1.utils import create_jsonapi_response, process_resource, sanitize_for_json
 from app.services.cache_service import cached_endpoint
 from db.models import resources
@@ -11,7 +12,7 @@ from db.models import resources
 from . import LIST_CACHE_TTL, filter_resource_fields, get_async_session, logger, router
 
 
-@router.get("/resources/")
+@router.get("/resources/", response_model=ResourceCollectionResponse)
 @cached_endpoint(ttl=LIST_CACHE_TTL)
 async def list_resources(
     request: Request,

--- a/backend/app/api/v1/endpoint_modules/resources/metadata.py
+++ b/backend/app/api/v1/endpoint_modules/resources/metadata.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, Query
 from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy.sql import select
 
+from app.api.schemas import MetadataBlockResponse, ResourceMetadataResponse
 from app.api.v1.utils import filter_empty_values, sanitize_for_json
 from app.services.distribution_repository import (
     DistributionContext,
@@ -102,7 +103,7 @@ def _separate_ogm_and_b1g_fields(resource_dict: dict) -> tuple[dict, dict]:
     return ogm_fields, b1g_fields
 
 
-@router.get("/resources/{id}/metadata")
+@router.get("/resources/{id}/metadata", response_model=ResourceMetadataResponse)
 async def get_resource_metadata(
     id: str,
     fields: Optional[str] = Query(None, description="Comma-separated list of fields to return"),
@@ -115,7 +116,7 @@ async def get_resource_metadata(
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
 
             # Convert to dict and sanitize datetime objects
             resource_dict = sanitize_for_json(dict(row._mapping))
@@ -151,10 +152,10 @@ async def get_resource_metadata(
         raise
     except Exception:
         logger.error("Error getting metadata for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get metadata"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get metadata") from None
 
 
-@router.get("/resources/{id}/metadata/ogm")
+@router.get("/resources/{id}/metadata/ogm", response_model=MetadataBlockResponse)
 async def get_resource_metadata_ogm(
     id: str,
     fields: Optional[str] = Query(None, description="Comma-separated list of fields to return"),
@@ -167,7 +168,7 @@ async def get_resource_metadata_ogm(
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
 
             # Convert to dict and sanitize datetime objects
             resource_dict = sanitize_for_json(dict(row._mapping))
@@ -196,10 +197,10 @@ async def get_resource_metadata_ogm(
         raise
     except Exception:
         logger.error("Error getting OGM metadata for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get OGM metadata"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get OGM metadata") from None
 
 
-@router.get("/resources/{id}/metadata/b1g")
+@router.get("/resources/{id}/metadata/b1g", response_model=MetadataBlockResponse)
 async def get_resource_metadata_b1g(
     id: str,
     fields: Optional[str] = Query(None, description="Comma-separated list of fields to return"),
@@ -212,7 +213,7 @@ async def get_resource_metadata_b1g(
             result = await session.execute(query)
             row = result.fetchone()
             if not row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
 
             # Convert to dict and sanitize datetime objects
             resource_dict = sanitize_for_json(dict(row._mapping))
@@ -232,7 +233,7 @@ async def get_resource_metadata_b1g(
         raise
     except Exception:
         logger.error("Error getting B1G metadata for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get B1G metadata"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get B1G metadata") from None
 
 
 def _get_metadata_url_for_format(

--- a/backend/app/api/v1/endpoint_modules/resources/ogm_viewer.py
+++ b/backend/app/api/v1/endpoint_modules/resources/ogm_viewer.py
@@ -3,7 +3,7 @@ import os
 from urllib.parse import quote
 
 from fastapi import HTTPException, Query
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse
 from sqlalchemy.sql import select
 
 from db.models import resources
@@ -11,7 +11,7 @@ from db.models import resources
 from . import get_async_session, logger, router
 
 
-@router.get("/resources/{id}/ogm-viewer")
+@router.get("/resources/{id}/ogm-viewer", response_class=HTMLResponse)
 async def get_resource_viewer(
     id: str,
     embed: bool = Query(False, description="Embedded mode for iframe usage"),
@@ -85,4 +85,4 @@ async def get_resource_viewer(
         raise
     except Exception as e:
         logger.error(f"Error creating viewer page for resource {id}: {str(e)}", exc_info=True)
-        return JSONResponse(content={"error": "Failed to create viewer page"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to create viewer page") from e

--- a/backend/app/api/v1/endpoint_modules/resources/relationships.py
+++ b/backend/app/api/v1/endpoint_modules/resources/relationships.py
@@ -1,15 +1,15 @@
 from typing import Optional
 
-from fastapi import Query
-from fastapi.responses import JSONResponse
+from fastapi import HTTPException, Query
 
+from app.api.schemas import ResourceRelationshipsResponse
 from app.api.v1.utils import create_response
 from app.services.relationship_service import RelationshipService
 
 from . import logger, router
 
 
-@router.get("/resources/{id}/relationships")
+@router.get("/resources/{id}/relationships", response_model=ResourceRelationshipsResponse)
 async def get_resource_relationships(
     id: str,
     callback: Optional[str] = Query(None, description="JSONP callback name"),
@@ -26,4 +26,4 @@ async def get_resource_relationships(
         return create_response(response_payload, callback)
     except Exception:
         logger.error("Error getting relationships for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get relationships"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get relationships") from None

--- a/backend/app/api/v1/endpoint_modules/resources/similar_items.py
+++ b/backend/app/api/v1/endpoint_modules/resources/similar_items.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
 from fastapi import HTTPException, Query, Request
-from fastapi.responses import JSONResponse
 from sqlalchemy.sql import select
 
+from app.api.schemas import ResourceSimilarItemsResponse
 from app.api.v1.utils import create_response
 from app.services.cache_service import cached_endpoint
 from app.services.similar_items_service import SimilarItemsService
@@ -12,7 +12,7 @@ from db.models import resources
 from . import RESOURCE_CACHE_TTL, async_session, logger, router
 
 
-@router.get("/resources/{id}/similar-items")
+@router.get("/resources/{id}/similar-items", response_model=ResourceSimilarItemsResponse)
 @cached_endpoint(ttl=RESOURCE_CACHE_TTL)
 async def get_resource_similar_items(
     request: Request,
@@ -28,7 +28,7 @@ async def get_resource_similar_items(
             resource_row = resource_result.fetchone()
 
             if not resource_row:
-                return JSONResponse(content={"error": "Resource not found"}, status_code=404)
+                raise HTTPException(status_code=404, detail="Resource not found")
 
             # Get similar items
             similar_items = await SimilarItemsService.get_similar_items(id, session, limit=12)
@@ -40,6 +40,8 @@ async def get_resource_similar_items(
 
             return create_response(response_payload, callback)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Error getting similar items for resource %s", id, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to get similar items") from e

--- a/backend/app/api/v1/endpoint_modules/resources/spatial_facets.py
+++ b/backend/app/api/v1/endpoint_modules/resources/spatial_facets.py
@@ -3,6 +3,7 @@ from typing import Optional
 from fastapi import HTTPException, Query, Request
 from sqlalchemy.sql import select
 
+from app.api.schemas import ResourceSpatialFacetsResponse
 from app.api.v1.utils import create_response
 from app.services.spatial_facet_service import SpatialFacetService
 from db.models import resources
@@ -10,7 +11,7 @@ from db.models import resources
 from . import get_async_session, logger, router
 
 
-@router.get("/resources/{id}/spatial-facets")
+@router.get("/resources/{id}/spatial-facets", response_model=ResourceSpatialFacetsResponse)
 async def get_resource_spatial_facets(
     request: Request,
     id: str,
@@ -56,6 +57,4 @@ async def get_resource_spatial_facets(
 
     except Exception as e:
         logger.error(f"Error getting spatial facets for resource {id}: {str(e)}", exc_info=True)
-        raise HTTPException(
-            status_code=500, detail=f"Error retrieving spatial facets: {str(e)}"
-        ) from e
+        raise HTTPException(status_code=500, detail="Failed to get spatial facets") from e

--- a/backend/app/api/v1/endpoint_modules/resources/static_map.py
+++ b/backend/app/api/v1/endpoint_modules/resources/static_map.py
@@ -32,7 +32,7 @@ def _svg_placeholder(*, title: str, subtitle: str) -> Response:
     )
 
 
-@router.get("/resources/{id}/static-map")
+@router.get("/resources/{id}/static-map", response_class=Response)
 async def get_resource_static_map(
     id: str,
     request: Request,
@@ -110,7 +110,7 @@ async def get_resource_static_map(
         )
 
 
-@router.get("/resources/{id}/static-map/no-cache")
+@router.get("/resources/{id}/static-map/no-cache", response_class=Response)
 async def get_resource_static_map_no_cache(
     id: str,
     request: Request,

--- a/backend/app/api/v1/endpoint_modules/resources/thumbnail.py
+++ b/backend/app/api/v1/endpoint_modules/resources/thumbnail.py
@@ -638,7 +638,7 @@ async def _get_resource_thumbnail_response(
     return await _svg_icon_for_resource(resource_dict, variant=variant)
 
 
-@router.get("/resources/{id}/thumbnail")
+@router.get("/resources/{id}/thumbnail", response_class=Response)
 async def get_resource_thumbnail(
     id: str,
     request: Request,
@@ -675,7 +675,7 @@ async def get_resource_thumbnail(
         return _svg_placeholder(title="Thumbnail unavailable", subtitle="Error loading thumbnail")
 
 
-@router.get("/resources/{id}/thumbnail/no-cache")
+@router.get("/resources/{id}/thumbnail/no-cache", response_class=Response)
 async def get_resource_thumbnail_no_cache(
     id: str,
     request: Request,

--- a/backend/app/api/v1/endpoint_modules/resources/viewer.py
+++ b/backend/app/api/v1/endpoint_modules/resources/viewer.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
 from fastapi import HTTPException, Query, Request
-from fastapi.responses import JSONResponse
 from sqlalchemy.sql import select
 
+from app.api.schemas import ResourceViewerResponse
 from app.api.v1.utils import create_response, sanitize_for_json
 from app.services.distribution_repository import fetch_distribution_context
 from app.services.viewer_service import ViewerService
@@ -12,7 +12,7 @@ from db.models import resources
 from . import async_session, logger, router
 
 
-@router.get("/resources/{id}/viewer")
+@router.get("/resources/{id}/viewer", response_model=ResourceViewerResponse)
 async def get_resource_viewer_data(
     request: Request,
     id: str,
@@ -56,4 +56,4 @@ async def get_resource_viewer_data(
         raise
     except Exception:
         logger.error("Error getting viewer data for resource %s", id, exc_info=True)
-        return JSONResponse(content={"error": "Failed to get viewer data"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get viewer data") from None

--- a/backend/app/api/v1/endpoint_modules/root.py
+++ b/backend/app/api/v1/endpoint_modules/root.py
@@ -3,14 +3,16 @@ import logging
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
+from app.api.schemas import APIRootResponse
 from app.api.v1.utils import create_jsonapi_response
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(responses=PUBLIC_ERROR_RESPONSES)
 
 
-@router.get("/")
+@router.get("/", response_model=APIRootResponse)
 async def api_root(request: Request):
     """Return basic API information including version."""
     api_info = {

--- a/backend/app/api/v1/endpoint_modules/search.py
+++ b/backend/app/api/v1/endpoint_modules/search.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import select
 
 from app.api.errors import COMMON_ERROR_RESPONSES, api_error_response, get_request_id
+from app.api.schemas import FacetResponse, SearchResponse, SuggestResponse
 from app.api.v1.advanced_search_utils import validate_adv_q
 from app.api.v1.strong_params import FACET_ALLOWED_PARAMS
 from app.api.v1.utils import (
@@ -745,7 +746,7 @@ async def _handle_search(request: Request, params: dict) -> JSONResponse:
     return _attach_search_timing_headers(response, timings)
 
 
-@router.get("/search", responses=COMMON_ERROR_RESPONSES)
+@router.get("/search", response_model=SearchResponse, responses=COMMON_ERROR_RESPONSES)
 @cached_endpoint(ttl=SEARCH_CACHE_TTL)
 async def search(
     request: Request,
@@ -790,9 +791,12 @@ async def search(
             try:
                 parsed_adv_q = json.loads(adv_q)
             except json.JSONDecodeError:
-                return JSONResponse(
-                    content={"error": "Invalid JSON in adv_q parameter"},
+                return api_error_response(
                     status_code=400,
+                    code="invalid_advanced_query",
+                    title="Bad request",
+                    detail="Invalid JSON in adv_q parameter",
+                    request_id=get_request_id(request),
                 )
 
         # Get the raw query string from the request scope before FastAPI parses it
@@ -852,7 +856,7 @@ async def search(
         return _search_error_response(request, code="search_request_failed")
 
 
-@router.post("/search", responses=COMMON_ERROR_RESPONSES)
+@router.post("/search", response_model=SearchResponse, responses=COMMON_ERROR_RESPONSES)
 @cached_endpoint(ttl=SEARCH_CACHE_TTL)
 async def search_post(
     request: Request,
@@ -929,7 +933,11 @@ async def search_post(
         return _search_error_response(request, code="search_request_failed")
 
 
-@router.get("/search/facets/{facet_name}", responses=COMMON_ERROR_RESPONSES)
+@router.get(
+    "/search/facets/{facet_name}",
+    response_model=FacetResponse,
+    responses=COMMON_ERROR_RESPONSES,
+)
 @cached_endpoint(ttl=SEARCH_CACHE_TTL)
 async def get_facet(
     facet_name: str,
@@ -963,18 +971,23 @@ async def get_facet(
         try:
             get_facet_aggregation_config(facet_name)
         except ValueError:
-            return JSONResponse(
-                content={"error": f"Invalid facet name: {facet_name}"}, status_code=400
+            return api_error_response(
+                status_code=400,
+                code="invalid_facet",
+                title="Bad request",
+                detail=f"Invalid facet name: {facet_name}",
+                request_id=get_request_id(request),
             )
 
         # Validate sort parameter
         valid_sorts = {"count_desc", "count_asc", "alpha_asc", "alpha_desc"}
         if sort not in valid_sorts:
-            return JSONResponse(
-                content={
-                    "error": f"Invalid sort parameter. Must be one of: {', '.join(valid_sorts)}"
-                },
+            return api_error_response(
                 status_code=400,
+                code="invalid_sort",
+                title="Bad request",
+                detail=(f"Invalid sort parameter. Must be one of: {', '.join(valid_sorts)}"),
+                request_id=get_request_id(request),
             )
 
         # Parse adv_q from JSON string if provided
@@ -983,9 +996,12 @@ async def get_facet(
             try:
                 parsed_adv_q = json.loads(adv_q)
             except json.JSONDecodeError:
-                return JSONResponse(
-                    content={"error": "Invalid JSON in adv_q parameter"},
+                return api_error_response(
                     status_code=400,
+                    code="invalid_advanced_query",
+                    title="Bad request",
+                    detail="Invalid JSON in adv_q parameter",
+                    request_id=get_request_id(request),
                 )
 
         # Extract filters from query parameters (similar to search endpoint)
@@ -1063,7 +1079,13 @@ async def get_facet(
     except HTTPException:
         raise
     except ValueError:
-        return JSONResponse(content={"error": "Invalid facet request"}, status_code=400)
+        return api_error_response(
+            status_code=400,
+            code="invalid_facet_request",
+            title="Bad request",
+            detail="Invalid facet request",
+            request_id=get_request_id(request),
+        )
     except Exception:
         logger.error("Error getting facet values", exc_info=True)
         return _search_error_response(
@@ -1074,7 +1096,7 @@ async def get_facet(
         )
 
 
-@router.get("/suggest", responses=COMMON_ERROR_RESPONSES)
+@router.get("/suggest", response_model=SuggestResponse, responses=COMMON_ERROR_RESPONSES)
 @cached_endpoint(ttl=SUGGEST_CACHE_TTL)
 async def suggest(
     request: Request,

--- a/backend/app/api/v1/endpoint_modules/static_maps.py
+++ b/backend/app/api/v1/endpoint_modules/static_maps.py
@@ -7,6 +7,7 @@ from fastapi.responses import Response
 from PIL import Image
 from sqlalchemy.sql import select
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
 from app.services.cache_service import (
     alias_redirect_cache_control_header,
     cache_control_header,
@@ -18,7 +19,7 @@ from db.models import resources
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(responses=PUBLIC_ERROR_RESPONSES)
 
 ASSET_CACHE_TTL_SECONDS = int(os.getenv("ASSET_CACHE_TTL_SECONDS", "3600"))
 
@@ -202,7 +203,7 @@ async def _get_or_generate_map_data(
     raise HTTPException(status_code=400, detail="Unsupported static map variant")
 
 
-@router.get("/static-maps/institutions/{map_id}")
+@router.get("/static-maps/institutions/{map_id}", response_class=Response)
 async def get_institution_static_map(
     map_id: str,
     request: Request,
@@ -233,7 +234,7 @@ async def get_institution_static_map(
             )
     except Exception as e:
         logger.error(f"Error retrieving institution static map {map_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to retrieve static map") from e
 
     if not map_data:
         raise HTTPException(status_code=404, detail="Institution static map not found")
@@ -241,7 +242,7 @@ async def get_institution_static_map(
     return _validated_static_asset_response(map_data, request)
 
 
-@router.get("/static-map-assets/{map_hash}")
+@router.get("/static-map-assets/{map_hash}", response_class=Response)
 async def get_static_map_asset(map_hash: str, request: Request):
     """Serve a hash-addressed immutable static map or icon asset directly from Redis."""
     map_service = StaticMapService()
@@ -257,7 +258,7 @@ async def get_static_map_asset(map_hash: str, request: Request):
     )
 
 
-@router.get("/static-maps/{resource_id}/geometry")
+@router.get("/static-maps/{resource_id}/geometry", response_class=Response)
 async def get_static_map_geometry(resource_id: str, request: Request):
     """Serve or generate the static map with geometry overlay for a resource."""
     map_service = StaticMapService()
@@ -292,12 +293,12 @@ async def get_static_map_geometry(resource_id: str, request: Request):
         raise
     except Exception as e:
         logger.error(f"Error retrieving static map geometry {resource_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to retrieve static map") from e
 
     return _validated_static_asset_response(map_data, request)
 
 
-@router.get("/static-maps/{resource_id}/resource-class-icon")
+@router.get("/static-maps/{resource_id}/resource-class-icon", response_class=Response)
 async def get_static_map_resource_class_icon(resource_id: str):
     """Serve the resource-class icon over the basemap background."""
     redirect = await _get_asset_redirect(
@@ -359,10 +360,10 @@ async def get_static_map_resource_class_icon(resource_id: str):
         raise
     except Exception as e:
         logger.error(f"Error retrieving static map icon asset {resource_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to retrieve static map") from e
 
 
-@router.get("/static-maps/{resource_id}")
+@router.get("/static-maps/{resource_id}", response_class=Response)
 async def get_static_map(resource_id: str, request: Request):
     """Serve or generate the basemap-only static map asset for a resource."""
     map_service = StaticMapService()
@@ -397,6 +398,6 @@ async def get_static_map(resource_id: str, request: Request):
         raise
     except Exception as e:
         logger.error(f"Error retrieving basemap static map {resource_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to retrieve static map") from e
 
     return _validated_static_asset_response(map_data, request)

--- a/backend/app/api/v1/endpoint_modules/thumbnails.py
+++ b/backend/app/api/v1/endpoint_modules/thumbnails.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import Response
 from PIL import Image
 
+from app.api.errors import PUBLIC_ERROR_RESPONSES
 from app.services.cache_service import (
     alias_redirect_cache_control_header,
     cache_control_header,
@@ -17,7 +18,7 @@ from app.services.thumbnail_alias_service import is_thumbnail_hash
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(responses=PUBLIC_ERROR_RESPONSES)
 
 ASSET_CACHE_TTL_SECONDS = int(os.getenv("ASSET_CACHE_TTL_SECONDS", "3600"))
 
@@ -120,7 +121,7 @@ def _detect_image_type(image_data: bytes) -> str:
     return "image/jpeg"
 
 
-@router.get("/thumbnails/placeholder")
+@router.get("/thumbnails/placeholder", response_class=Response)
 async def get_placeholder_thumbnail():
     """Serve a neutral thumbnail placeholder image."""
     placeholder_svg = """
@@ -146,7 +147,7 @@ async def get_placeholder_thumbnail():
     )
 
 
-@router.get("/thumbnails/{resource_id}")
+@router.get("/thumbnails/{resource_id}", response_class=Response)
 async def get_thumbnail(resource_id: str, request: Request):
     """Serve a thumbnail asset or resolve a resource-id thumbnail fallback."""
     if not is_thumbnail_hash(resource_id):
@@ -160,7 +161,7 @@ async def get_thumbnail(resource_id: str, request: Request):
         image_data = await image_service.get_cached_image(resource_id)
     except Exception as e:
         logger.error(f"Error retrieving cached image {resource_id}: {e}")
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(status_code=500, detail="Failed to retrieve thumbnail") from e
 
     if not image_data:
         if is_thumbnail_hash(resource_id):
@@ -181,7 +182,7 @@ async def get_thumbnail(resource_id: str, request: Request):
             raise
         except Exception as e:
             logger.error(f"Error retrieving resource thumbnail asset {resource_id}: {e}")
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            raise HTTPException(status_code=500, detail="Failed to retrieve thumbnail") from e
 
     # Validate that the cached content is actually an image
     try:

--- a/backend/app/api/v1/endpoints.py
+++ b/backend/app/api/v1/endpoints.py
@@ -40,7 +40,7 @@ router.include_router(turnstile_router, tags=["turnstile"], include_in_schema=Fa
 router.include_router(mcp_router, tags=["mcp"])
 router.include_router(slack_router, tags=["slack"], include_in_schema=False)
 router.include_router(ogm_router, tags=["ogm"])
-# Hide admin, gazetteer, and shapefiles endpoints from Swagger documentation
+# Hide admin, gazetteer, and shapefiles endpoints from Swagger documentation.
 router.include_router(admin_router, prefix="/admin", tags=["admin"], include_in_schema=False)
 router.include_router(ogm_webhook_router, prefix="/admin", tags=["admin"], include_in_schema=False)
 router.include_router(gazetteer_router, tags=["gazetteers"], include_in_schema=False)

--- a/backend/app/elasticsearch/search.py
+++ b/backend/app/elasticsearch/search.py
@@ -2205,7 +2205,10 @@ async def process_search_response(
         logger.error(f"Response body: {response}")
         raise HTTPException(
             status_code=500,
-            detail={"error": str(e), "traceback": error_trace, "response": response},
+            detail={
+                "message": "Failed to process search response",
+                "code": "search_response_processing_failed",
+            },
         ) from e
 
 
@@ -2876,7 +2879,13 @@ async def get_facet_values(
         return buckets
     except Exception as es_error:
         logger.error(f"Elasticsearch error getting facet values: {str(es_error)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(es_error)) from es_error
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "message": "Elasticsearch facet lookup failed",
+                "code": "elasticsearch_facet_lookup_failed",
+            },
+        ) from es_error
 
 
 def process_facet_response(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ except ImportError:
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.openapi.docs import (
@@ -35,7 +36,9 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from app.api.errors import (
     RequestIDMiddleware,
     get_request_id,
+    http_exception_handler,
     internal_server_error_response,
+    validation_exception_handler,
 )
 from app.api.ogc import router as ogc_router
 from app.api.v1.endpoints import router as public_router
@@ -252,6 +255,9 @@ app.add_middleware(RequestIDMiddleware)
 # Include routers
 app.include_router(public_router, prefix="/api/v1")
 app.include_router(ogc_router, prefix="/api/v1/ogc")
+
+app.add_exception_handler(HTTPException, http_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_handler)
 
 
 @app.get("/api/v1", include_in_schema=False)

--- a/backend/tests/api/test_error_contracts.py
+++ b/backend/tests/api/test_error_contracts.py
@@ -2,7 +2,8 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
@@ -11,10 +12,32 @@ from app.api.errors import (
     REQUEST_ID_HEADER,
     APIErrorResponse,
     RequestIDMiddleware,
+    http_exception_handler,
     internal_server_error_response,
+    validation_exception_handler,
 )
 from app.api.v1.endpoint_modules import search as search_module
 from app.main import app as main_app
+
+API_ERROR_REF = {"$ref": "#/components/schemas/APIErrorResponse"}
+
+
+def _assert_error_payload(
+    payload: dict,
+    *,
+    status: int,
+    code: str,
+    title: str,
+    detail: str | None = None,
+    request_id: str | None = None,
+):
+    assert payload["errors"][0]["status"] == status
+    assert payload["errors"][0]["code"] == code
+    assert payload["errors"][0]["title"] == title
+    if detail is not None:
+        assert payload["errors"][0]["detail"] == detail
+    if request_id is not None:
+        assert payload["errors"][0]["request_id"] == request_id
 
 
 def test_error_response_contract_serializes_request_id():
@@ -74,6 +97,78 @@ def test_unhandled_exceptions_use_public_safe_error_envelope():
     assert "database password secret" not in response.text
 
 
+def test_http_exceptions_use_public_error_envelope():
+    app = FastAPI(responses=COMMON_ERROR_RESPONSES)
+    app.add_middleware(RequestIDMiddleware)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+
+    @app.get("/missing")
+    async def missing():
+        raise HTTPException(status_code=404, detail="Resource not found")
+
+    client = TestClient(app)
+    response = client.get("/missing", headers={REQUEST_ID_HEADER: "req-http"})
+
+    assert response.status_code == 404
+    assert response.headers[REQUEST_ID_HEADER] == "req-http"
+    _assert_error_payload(
+        response.json(),
+        status=404,
+        code="not_found",
+        title="Not found",
+        detail="Resource not found",
+        request_id="req-http",
+    )
+
+
+def test_http_5xx_details_are_sanitized():
+    app = FastAPI(responses=COMMON_ERROR_RESPONSES)
+    app.add_middleware(RequestIDMiddleware)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+
+    @app.get("/upstream")
+    async def upstream():
+        raise HTTPException(status_code=503, detail="postgres://secret@localhost/db")
+
+    client = TestClient(app)
+    response = client.get("/upstream", headers={REQUEST_ID_HEADER: "req-upstream"})
+
+    assert response.status_code == 503
+    _assert_error_payload(
+        response.json(),
+        status=503,
+        code="service_unavailable",
+        title="Service unavailable",
+        detail="The service is temporarily unavailable.",
+        request_id="req-upstream",
+    )
+    assert "postgres://secret" not in response.text
+
+
+def test_validation_errors_use_public_error_envelope():
+    app = FastAPI(responses=COMMON_ERROR_RESPONSES)
+    app.add_middleware(RequestIDMiddleware)
+    app.add_exception_handler(RequestValidationError, validation_exception_handler)
+
+    @app.get("/items")
+    async def items(limit: int = Query(..., ge=1)):
+        return {"limit": limit}
+
+    client = TestClient(app)
+    response = client.get("/items?limit=0", headers={REQUEST_ID_HEADER: "req-validation"})
+
+    assert response.status_code == 422
+    assert response.headers[REQUEST_ID_HEADER] == "req-validation"
+    _assert_error_payload(
+        response.json(),
+        status=422,
+        code="validation_error",
+        title="Validation error",
+        detail="Request validation failed.",
+        request_id="req-validation",
+    )
+
+
 @pytest.mark.unit
 def test_main_app_adds_request_id_header_to_normal_responses():
     client = TestClient(main_app)
@@ -83,16 +178,107 @@ def test_main_app_adds_request_id_header_to_normal_responses():
     assert response.headers[REQUEST_ID_HEADER] == "req-main"
 
 
-def test_openapi_documents_standard_500_error_schema():
+def test_openapi_documents_public_success_and_error_schemas():
     client = TestClient(main_app)
     schema = client.get("/api/openapi.json").json()
 
-    assert "APIErrorResponse" in schema["components"]["schemas"]
-    search_get = schema["paths"]["/api/v1/search"]["get"]
-    assert search_get["responses"]["500"]["description"] == "Internal server error"
-    assert search_get["responses"]["500"]["content"]["application/json"]["schema"] == {
-        "$ref": "#/components/schemas/APIErrorResponse"
+    component_names = schema["components"]["schemas"]
+    for component in (
+        "APIErrorResponse",
+        "APIRootResponse",
+        "SearchResponse",
+        "SuggestResponse",
+        "FacetResponse",
+        "ResourceResponse",
+        "ResourceCollectionResponse",
+        "ResourceCitationResponse",
+        "ResourceDownloadsResponse",
+        "DataDictionaryListResponse",
+        "HomeBlogPostsResponse",
+        "MapH3Response",
+        "OGCCollectionsResponse",
+        "OGCFeatureCollectionResponse",
+        "OGMRepoSummariesResponse",
+        "MCPInfoResponse",
+    ):
+        assert component in component_names
+
+    for hidden_prefix in (
+        "/api/v1/admin",
+        "/api/v1/gazetteers",
+        "/api/v1/feedback",
+        "/api/v1/slack",
+        "/api/v1/turnstile",
+        "/api/v1/shapefiles",
+    ):
+        assert all(not path.startswith(hidden_prefix) for path in schema["paths"])
+
+    expected_success_schemas = {
+        ("/api/v1/", "get"): "#/components/schemas/APIRootResponse",
+        ("/api/v1/search", "get"): "#/components/schemas/SearchResponse",
+        ("/api/v1/search", "post"): "#/components/schemas/SearchResponse",
+        ("/api/v1/search/facets/{facet_name}", "get"): "#/components/schemas/FacetResponse",
+        ("/api/v1/suggest", "get"): "#/components/schemas/SuggestResponse",
+        ("/api/v1/resources/", "get"): "#/components/schemas/ResourceCollectionResponse",
+        ("/api/v1/resources/{id}", "get"): "#/components/schemas/ResourceResponse",
+        (
+            "/api/v1/resources/{id}/citation",
+            "get",
+        ): "#/components/schemas/ResourceCitationResponse",
+        (
+            "/api/v1/resources/{id}/citation/json-ld",
+            "get",
+        ): "#/components/schemas/SchemaOrgCitationResponse",
+        (
+            "/api/v1/resources/{id}/downloads",
+            "get",
+        ): "#/components/schemas/ResourceDownloadsResponse",
+        (
+            "/api/v1/resources/{id}/downloads/generated/{download_type}",
+            "get",
+        ): "#/components/schemas/GeneratedDownloadResponse",
+        (
+            "/api/v1/resources/{id}/data-dictionaries",
+            "get",
+        ): "#/components/schemas/DataDictionaryListResponse",
+        ("/api/v1/home/blog-posts", "get"): "#/components/schemas/HomeBlogPostsResponse",
+        ("/api/v1/map/h3", "get"): "#/components/schemas/MapH3Response",
+        ("/api/v1/ogc/collections", "get"): "#/components/schemas/OGCCollectionsResponse",
+        (
+            "/api/v1/ogc/collections/btaa-records/items",
+            "get",
+        ): "#/components/schemas/OGCFeatureCollectionResponse",
+        ("/api/v1/ogm/repos", "get"): "#/components/schemas/OGMRepoSummariesResponse",
+        ("/api/v1/mcp", "get"): "#/components/schemas/MCPInfoResponse",
     }
+    for (path, method), ref in expected_success_schemas.items():
+        assert schema["paths"][path][method]["responses"]["200"]["content"]["application/json"][
+            "schema"
+        ] == {"$ref": ref}
+
+    for path, operations in schema["paths"].items():
+        if not path.startswith("/api/v1"):
+            continue
+        for method, operation in operations.items():
+            if method not in {"get", "post"}:
+                continue
+
+            responses = operation["responses"]
+            for status_code in ("400", "422", "500"):
+                assert (
+                    responses[status_code]["content"]["application/json"]["schema"] == API_ERROR_REF
+                )
+
+            success_content = responses.get("200", {}).get("content", {})
+            success_json = success_content.get("application/json")
+            if success_json is not None:
+                assert success_json.get("schema")
+                assert success_json["schema"] != {}
+                assert success_json["schema"] not in (
+                    {"$ref": "#/components/schemas/GenericObjectResponse"},
+                    {"$ref": "#/components/schemas/GenericArrayResponse"},
+                    {"$ref": "#/components/schemas/JSONAPIResponse"},
+                )
 
 
 def _build_request(query_string: bytes = b"q=test") -> Request:

--- a/backend/tests/api/v1/test_admin_api_keys.py
+++ b/backend/tests/api/v1/test_admin_api_keys.py
@@ -16,6 +16,13 @@ os.environ.setdefault("ADMIN_USERNAME", "admin")
 os.environ.setdefault("ADMIN_PASSWORD", "changeme")
 
 
+def error_detail(response):
+    payload = response.json()
+    if "errors" in payload:
+        return payload["errors"][0]["detail"]
+    return payload["detail"]
+
+
 @pytest.fixture
 def admin_client() -> TestClient:
     """Test client using the main FastAPI app with all middleware and routes."""
@@ -152,7 +159,7 @@ class TestAdminAPIKeysLifecycle:
             auth=self.auth,
         )
         assert create_resp.status_code == 400
-        assert "Invalid IP address" in create_resp.json()["detail"]
+        assert "Invalid IP address" in error_detail(create_resp)
 
     def test_update_api_key_ip_whitelist(self, admin_client: TestClient):
         """Test updating an API key's IP whitelist."""

--- a/backend/tests/api/v1/test_advanced_search.py
+++ b/backend/tests/api/v1/test_advanced_search.py
@@ -14,6 +14,13 @@ from httpx import AsyncClient
 pytestmark = pytest.mark.asyncio
 
 
+def error_detail(response):
+    payload = response.json()
+    if "errors" in payload:
+        return payload["errors"][0]["detail"]
+    return payload["detail"]
+
+
 class TestAdvancedSearchValidation:
     """Test validation of advanced query parameters."""
 
@@ -22,25 +29,23 @@ class TestAdvancedSearchValidation:
         payload = {"adv_q": [{"f": "dct_title_s", "q": "Iowa"}]}
         response = await async_client.post("/api/v1/search", json=payload)
         assert response.status_code == 400
-        assert "op" in response.json()["detail"].lower()
+        assert "op" in error_detail(response).lower()
 
     async def test_adv_q_missing_field(self, async_client: AsyncClient):
         """Test that missing field returns 400 error."""
         payload = {"adv_q": [{"op": "AND", "q": "Iowa"}]}
         response = await async_client.post("/api/v1/search", json=payload)
         assert response.status_code == 400
-        assert (
-            "f" in response.json()["detail"].lower() or "field" in response.json()["detail"].lower()
-        )
+        detail = error_detail(response).lower()
+        assert "f" in detail or "field" in detail
 
     async def test_adv_q_missing_query(self, async_client: AsyncClient):
         """Test that missing query returns 400 error."""
         payload = {"adv_q": [{"op": "AND", "f": "dct_title_s"}]}
         response = await async_client.post("/api/v1/search", json=payload)
         assert response.status_code == 400
-        assert (
-            "q" in response.json()["detail"].lower() or "query" in response.json()["detail"].lower()
-        )
+        detail = error_detail(response).lower()
+        assert "q" in detail or "query" in detail
 
     async def test_adv_q_empty_query(self, async_client: AsyncClient):
         """Test that empty query returns 400 error."""
@@ -59,7 +64,7 @@ class TestAdvancedSearchValidation:
         payload = {"adv_q": [{"op": "XOR", "f": "dct_title_s", "q": "Iowa"}]}
         response = await async_client.post("/api/v1/search", json=payload)
         assert response.status_code == 400
-        assert "invalid operator" in response.json()["detail"].lower()
+        assert "invalid operator" in error_detail(response).lower()
 
     async def test_adv_q_empty_list(self, async_client: AsyncClient):
         """Test that empty list returns 400 error."""

--- a/backend/tests/api/v1/test_citation_endpoints.py
+++ b/backend/tests/api/v1/test_citation_endpoints.py
@@ -10,6 +10,11 @@ from app.main import app
 client = TestClient(app)
 
 
+def assert_public_error(data, *, status: int, code: str):
+    assert data["errors"][0]["status"] == status
+    assert data["errors"][0]["code"] == code
+
+
 @pytest.mark.unit
 def test_citation_endpoint_paths_exist():
     """Test that citation endpoints are registered."""
@@ -26,7 +31,7 @@ def test_citation_endpoint_returns_404_for_nonexistent():
     assert response.status_code in [404, 500]
     if response.status_code == 404:
         data = response.json()
-        assert "error" in data or "detail" in data
+        assert_public_error(data, status=404, code="not_found")
 
 
 @pytest.mark.unit

--- a/backend/tests/api/v1/test_endpoint_modules_resources_extra.py
+++ b/backend/tests/api/v1/test_endpoint_modules_resources_extra.py
@@ -39,6 +39,11 @@ class DummySession:
         pass
 
 
+@pytest.fixture(autouse=True)
+def disable_endpoint_cache(monkeypatch):
+    monkeypatch.setattr("app.services.cache_service.ENDPOINT_CACHE", False)
+
+
 @pytest.mark.asyncio
 async def test_list_resources_success(monkeypatch):
     from app.api.v1.endpoint_modules import resources as res
@@ -99,7 +104,14 @@ async def test_get_resource_found(monkeypatch):
         def url(self):
             return self._url
 
-    resp = await res.get_resource(request=DummyRequest(), id="r1", callback=None)
+    resp = await res.get_resource(
+        request=DummyRequest(),
+        id="r1",
+        fields=None,
+        ui_profile=None,
+        callback=None,
+        format=None,
+    )
     assert hasattr(resp, "body")
 
 
@@ -146,6 +158,8 @@ async def test_get_resource_homepage_profile_uses_lightweight_processor(monkeypa
 
 @pytest.mark.asyncio
 async def test_get_resource_not_found(monkeypatch):
+    from fastapi import HTTPException
+
     from app.api.v1.endpoint_modules import resources as res
 
     res.async_session = lambda: DummySession(fetchone_row=None)
@@ -160,13 +174,15 @@ async def test_get_resource_not_found(monkeypatch):
         def url(self):
             return self._url
 
-    resp = await res.get_resource(request=DummyRequest(), id="missing", callback=None)
-    assert hasattr(resp, "body")
-    assert resp.status_code == 404
+    with pytest.raises(HTTPException) as exc:
+        await res.get_resource(request=DummyRequest(), id="missing", callback=None)
+    assert exc.value.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_get_resource_error(monkeypatch):
+    from fastapi import HTTPException
+
     from app.api.v1.endpoint_modules import resources as res
 
     row = make_row({"id": "r1"})
@@ -187,9 +203,9 @@ async def test_get_resource_error(monkeypatch):
         def url(self):
             return self._url
 
-    resp = await res.get_resource(request=DummyRequest(), id="r1", callback=None)
-    assert hasattr(resp, "body")
-    assert resp.status_code == 500
+    with pytest.raises(HTTPException) as exc:
+        await res.get_resource(request=DummyRequest(), id="r1", callback=None)
+    assert exc.value.status_code == 500
 
 
 @pytest.mark.asyncio
@@ -205,19 +221,21 @@ async def test_get_resource_ogm_success(monkeypatch):
             return resource_dict
 
     monkeypatch.setattr(res, "OGMFieldMapper", FakeMapper)
-    resp = await res.get_resource_ogm("r1", callback="cb")
+    resp = await res.get_resource_ogm("r1", fields=None, callback="cb")
     # JSONP-like acceptable as JSONResponse/str body exists
     assert resp is not None
 
 
 @pytest.mark.asyncio
 async def test_get_resource_ogm_not_found(monkeypatch):
+    from fastapi import HTTPException
+
     from app.api.v1.endpoint_modules import resources as res
 
     res.async_session = lambda: DummySession(fetchone_row=None)
-    resp = await res.get_resource_ogm("x", callback=None)
-    assert hasattr(resp, "body")
-    assert resp.status_code == 404
+    with pytest.raises(HTTPException) as exc:
+        await res.get_resource_ogm("x", callback=None)
+    assert exc.value.status_code == 404
 
 
 # Summaries endpoint tests removed - endpoint is commented out and not available
@@ -250,12 +268,14 @@ async def test_get_resource_viewer_not_found(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_resource_viewer_error(monkeypatch):
+    from fastapi import HTTPException
+
     from app.api.v1.endpoint_modules import resources as res
 
     res.async_session = lambda: DummySession(raise_on="execute")
-    resp = await res.get_resource_viewer("r1", embed=False)
-    assert hasattr(resp, "body")
-    assert resp.status_code == 500
+    with pytest.raises(HTTPException) as exc:
+        await res.get_resource_viewer("r1", embed=False)
+    assert exc.value.status_code == 500
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/v1/test_facet_endpoint.py
+++ b/backend/tests/api/v1/test_facet_endpoint.py
@@ -26,6 +26,13 @@ def disable_caching():
         yield
 
 
+def error_detail(response):
+    payload = response.json()
+    if "errors" in payload:
+        return payload["errors"][0]["detail"]
+    return payload.get("error") or payload["detail"]
+
+
 class TestFacetEndpointValidation:
     """Test validation of facet endpoint parameters."""
 
@@ -33,7 +40,7 @@ class TestFacetEndpointValidation:
         """Test that invalid facet name returns 400 error."""
         response = await async_client.get("/api/v1/search/facets/invalid_facet_name")
         assert response.status_code == 400
-        assert "invalid facet name" in response.json()["error"].lower()
+        assert "invalid facet name" in error_detail(response).lower()
 
     async def test_invalid_sort_parameter(self, async_client: AsyncClient):
         """Test that invalid sort parameter returns 400 error."""
@@ -41,7 +48,7 @@ class TestFacetEndpointValidation:
             "/api/v1/search/facets/schema_provider_s?sort=invalid_sort"
         )
         assert response.status_code == 400
-        assert "invalid sort parameter" in response.json()["error"].lower()
+        assert "invalid sort parameter" in error_detail(response).lower()
 
     async def test_invalid_page_parameter(self, async_client: AsyncClient):
         """Test that invalid page parameter returns validation error."""
@@ -59,7 +66,7 @@ class TestFacetEndpointValidation:
             "/api/v1/search/facets/schema_provider_s?adv_q=invalid_json"
         )
         assert response.status_code == 400
-        assert "invalid json" in response.json()["error"].lower()
+        assert "invalid json" in error_detail(response).lower()
 
 
 class TestFacetEndpointSuccess:
@@ -720,7 +727,7 @@ class TestFacetEndpointIntegration:
         response = await async_client.get("/api/v1/search/facets/invalid_facet")
 
         assert response.status_code == 400
-        assert "error" in response.json()
+        assert "invalid facet" in error_detail(response).lower()
 
     @patch("app.api.v1.endpoint_modules.search.get_facet_values")
     @patch("app.api.v1.endpoint_modules.search.process_facet_response")

--- a/backend/tests/api/v1/test_gazetteer_endpoints.py
+++ b/backend/tests/api/v1/test_gazetteer_endpoints.py
@@ -8,6 +8,18 @@ from app.main import app
 client = TestClient(app)
 
 
+def assert_public_error(data, *, status: int, code: str, detail: str | None = None):
+    assert "errors" in data
+    assert len(data["errors"]) == 1
+
+    error = data["errors"][0]
+    assert error["status"] == status
+    assert error["code"] == code
+    assert "request_id" in error
+    if detail is not None:
+        assert error["detail"] == detail
+
+
 def test_list_gazetteers():
     """Test the list_gazetteers endpoint."""
     # Call endpoint
@@ -349,8 +361,13 @@ class TestGazetteerEndpointsEnhanced:
 
         assert response.status_code == 500
         data = response.json()
-        assert "detail" in data
-        assert data["detail"] == "Failed to list gazetteers"
+        assert_public_error(
+            data,
+            status=500,
+            code="internal_server_error",
+            detail="An unexpected error occurred.",
+        )
+        assert "Database connection failed" not in response.text
 
     def test_search_all_gazetteers_missing_query(self):
         """Test search all gazetteers without required query parameter."""
@@ -364,8 +381,12 @@ class TestGazetteerEndpointsEnhanced:
 
         assert response.status_code == 400
         data = response.json()
-        assert "detail" in data
-        assert "Invalid gazetteer specified" in data["detail"]
+        assert_public_error(
+            data,
+            status=400,
+            code="bad_request",
+            detail="Invalid gazetteer specified",
+        )
 
     def test_search_all_gazetteers_invalid_limit(self):
         """Test search with invalid limit parameter."""
@@ -405,7 +426,12 @@ class TestGazetteerEndpointsEnhanced:
                 assert isinstance(gazetteer_data["data"], list)
         else:
             # Handle error response structure
-            assert "detail" in data
+            assert_public_error(
+                data,
+                status=500,
+                code="internal_server_error",
+                detail="An unexpected error occurred.",
+            )
 
     def test_search_all_gazetteers_specific_geonames(self):
         """Test search with specific gazetteer (geonames)."""
@@ -451,8 +477,13 @@ class TestGazetteerEndpointsEnhanced:
 
         assert response.status_code == 500
         data = response.json()
-        assert "detail" in data
-        assert "Failed to search GeoNames" in data["detail"]
+        assert_public_error(
+            data,
+            status=500,
+            code="internal_server_error",
+            detail="An unexpected error occurred.",
+        )
+        assert "Database error" not in response.text
 
     def test_search_wof_success(self):
         """Test successful WOF search."""
@@ -482,8 +513,13 @@ class TestGazetteerEndpointsEnhanced:
 
         assert response.status_code == 500
         data = response.json()
-        assert "detail" in data
-        assert "Failed to search WOF" in data["detail"]
+        assert_public_error(
+            data,
+            status=500,
+            code="internal_server_error",
+            detail="An unexpected error occurred.",
+        )
+        assert "Database error" not in response.text
 
     def test_search_btaa_success(self):
         """Test successful BTAA search."""
@@ -513,8 +549,13 @@ class TestGazetteerEndpointsEnhanced:
 
         assert response.status_code == 500
         data = response.json()
-        assert "detail" in data
-        assert "Failed to search BTAA" in data["detail"]
+        assert_public_error(
+            data,
+            status=500,
+            code="internal_server_error",
+            detail="An unexpected error occurred.",
+        )
+        assert "Database error" not in response.text
 
     def test_search_with_pagination(self):
         """Test search with pagination parameters."""

--- a/backend/tests/api/v1/test_resource_endpoints.py
+++ b/backend/tests/api/v1/test_resource_endpoints.py
@@ -12,6 +12,18 @@ from app.services.relationship_service import RelationshipService
 client = TestClient(app)
 
 
+def assert_public_error(data, *, status: int, code: str, detail: str | None = None):
+    assert "errors" in data
+    assert len(data["errors"]) == 1
+
+    error = data["errors"][0]
+    assert error["status"] == status
+    assert error["code"] == code
+    assert "request_id" in error
+    if detail is not None:
+        assert error["detail"] == detail
+
+
 @pytest.mark.unit
 def test_relationship_service_initialization():
     """Test that RelationshipService can be initialized."""
@@ -123,12 +135,12 @@ def test_ogm_endpoint_404_handling():
     assert response.status_code == 404
 
     data = response.json()
-    # The endpoint may return {"error": "..."}, {"message": "..."}, or {"detail": "..."} format
-    assert "error" in data or "message" in data or "detail" in data
-    if "error" in data:
-        assert data["error"] == "Resource not found"
-    elif "detail" in data:
-        assert data["detail"] == "Resource not found"
+    assert_public_error(
+        data,
+        status=404,
+        code="not_found",
+        detail="Resource not found",
+    )
 
 
 def test_viewer_endpoint_404_handling():
@@ -142,12 +154,21 @@ def test_viewer_endpoint_404_handling():
 
     if response.status_code == 404:
         data = response.json()
-        assert "detail" in data
-        assert data["detail"] == "Resource not found"
+        assert_public_error(
+            data,
+            status=404,
+            code="not_found",
+            detail="Resource not found",
+        )
     elif response.status_code == 500:
         # Database connection issues are acceptable in test environment
         data = response.json()
-        assert "error" in data
+        assert_public_error(
+            data,
+            status=500,
+            code="internal_server_error",
+            detail="An unexpected error occurred.",
+        )
 
 
 def test_ogm_endpoint_success_response():
@@ -761,8 +782,12 @@ class TestResourceEndpointsEnhanced:
 
         assert response.status_code == 404
         data = response.json()
-        assert "error" in data
-        assert data["error"] == "Resource not found"
+        assert_public_error(
+            data,
+            status=404,
+            code="not_found",
+            detail="Resource not found",
+        )
 
     @patch("app.services.link_service.LinkService.get_resource_links")
     def test_get_resource_links_success(self, mock_get_links):

--- a/backend/tests/api/v1/test_thumbnail_endpoints.py
+++ b/backend/tests/api/v1/test_thumbnail_endpoints.py
@@ -27,6 +27,13 @@ def create_valid_jpeg_image() -> bytes:
     return buffer.getvalue()
 
 
+def error_detail(response):
+    payload = response.json()
+    if "errors" in payload:
+        return payload["errors"][0]["detail"]
+    return payload["detail"]
+
+
 @pytest.fixture
 def app():
     """Create FastAPI app with thumbnails router."""
@@ -203,7 +210,7 @@ class TestThumbnailEndpoints:
             response = client.get(f"/thumbnails/{test_image_hash}")
 
             assert response.status_code == 404
-            assert "Resource not found" in response.json()["detail"]
+            assert "Resource not found" in error_detail(response)
 
     def test_get_thumbnail_missing_hash_returns_404(self, client):
         """Missing immutable asset hashes should let clients fall back by image error."""
@@ -412,7 +419,8 @@ class TestThumbnailEndpoints:
             response = client.get(f"/thumbnails/{test_image_hash}")
 
             assert response.status_code == 500
-            assert "Service error" in response.json()["detail"]
+            assert error_detail(response) == "Failed to retrieve thumbnail"
+            assert "Service error" not in response.text
 
     def test_get_thumbnail_cache_headers(self, client):
         """Test that cached thumbnails have proper caching headers."""
@@ -664,7 +672,8 @@ class TestThumbnailEndpoints:
                 response = client.get(f"/thumbnails/{test_image_hash}")
 
                 assert response.status_code == 500
-                assert error_message in response.json()["detail"]
+                assert error_detail(response) == "Failed to retrieve thumbnail"
+                assert error_message not in response.text
 
     def test_placeholder_thumbnail_accessibility(self, client):
         """Test that placeholder thumbnail is accessible and well-formed."""

--- a/docs/README.md
+++ b/docs/README.md
@@ -167,6 +167,22 @@ Public-facing endpoint and parameter details should be kept in
 `mkdocs/docs/specification/endpoints.md` and
 `mkdocs/docs/specification/parameters.md`.
 
+Public OpenAPI routes must declare named Pydantic success response models and
+shared JSON error responses. JSON:API resource envelopes, search/facet
+pagination metadata, home/blog payloads, OGM status payloads, OGC facade
+payloads, MCP metadata, map/H3 payloads, and resource subroute wrappers are
+stable contract shapes. JSON:API resource `attributes`, selected `meta` blocks,
+metadata field blocks, and relationship/link payload details remain
+intentionally extensible so OGM/Aardvark fields and B1G enrichments can evolve
+without over-modeling every metadata key.
+
+Public errors use the `{"errors": [...]}` envelope documented in the MkDocs
+API specification. The API returns `X-Request-ID` on normal and error
+responses; callers may provide that header or let the server generate it. Public
+5xx bodies must use safe generic details and must not expose raw exception text,
+Elasticsearch query internals, database connection strings, SQL, or upstream
+stack details.
+
 ## Makefile Command Families
 
 Run Makefile targets from the repository root.

--- a/mkdocs/docs/api.md
+++ b/mkdocs/docs/api.md
@@ -199,15 +199,29 @@ curl -X POST \
 
 ## Error Codes
 
+Errors are returned as JSON with an `errors` array. Each error includes `status`, `code`, `title`, optional safe `detail`, and a `request_id` that also appears in the `X-Request-ID` response header.
+
 | Code | Description |
 |------|-------------|
 | 400  | Bad Request - Invalid syntax |
 | 404  | Not Found - Resource doesn't exist |
 | 406  | Not Acceptable - Unsupported format |
+| 422  | Validation Error - Invalid parameter value |
+| 502  | Upstream Service Failed |
+| 503  | Service Unavailable |
 | 500  | Internal Server Error |
+
+## Response Contracts
+
+The OpenAPI document at `/api/openapi.json` declares named response schemas for
+the public v1 API surface, including search, suggest, resources, resource
+subroutes, OGC API Records, home/blog posts, map/H3 aggregation, OGM status, and
+MCP metadata. JSON:API resource envelopes are stable; resource attributes and
+metadata blocks remain extensible so Aardvark and B1G fields can evolve without
+requiring a schema update for every metadata key.
 
 ## Rate Limits
 
 - **Anonymous**: 100 requests/hour
 - **Authenticated**: 1000 requests/hour
-- **API Key**: 10000 requests/hour 
+- **API Key**: 10000 requests/hour

--- a/mkdocs/docs/specification/error_handling.md
+++ b/mkdocs/docs/specification/error_handling.md
@@ -2,21 +2,41 @@
 
 {% include-markdown "includes/wip.md" %}
 
-Errors **MUST** return a JSON object with `type`, `title`, `status`, and `detail` properties.
+Public API errors return a JSON object with an `errors` array. Each error object includes:
 
 ```json
 {
-  "type": "https://opengeometadata.org/api/errors/RateLimitExceeded",
-  "title": "Rate limit exceeded",
-  "status": 429,
-  "detail": "Allowed 1000 requests per minute; received 1423."
+  "errors": [
+    {
+      "status": 404,
+      "code": "not_found",
+      "title": "Not found",
+      "detail": "Resource not found",
+      "request_id": "01HZY7V9C4V6B2D5W8QZ"
+    }
+  ]
 }
 ```
+
+| Field | Meaning |
+| :---- | :---- |
+| `status` | HTTP status code for the error. |
+| `code` | Stable machine-readable error code. |
+| `title` | Short human-readable category. |
+| `detail` | Optional safe detail for client-facing errors. |
+| `request_id` | Request correlation ID, also returned in the `X-Request-ID` response header. |
+
+Clients may send an `X-Request-ID` header. If omitted, the API generates one. The same value is returned on normal and error responses.
+
+For 5xx errors, `detail` is intentionally generic. Public responses do not expose raw exception text, Elasticsearch query internals, database connection strings, SQL text, or upstream stack details.
 
 | HTTP Status | Meaning |
 | :---- | :---- |
 | 400 | Bad request / parameter validation error |
 | 401 | Missing or invalid API key |
 | 404 | Record or endpoint not found |
+| 422 | Request validation error |
 | 429 | Rate limit exceeded |
+| 502 | Upstream service failed |
+| 503 | Service unavailable |
 | 500 | Internal server error |


### PR DESCRIPTION
## Summary

This PR finishes the v1 public API contract hardening pass for the current public surface.

It adds named Pydantic response models for the stable public response families, centralizes public error handling around the `{"errors": [...]}` envelope, documents shared error schemas in OpenAPI, and updates public routes to declare success/error contracts without changing successful wire payloads.

## What Changed

- Added `app/api/schemas.py` with named response models for root, search, suggest, facets, resources, resource subroutes, home/blog posts, map/H3, OGC, OGM status, MCP metadata, citations, downloads, metadata, relationships, similar items, viewer payloads, and data dictionaries.
- Added centralized HTTP/validation/generic error handling with request IDs and safe 5xx bodies.
- Applied response models and shared documented error responses to public JSON routes.
- Kept gazetteer, admin, feedback, Slack, Turnstile, webhook, analytics, and shapefile compatibility routes hidden from public OpenAPI.
- Replaced public ad hoc error JSON with the shared error envelope where applicable.
- Sanitized search/Elasticsearch error paths so public responses do not expose raw backend details.
- Expanded API contract/OpenAPI regression tests to reject generic success schemas for public routes.
- Updated internal and public docs for the error envelope, request ID behavior, and response-contract policy.

## Why

Before this change, the API had safe behavior in many paths but lacked an explicit, testable public contract across the v1 surface. Several public responses were still effectively documented as generic dictionaries, and error bodies were not uniformly represented in OpenAPI.

This PR makes the public API safer and more predictable ahead of a v1.0.0 release while intentionally keeping dynamic OGM/Aardvark/B1G metadata fields extensible.

## Validation

- `python -m pytest tests/api/test_error_contracts.py`
- Focused route regression suite: `198 passed, 9 skipped`
- `make lint-check`
- `COMPOSE_PROJECT_NAME=data-api WALLCLOCK_TIMEOUT_SECONDS=300 make test`
  - `1759 passed, 129 skipped, 1 xpassed`
  - Coverage: `61.42%`

## Follow-Up Before v1.0.0

This PR closes the public HTTP API contract hardening work, but I would still address these before tagging v1.0.0:

- Sanitize MCP JSON-RPC internal error payloads so they cannot expose raw `str(exc)`.
- Put database migrations on rails with a schema ledger or Alembic baseline.
- Update release identity/version metadata from `0.7.0` to the final v1 version when ready.
- Run final k6 smoke/stress checks against a production-like deployment.