### PR TITLE
Remove bridge sync indexing cap

### DIFF
--- a/backend/app/services/bridge_sync/cache_refresh.py
+++ b/backend/app/services/bridge_sync/cache_refresh.py
@@ -18,6 +18,7 @@ from db.models import resources
 logger = logging.getLogger(__name__)
 
 DEFAULT_REWARM_RESOURCE_PATHS = ("/api/v1/resources/{id}",)
+DEFAULT_REFRESH_BATCH_SIZE = 5000
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -38,6 +39,16 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _positive_env_int(name: str, default: int) -> int:
+    value = _env_int(name, default)
+    if value < 1:
+        logger.warning(
+            "Invalid non-positive integer for %s=%r; using default=%s", name, value, default
+        )
+        return default
+    return value
+
+
 def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
@@ -48,6 +59,51 @@ def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
         seen.add(cleaned)
         result.append(cleaned)
     return result
+
+
+def _refresh_batch_size() -> int:
+    # BRIDGE_CACHE_REFRESH_MAX_RESOURCE_IDS used to be a total cap. Keep it as
+    # a compatibility alias, but interpret it as batch size so no IDs are lost.
+    legacy_batch_size = _positive_env_int(
+        "BRIDGE_CACHE_REFRESH_MAX_RESOURCE_IDS", DEFAULT_REFRESH_BATCH_SIZE
+    )
+    return _positive_env_int("BRIDGE_CACHE_REFRESH_BATCH_SIZE", legacy_batch_size)
+
+
+def _chunk_list(values: list[str], size: int) -> Iterable[list[str]]:
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+def _merge_numeric_stats(total: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(total)
+    for key, value in update.items():
+        if isinstance(value, bool):
+            merged[key] = bool(merged.get(key, True)) and value if key == "enabled" else value
+        elif isinstance(value, (int, float)):
+            merged[key] = merged.get(key, 0) + value
+        elif isinstance(value, dict):
+            existing = merged.get(key) if isinstance(merged.get(key), dict) else {}
+            merged[key] = _merge_numeric_stats(existing, value)
+        elif key not in merged:
+            merged[key] = value
+    return merged
+
+
+def _merge_representation_delete_stats(
+    total: dict[str, Any] | None,
+    update: dict[str, Any],
+) -> dict[str, Any]:
+    merged = dict(total or {})
+    if "durable_deleted" in update:
+        merged["durable_deleted"] = bool(merged.get("durable_deleted", True)) and bool(
+            update.get("durable_deleted")
+        )
+    if "redis_deleted" in update:
+        merged["redis_deleted"] = int(merged.get("redis_deleted", 0)) + int(
+            update.get("redis_deleted") or 0
+        )
+    return merged
 
 
 def _warm_path_from_record(record: dict[str, Any]) -> str | None:
@@ -276,24 +332,48 @@ async def refresh_cache_for_changed_resources(
     if not changed_ids:
         return {"enabled": True, "resource_ids": 0, "invalidated": 0, "warmed": 0, "errors": 0}
 
-    tags = [f"resource:{rid}" for rid in changed_ids]
+    batch_size = _refresh_batch_size()
     cache = CacheService()
+    warm_paths: list[str] = []
+    warm_path_seen: set[str] = set()
 
-    tagged_records = await cache.cached_records_for_tags(tags)
-    tagged_paths = [_warm_path_from_record(record) for record in tagged_records]
-    warm_paths = _dedupe_preserve_order(
-        [
-            *[path for path in tagged_paths if path],
-            *_default_resource_warm_paths(changed_ids),
-        ]
-    )[:max_warm_urls]
+    def add_warm_path(path: str | None) -> None:
+        if max_warm_urls <= 0 or len(warm_paths) >= max_warm_urls:
+            return
+        if not path or path in warm_path_seen:
+            return
+        warm_path_seen.add(path)
+        warm_paths.append(path)
 
-    representation_delete_stats = await delete_resource_representations(
-        changed_ids,
-        cache_service=cache,
-    )
-    invalidated = await cache.invalidate_tags(tags)
-    generated_assets = await _warm_generated_assets_for_changed_resources(changed_ids)
+    tagged_records_count = 0
+    representation_delete_stats: dict[str, Any] | None = None
+    generated_assets: dict[str, Any] = {}
+    invalidated = 0
+    batches = 0
+
+    for batch_ids in _chunk_list(changed_ids, batch_size):
+        batches += 1
+        tags = [f"resource:{rid}" for rid in batch_ids]
+
+        tagged_records = await cache.cached_records_for_tags(tags)
+        tagged_records_count += len(tagged_records)
+        for record in tagged_records:
+            add_warm_path(_warm_path_from_record(record))
+        for path in _default_resource_warm_paths(batch_ids):
+            add_warm_path(path)
+
+        batch_representation_delete_stats = await delete_resource_representations(
+            batch_ids,
+            cache_service=cache,
+        )
+        representation_delete_stats = _merge_representation_delete_stats(
+            representation_delete_stats,
+            batch_representation_delete_stats,
+        )
+
+        invalidated += await cache.invalidate_tags(tags)
+        batch_generated_assets = await _warm_generated_assets_for_changed_resources(batch_ids)
+        generated_assets = _merge_numeric_stats(generated_assets, batch_generated_assets)
 
     warmed = 0
     errors = 0
@@ -326,9 +406,11 @@ async def refresh_cache_for_changed_resources(
     stats = {
         "enabled": True,
         "resource_ids": len(changed_ids),
-        "tagged_records": len(tagged_records),
+        "batch_size": batch_size,
+        "batches": batches,
+        "tagged_records": tagged_records_count,
         "warm_urls": len(warm_paths),
-        "resource_representations_deleted": representation_delete_stats,
+        "resource_representations_deleted": representation_delete_stats or {},
         "generated_assets": generated_assets,
         "invalidated": invalidated,
         "warmed": warmed,

--- a/backend/app/services/bridge_sync/cache_refresh.py
+++ b/backend/app/services/bridge_sync/cache_refresh.py
@@ -269,11 +269,10 @@ async def refresh_cache_for_changed_resources(
     if not ENDPOINT_CACHE or not _env_bool("BRIDGE_CACHE_REFRESH_ENABLED", True):
         return {"enabled": False, "resource_ids": 0, "invalidated": 0, "warmed": 0, "errors": 0}
 
-    max_resource_ids = _env_int("BRIDGE_CACHE_REFRESH_MAX_RESOURCE_IDS", 5000)
     max_warm_urls = _env_int("BRIDGE_CACHE_REWARM_MAX_URLS", 2500)
     request_timeout = float(os.getenv("BRIDGE_CACHE_REWARM_TIMEOUT_SECONDS", "20"))
 
-    changed_ids = _dedupe_preserve_order(resource_ids)[:max_resource_ids]
+    changed_ids = _dedupe_preserve_order(resource_ids)
     if not changed_ids:
         return {"enabled": True, "resource_ids": 0, "invalidated": 0, "warmed": 0, "errors": 0}
 

--- a/backend/app/services/bridge_sync/report.py
+++ b/backend/app/services/bridge_sync/report.py
@@ -254,6 +254,35 @@ def _alert_items(run: dict[str, Any], recent_runs: list[dict[str, Any]]) -> list
                 f"Delta processed only {processed:,} resource{'' if processed == 1 else 's'}; "
                 f"threshold is {minimum:,}."
             )
+    index_stats = (
+        stats.get("search_index_refresh")
+        if isinstance(stats.get("search_index_refresh"), dict)
+        else {}
+    )
+    if index_stats and index_stats.get("enabled") is not False:
+        if index_stats.get("error"):
+            alerts.append(f"Elasticsearch refresh failed: {index_stats.get('error')}.")
+        else:
+            expected_indexed = _coerce_int(
+                stats.get("changed_resources"), _coerce_int(stats.get("processed"))
+            )
+            requested_indexed = _coerce_int(index_stats.get("resource_ids"))
+            indexed = _coerce_int(index_stats.get("indexed"))
+            index_errors = _coerce_int(index_stats.get("errors"))
+            if expected_indexed and requested_indexed and requested_indexed < expected_indexed:
+                alerts.append(
+                    "Elasticsearch refresh received only "
+                    f"{requested_indexed:,} of {expected_indexed:,} changed resource IDs."
+                )
+            if requested_indexed and indexed + index_errors < requested_indexed:
+                alerts.append(
+                    "Elasticsearch refresh finished short: "
+                    f"{indexed:,} indexed and {index_errors:,} errors for "
+                    f"{requested_indexed:,} requested resource IDs."
+                )
+    cache_stats = stats.get("cache_refresh") if isinstance(stats.get("cache_refresh"), dict) else {}
+    if cache_stats and cache_stats.get("enabled") is not False and cache_stats.get("error"):
+        alerts.append(f"Cache refresh failed: {cache_stats.get('error')}.")
     running_runs = [
         r for r in recent_runs if str(r.get("bridge_status") or "").lower() == "running"
     ]

--- a/backend/app/services/bridge_sync/search_index.py
+++ b/backend/app/services/bridge_sync/search_index.py
@@ -12,7 +12,7 @@ from db.database import database
 from db.models import resources
 
 logger = logging.getLogger(__name__)
-RESOURCE_FETCH_BATCH_SIZE = 1000
+DEFAULT_REFRESH_BATCH_SIZE = 5000
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -20,6 +20,23 @@ def _env_bool(name: str, default: bool) -> bool:
     if value is None:
         return default
     return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning("Invalid integer for %s=%r; using default=%s", name, value, default)
+        return default
+    if parsed < 1:
+        logger.warning(
+            "Invalid non-positive integer for %s=%r; using default=%s", name, value, default
+        )
+        return default
+    return parsed
 
 
 def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
@@ -34,35 +51,31 @@ def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
     return result
 
 
-def _chunk_list(values: list[str], size: int = RESOURCE_FETCH_BATCH_SIZE) -> Iterable[list[str]]:
+def _refresh_batch_size() -> int:
+    # BRIDGE_SEARCH_INDEX_MAX_RESOURCE_IDS used to be a total cap. Keep it as
+    # a compatibility alias, but interpret it as batch size so no IDs are lost.
+    legacy_batch_size = _env_int("BRIDGE_SEARCH_INDEX_MAX_RESOURCE_IDS", DEFAULT_REFRESH_BATCH_SIZE)
+    return _env_int("BRIDGE_SEARCH_INDEX_BATCH_SIZE", legacy_batch_size)
+
+
+def _chunk_list(values: list[str], size: int) -> Iterable[list[str]]:
     for start in range(0, len(values), size):
         yield values[start : start + size]
 
 
-async def index_changed_resources(resource_ids: Iterable[str]) -> dict[str, Any]:
-    """Targeted Elasticsearch refresh for resources imported by bridge delta sync."""
-
-    if not _env_bool("BRIDGE_SEARCH_INDEX_REFRESH_ENABLED", True):
-        return {"enabled": False, "resource_ids": 0, "indexed": 0, "errors": 0}
-
-    changed_ids = _dedupe_preserve_order(resource_ids)
-    if not changed_ids:
-        return {"enabled": True, "resource_ids": 0, "indexed": 0, "errors": 0}
-
-    if not database.is_connected:
-        await database.connect()
-
-    index_name = os.getenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
-    rows_by_id: dict[str, dict[str, Any]] = {}
-    for batch_ids in _chunk_list(changed_ids):
-        rows = await database.fetch_all(select(resources).where(resources.c.id.in_(batch_ids)))
-        rows_by_id.update({str(row["id"]): dict(row) for row in rows})
+async def _index_changed_resource_batch(
+    batch_ids: list[str],
+    *,
+    index_name: str,
+) -> dict[str, int]:
+    rows = await database.fetch_all(select(resources).where(resources.c.id.in_(batch_ids)))
+    rows_by_id = {str(row["id"]): dict(row) for row in rows}
 
     indexed = 0
     errors = 0
     missing = 0
 
-    for resource_id in changed_ids:
+    for resource_id in batch_ids:
         row = rows_by_id.get(resource_id)
         if not row:
             missing += 1
@@ -88,6 +101,36 @@ async def index_changed_resources(resource_ids: Iterable[str]) -> dict[str, Any]
             errors += 1
             logger.warning("Failed indexing bridge resource id=%s: %s", resource_id, exc)
 
+    return {"indexed": indexed, "missing": missing, "errors": errors}
+
+
+async def index_changed_resources(resource_ids: Iterable[str]) -> dict[str, Any]:
+    """Targeted Elasticsearch refresh for resources imported by bridge delta sync."""
+
+    if not _env_bool("BRIDGE_SEARCH_INDEX_REFRESH_ENABLED", True):
+        return {"enabled": False, "resource_ids": 0, "indexed": 0, "errors": 0}
+
+    changed_ids = _dedupe_preserve_order(resource_ids)
+    if not changed_ids:
+        return {"enabled": True, "resource_ids": 0, "indexed": 0, "errors": 0}
+
+    if not database.is_connected:
+        await database.connect()
+
+    index_name = os.getenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
+    batch_size = _refresh_batch_size()
+    batches = 0
+    indexed = 0
+    errors = 0
+    missing = 0
+
+    for batch_ids in _chunk_list(changed_ids, batch_size):
+        batches += 1
+        batch_stats = await _index_changed_resource_batch(batch_ids, index_name=index_name)
+        indexed += batch_stats["indexed"]
+        missing += batch_stats["missing"]
+        errors += batch_stats["errors"]
+
     try:
         await es.indices.refresh(index=index_name)
     except Exception as exc:
@@ -96,6 +139,8 @@ async def index_changed_resources(resource_ids: Iterable[str]) -> dict[str, Any]
     stats = {
         "enabled": True,
         "resource_ids": len(changed_ids),
+        "batch_size": batch_size,
+        "batches": batches,
         "indexed": indexed,
         "missing": missing,
         "errors": errors,

--- a/backend/app/services/bridge_sync/search_index.py
+++ b/backend/app/services/bridge_sync/search_index.py
@@ -12,6 +12,7 @@ from db.database import database
 from db.models import resources
 
 logger = logging.getLogger(__name__)
+RESOURCE_FETCH_BATCH_SIZE = 1000
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -19,17 +20,6 @@ def _env_bool(name: str, default: bool) -> bool:
     if value is None:
         return default
     return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
-
-
-def _env_int(name: str, default: int) -> int:
-    value = os.getenv(name)
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except ValueError:
-        logger.warning("Invalid integer for %s=%r; using default=%s", name, value, default)
-        return default
 
 
 def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
@@ -44,14 +34,18 @@ def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
     return result
 
 
+def _chunk_list(values: list[str], size: int = RESOURCE_FETCH_BATCH_SIZE) -> Iterable[list[str]]:
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
 async def index_changed_resources(resource_ids: Iterable[str]) -> dict[str, Any]:
     """Targeted Elasticsearch refresh for resources imported by bridge delta sync."""
 
     if not _env_bool("BRIDGE_SEARCH_INDEX_REFRESH_ENABLED", True):
         return {"enabled": False, "resource_ids": 0, "indexed": 0, "errors": 0}
 
-    max_resource_ids = _env_int("BRIDGE_SEARCH_INDEX_MAX_RESOURCE_IDS", 5000)
-    changed_ids = _dedupe_preserve_order(resource_ids)[:max_resource_ids]
+    changed_ids = _dedupe_preserve_order(resource_ids)
     if not changed_ids:
         return {"enabled": True, "resource_ids": 0, "indexed": 0, "errors": 0}
 
@@ -59,8 +53,10 @@ async def index_changed_resources(resource_ids: Iterable[str]) -> dict[str, Any]
         await database.connect()
 
     index_name = os.getenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
-    rows = await database.fetch_all(select(resources).where(resources.c.id.in_(changed_ids)))
-    rows_by_id = {str(row["id"]): dict(row) for row in rows}
+    rows_by_id: dict[str, dict[str, Any]] = {}
+    for batch_ids in _chunk_list(changed_ids):
+        rows = await database.fetch_all(select(resources).where(resources.c.id.in_(batch_ids)))
+        rows_by_id.update({str(row["id"]): dict(row) for row in rows})
 
     indexed = 0
     errors = 0

--- a/backend/tests/services/test_bridge_cache_refresh.py
+++ b/backend/tests/services/test_bridge_cache_refresh.py
@@ -72,6 +72,45 @@ async def test_refresh_cache_for_changed_resources_deletes_durable_and_warms_ass
 
 
 @pytest.mark.asyncio
+async def test_refresh_cache_for_changed_resources_invalidates_every_changed_id(
+    monkeypatch,
+):
+    fake_cache = FakeCacheService()
+    monkeypatch.setattr(cache_refresh, "ENDPOINT_CACHE", True)
+    monkeypatch.setenv("BRIDGE_CACHE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("BRIDGE_CACHE_REFRESH_MAX_RESOURCE_IDS", "1")
+    monkeypatch.setenv("BRIDGE_CACHE_REWARM_MAX_URLS", "0")
+
+    with (
+        patch.object(cache_refresh, "CacheService", return_value=fake_cache),
+        patch.object(
+            cache_refresh,
+            "delete_resource_representations",
+            new=AsyncMock(return_value={"durable_deleted": True}),
+        ) as mock_delete_representations,
+        patch.object(
+            cache_refresh,
+            "_warm_generated_assets_for_changed_resources",
+            new=AsyncMock(return_value={"enabled": True, "resources": 3}),
+        ) as mock_warm_assets,
+    ):
+        stats = await cache_refresh.refresh_cache_for_changed_resources(
+            ["resource-1", "resource-2", "resource-1", "resource-3"]
+        )
+
+    expected_ids = ["resource-1", "resource-2", "resource-3"]
+    expected_tags = [f"resource:{resource_id}" for resource_id in expected_ids]
+    assert stats["resource_ids"] == 3
+    assert fake_cache.cached_records_calls == [expected_tags]
+    assert fake_cache.invalidate_calls == [expected_tags]
+    mock_delete_representations.assert_awaited_once_with(
+        expected_ids,
+        cache_service=fake_cache,
+    )
+    mock_warm_assets.assert_awaited_once_with(expected_ids)
+
+
+@pytest.mark.asyncio
 async def test_warm_generated_assets_for_changed_resources_warms_all_generated_assets(
     monkeypatch,
 ):

--- a/backend/tests/services/test_bridge_cache_refresh.py
+++ b/backend/tests/services/test_bridge_cache_refresh.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
@@ -24,7 +24,7 @@ class FakeCacheService:
 
     async def invalidate_tags(self, tags):
         self.invalidate_calls.append(list(tags))
-        return 3
+        return len(tags)
 
 
 @pytest.mark.asyncio
@@ -55,7 +55,7 @@ async def test_refresh_cache_for_changed_resources_deletes_durable_and_warms_ass
 
     assert stats["enabled"] is True
     assert stats["resource_ids"] == 1
-    assert stats["invalidated"] == 3
+    assert stats["invalidated"] == 1
     assert stats["resource_representations_deleted"] == {
         "durable_deleted": True,
         "redis_deleted": 2,
@@ -81,6 +81,9 @@ async def test_refresh_cache_for_changed_resources_invalidates_every_changed_id(
     monkeypatch.setenv("BRIDGE_CACHE_REFRESH_MAX_RESOURCE_IDS", "1")
     monkeypatch.setenv("BRIDGE_CACHE_REWARM_MAX_URLS", "0")
 
+    async def fake_warm_assets(resource_ids):
+        return {"enabled": True, "resources": len(resource_ids)}
+
     with (
         patch.object(cache_refresh, "CacheService", return_value=fake_cache),
         patch.object(
@@ -91,7 +94,7 @@ async def test_refresh_cache_for_changed_resources_invalidates_every_changed_id(
         patch.object(
             cache_refresh,
             "_warm_generated_assets_for_changed_resources",
-            new=AsyncMock(return_value={"enabled": True, "resources": 3}),
+            new=AsyncMock(side_effect=fake_warm_assets),
         ) as mock_warm_assets,
     ):
         stats = await cache_refresh.refresh_cache_for_changed_resources(
@@ -99,15 +102,24 @@ async def test_refresh_cache_for_changed_resources_invalidates_every_changed_id(
         )
 
     expected_ids = ["resource-1", "resource-2", "resource-3"]
-    expected_tags = [f"resource:{resource_id}" for resource_id in expected_ids]
+    expected_tag_batches = [[f"resource:{resource_id}"] for resource_id in expected_ids]
     assert stats["resource_ids"] == 3
-    assert fake_cache.cached_records_calls == [expected_tags]
-    assert fake_cache.invalidate_calls == [expected_tags]
-    mock_delete_representations.assert_awaited_once_with(
-        expected_ids,
-        cache_service=fake_cache,
-    )
-    mock_warm_assets.assert_awaited_once_with(expected_ids)
+    assert stats["batch_size"] == 1
+    assert stats["batches"] == 3
+    assert stats["invalidated"] == 3
+    assert stats["generated_assets"] == {"enabled": True, "resources": 3}
+    assert fake_cache.cached_records_calls == expected_tag_batches
+    assert fake_cache.invalidate_calls == expected_tag_batches
+    assert mock_delete_representations.await_args_list == [
+        call(["resource-1"], cache_service=fake_cache),
+        call(["resource-2"], cache_service=fake_cache),
+        call(["resource-3"], cache_service=fake_cache),
+    ]
+    assert mock_warm_assets.await_args_list == [
+        call(["resource-1"]),
+        call(["resource-2"]),
+        call(["resource-3"]),
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_bridge_search_index.py
+++ b/backend/tests/services/test_bridge_search_index.py
@@ -1,0 +1,87 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.services.bridge_sync.search_index as search_index
+
+
+class FakeDatabase:
+    def __init__(self, rows):
+        self.is_connected = True
+        self.rows = rows
+
+    async def connect(self):
+        self.is_connected = True
+
+    async def fetch_all(self, _query):
+        return self.rows
+
+
+class FakeIndices:
+    def __init__(self):
+        self.refreshed = []
+
+    async def refresh(self, *, index):
+        self.refreshed.append(index)
+
+
+class FakeElasticsearch:
+    def __init__(self):
+        self.indexed = []
+        self.deleted = []
+        self.indices = FakeIndices()
+
+    async def index(self, *, index, id, document):
+        self.indexed.append({"index": index, "id": id, "document": document})
+
+    async def delete(self, *, index, id, ignore_status):
+        self.deleted.append({"index": index, "id": id, "ignore_status": ignore_status})
+
+
+@pytest.mark.asyncio
+async def test_index_changed_resources_indexes_every_changed_id_even_if_legacy_limit_is_set(
+    monkeypatch,
+):
+    rows = [{"id": f"resource-{i}", "dct_title_s": f"Resource {i}"} for i in range(3)]
+    fake_database = FakeDatabase(rows)
+    fake_es = FakeElasticsearch()
+
+    async def fake_process_resource(row):
+        return {"id": row["id"], "title": row["dct_title_s"]}
+
+    monkeypatch.setenv("BRIDGE_SEARCH_INDEX_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("BRIDGE_SEARCH_INDEX_MAX_RESOURCE_IDS", "1")
+    monkeypatch.setenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
+    monkeypatch.setattr(search_index, "database", fake_database)
+    monkeypatch.setattr(search_index, "es", fake_es)
+    monkeypatch.setattr(search_index, "process_resource", fake_process_resource)
+
+    stats = await search_index.index_changed_resources(
+        ["resource-0", "resource-1", "resource-0", "", "resource-2"]
+    )
+
+    assert stats == {
+        "enabled": True,
+        "resource_ids": 3,
+        "indexed": 3,
+        "missing": 0,
+        "errors": 0,
+    }
+    assert [entry["id"] for entry in fake_es.indexed] == [
+        "resource-0",
+        "resource-1",
+        "resource-2",
+    ]
+    assert fake_es.indices.refreshed == ["btaa_geospatial_api"]
+
+
+@pytest.mark.asyncio
+async def test_index_changed_resources_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("BRIDGE_SEARCH_INDEX_REFRESH_ENABLED", "false")
+    monkeypatch.setattr(search_index, "database", FakeDatabase([]))
+    monkeypatch.setattr(search_index, "es", FakeElasticsearch())
+    monkeypatch.setattr(search_index, "process_resource", AsyncMock())
+
+    stats = await search_index.index_changed_resources(["resource-1"])
+
+    assert stats == {"enabled": False, "resource_ids": 0, "indexed": 0, "errors": 0}

--- a/backend/tests/services/test_bridge_search_index.py
+++ b/backend/tests/services/test_bridge_search_index.py
@@ -9,11 +9,13 @@ class FakeDatabase:
     def __init__(self, rows):
         self.is_connected = True
         self.rows = rows
+        self.fetch_calls = 0
 
     async def connect(self):
         self.is_connected = True
 
     async def fetch_all(self, _query):
+        self.fetch_calls += 1
         return self.rows
 
 
@@ -63,6 +65,8 @@ async def test_index_changed_resources_indexes_every_changed_id_even_if_legacy_l
     assert stats == {
         "enabled": True,
         "resource_ids": 3,
+        "batch_size": 1,
+        "batches": 3,
         "indexed": 3,
         "missing": 0,
         "errors": 0,
@@ -72,6 +76,7 @@ async def test_index_changed_resources_indexes_every_changed_id_even_if_legacy_l
         "resource-1",
         "resource-2",
     ]
+    assert fake_database.fetch_calls == 3
     assert fake_es.indices.refreshed == ["btaa_geospatial_api"]
 
 

--- a/backend/tests/services/test_bridge_sync_report.py
+++ b/backend/tests/services/test_bridge_sync_report.py
@@ -72,6 +72,32 @@ def test_build_bridge_sync_report_flags_low_delta(monkeypatch):
     assert "Delta processed only 2 resources" in text
 
 
+def test_build_bridge_sync_report_flags_partial_elasticsearch_refresh():
+    run = _sample_run(processed=8945)
+    run["bridge_stats_json"]["search_index_refresh"] = {
+        "enabled": True,
+        "resource_ids": 5000,
+        "indexed": 5000,
+        "errors": 0,
+    }
+
+    text = build_bridge_sync_report_text(run, recent_runs=[])
+
+    assert "Elasticsearch refresh received only 5,000 of 8,945 changed resource IDs." in text
+
+
+def test_build_bridge_sync_report_flags_cache_refresh_error():
+    run = _sample_run()
+    run["bridge_stats_json"]["cache_refresh"] = {
+        "enabled": True,
+        "error": "No __appsignal__.py file found",
+    }
+
+    text = build_bridge_sync_report_text(run, recent_runs=[])
+
+    assert "Cache refresh failed: No __appsignal__.py file found." in text
+
+
 def test_send_bridge_sync_report_email_skips_when_disabled(monkeypatch):
     monkeypatch.delenv("BRIDGE_SYNC_REPORT_ENABLED", raising=False)
 


### PR DESCRIPTION
## Summary

- Remove the hard total cap on bridge delta Elasticsearch refreshes so every changed resource ID is handled.
- Process bridge Elasticsearch refresh work in configurable batches of 5,000 by default.
- Process bridge cache invalidation/generated asset refresh work in configurable batches of 5,000 by default while keeping URL rewarm bounded.
- Keep the old `BRIDGE_SEARCH_INDEX_MAX_RESOURCE_IDS` and `BRIDGE_CACHE_REFRESH_MAX_RESOURCE_IDS` env vars as compatibility aliases for batch size, not total limits.
- Add bridge sync report warnings for partial Elasticsearch refreshes and cache refresh failures.
- Add tests for uncapped batched indexing/cache invalidation and the new report warnings.

## Root Cause

The May 23 production bridge run imported 8,945 changed resources, but the targeted Elasticsearch refresh only processed the first 5,000 IDs. That left a tail of stale ES documents/facets even though the database rows had the corrected provider/publisher values.

## Implementation Notes

The fix keeps the operational guardrail that large deltas should be chunked. The `5000` value now controls batch size, so a 300K-item delta is processed as multiple batches rather than one giant request or a truncated first slice.

## Validation

- `BTAA_SKIP_TEST_DB=true python -m pytest backend/tests/services/test_bridge_search_index.py backend/tests/services/test_bridge_cache_refresh.py backend/tests/services/test_bridge_sync_report.py`
- `ruff format --check backend/app/services/bridge_sync/search_index.py backend/app/services/bridge_sync/cache_refresh.py backend/app/services/bridge_sync/report.py backend/tests/services/test_bridge_search_index.py backend/tests/services/test_bridge_cache_refresh.py backend/tests/services/test_bridge_sync_report.py`
- `ruff check backend/app/services/bridge_sync/search_index.py backend/app/services/bridge_sync/cache_refresh.py backend/app/services/bridge_sync/report.py backend/tests/services/test_bridge_search_index.py backend/tests/services/test_bridge_cache_refresh.py backend/tests/services/test_bridge_sync_report.py`
- `git diff --check`

Refs #145