### PR TITLE
Re-add Allmaps viewing to the Geoportal

### DIFF
--- a/frontend/src/__tests__/components/ResourceView.test.tsx
+++ b/frontend/src/__tests__/components/ResourceView.test.tsx
@@ -13,6 +13,14 @@ vi.mock('../../services/analytics', () => ({
   scheduleAnalyticsBatch: vi.fn(),
 }));
 
+vi.mock('../../components/resource/AllmapsOverlayViewer', () => ({
+  AllmapsOverlayViewer: () => (
+    <div data-testid="allmaps-overlay-viewer">
+      Allmaps georeferenced map overlay
+    </div>
+  ),
+}));
+
 // Mock the API functions to return real fixture data
 vi.mock('../../services/api', () => ({
   fetchResourceDetails: vi.fn(),
@@ -312,6 +320,40 @@ const mockResourceWithLicensedAccesses: GeoDocument = {
           legacy_friendlier_id: '999-0001',
         },
       ],
+    },
+  },
+};
+
+const allmapsManifestUrl = 'https://example.com/iiif/manifest.json';
+const mockResourceWithAllmaps: GeoDocument = {
+  ...mockResourceData,
+  meta: {
+    ui: {
+      ...mockResourceData.meta?.ui,
+      viewer: {
+        protocol: 'wms',
+        endpoint: 'https://example.com/wms-allmaps-test',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [-91.5, 42.5],
+              [-87.017, 42.5],
+              [-87.017, 36.967],
+              [-91.5, 36.967],
+              [-91.5, 42.5],
+            ],
+          ],
+        },
+      },
+      allmaps: {
+        allmaps_id: '945e08a1a7c98ca3',
+        allmaps_annotated: true,
+        allmaps_manifest_uri: allmapsManifestUrl,
+        allmaps_annotation_url: `https://annotations.allmaps.org/?url=${encodeURIComponent(
+          allmapsManifestUrl
+        )}`,
+      },
     },
   },
 };
@@ -927,6 +969,58 @@ describe('ResourceView Component', () => {
 
       const indexMapContainer = document.querySelector('.viewer-information');
       expect(indexMapContainer).toBeInTheDocument();
+    });
+
+    it('renders Allmaps viewer tabs and sidebar links when an overlay is available', async () => {
+      const user = userEvent.setup();
+      fetchResourceDetails.mockResolvedValue(mockResourceWithAllmaps);
+
+      render(
+        <TestWrapper>
+          <ResourceView />
+        </TestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', {
+            name: 'Nondigitized paper map with library catalog link',
+          })
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('tab', { name: 'Item Viewer' })
+      ).toBeInTheDocument();
+      const mapOverlayTab = screen.getByRole('tab', { name: 'Map Overlay' });
+      expect(mapOverlayTab).toBeInTheDocument();
+
+      const viewerLink = screen.getByRole('link', {
+        name: /View map in the Allmaps viewer/i,
+      });
+      const editorLink = screen.getByRole('link', {
+        name: /Edit map control points with Allmaps editor/i,
+      });
+      expect(viewerLink).toHaveAttribute(
+        'href',
+        expect.stringContaining('https://viewer.allmaps.org/')
+      );
+      expect(viewerLink).toHaveAttribute(
+        'href',
+        expect.stringContaining('annotations.allmaps.org')
+      );
+      expect(editorLink).toHaveAttribute(
+        'href',
+        expect.stringContaining('https://editor.allmaps.org/#/collection')
+      );
+      expect(editorLink).toHaveAttribute(
+        'href',
+        expect.stringContaining(encodeURIComponent(allmapsManifestUrl))
+      );
+
+      await user.click(mapOverlayTab);
+
+      expect(screen.getByTestId('allmaps-overlay-viewer')).toBeInTheDocument();
     });
 
     it('renders LocationMap when geometry is available', async () => {

--- a/frontend/src/components/resource/AllmapsLinksCard.tsx
+++ b/frontend/src/components/resource/AllmapsLinksCard.tsx
@@ -1,0 +1,106 @@
+import { ExternalLink, Layers, PencilLine } from 'lucide-react';
+import { scheduleAnalyticsBatch } from '../../services/analytics';
+import {
+  type AllmapsAttributes,
+  getAllmapsEditorUrl,
+  getAllmapsViewerUrl,
+} from '../../utils/allmaps';
+
+interface AllmapsLinksCardProps {
+  allmaps: AllmapsAttributes | null | undefined;
+  resourceId?: string;
+  searchId?: string;
+}
+
+export function AllmapsLinksCard({
+  allmaps,
+  resourceId,
+  searchId,
+}: AllmapsLinksCardProps) {
+  const viewerUrl = getAllmapsViewerUrl(allmaps);
+  const editorUrl = getAllmapsEditorUrl(allmaps);
+
+  if (!viewerUrl && !editorUrl) return null;
+
+  const trackClick = (
+    label: string,
+    destinationUrl: string,
+    eventType: 'allmaps_viewer_click' | 'allmaps_editor_click'
+  ) => {
+    scheduleAnalyticsBatch({
+      events: [
+        {
+          event_type: eventType,
+          search_id: searchId,
+          resource_id: resourceId,
+          label,
+          destination_url: destinationUrl,
+          source_component: 'AllmapsLinksCard',
+        },
+      ],
+    });
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden">
+      <div className="px-6 py-4 bg-gray-50 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">Map Overlay</h2>
+      </div>
+      <div className="divide-y divide-gray-200">
+        {viewerUrl && (
+          <a
+            href={viewerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              trackClick(
+                'View map in the Allmaps viewer',
+                viewerUrl,
+                'allmaps_viewer_click'
+              )
+            }
+            className="flex items-center gap-3 px-6 py-4 text-sm font-medium text-blue-600 hover:bg-gray-50 hover:text-blue-800 hover:underline"
+          >
+            <Layers className="h-5 w-5 shrink-0 text-gray-400" />
+            <span className="min-w-0 flex-1">
+              View map in the Allmaps viewer
+            </span>
+            <ExternalLink className="h-4 w-4 shrink-0 text-gray-400" />
+          </a>
+        )}
+        {editorUrl && (
+          <a
+            href={editorUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              trackClick(
+                'Edit map control points with Allmaps editor',
+                editorUrl,
+                'allmaps_editor_click'
+              )
+            }
+            className="flex items-center gap-3 px-6 py-4 text-sm font-medium text-blue-600 hover:bg-gray-50 hover:text-blue-800 hover:underline"
+          >
+            <PencilLine className="h-5 w-5 shrink-0 text-gray-400" />
+            <span className="min-w-0 flex-1">
+              Edit map control points with Allmaps editor
+            </span>
+            <ExternalLink className="h-4 w-4 shrink-0 text-gray-400" />
+          </a>
+        )}
+      </div>
+      <div className="border-t border-gray-200 bg-gray-50 px-6 py-3">
+        <a
+          href="https://allmaps.org"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-sm font-medium text-gray-700 hover:text-blue-700 hover:underline"
+        >
+          <Layers className="h-4 w-4" />
+          Allmaps
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/resource/AllmapsOverlayViewer.client.tsx
+++ b/frontend/src/components/resource/AllmapsOverlayViewer.client.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { attachBasemapSwitcher } from '../../config/basemaps';
+import { leafletGestureMapOptions } from '../../config/leafletConfig';
+import { registerLeafletGestureHandling } from '../../config/leafletGestureHandling';
+import { getBboxFromGeometry } from '../../utils/geometryUtils';
+import {
+  type AllmapsAttributes,
+  getAllmapsAnnotationUrl,
+} from '../../utils/allmaps';
+
+type AllmapsGeometry =
+  | string
+  | GeoJSON.Geometry
+  | GeoJSON.Feature
+  | { wkt: string }
+  | null
+  | undefined;
+
+interface AllmapsOverlayViewerProps {
+  allmaps: AllmapsAttributes | null | undefined;
+  geometry?: AllmapsGeometry;
+}
+
+const DEFAULT_OPACITY = 0.75;
+const DEFAULT_CENTER: L.LatLngExpression = [44.5, -89.5];
+
+function getGeometryBounds(geometry: AllmapsGeometry): L.LatLngBounds | null {
+  const bbox = getBboxFromGeometry(
+    geometry as Parameters<typeof getBboxFromGeometry>[0]
+  );
+  if (!bbox) return null;
+
+  const bounds = L.latLngBounds(bbox[0], bbox[1]);
+  return bounds.isValid() ? bounds : null;
+}
+
+function getLayerBounds(layer: unknown): L.LatLngBounds | null {
+  const layerWithBounds = layer as {
+    getBounds?: () => L.LatLngBounds | null | undefined;
+  };
+
+  try {
+    const bounds = layerWithBounds.getBounds?.();
+    return bounds?.isValid?.() ? bounds : null;
+  } catch {
+    return null;
+  }
+}
+
+export function AllmapsOverlayViewer({
+  allmaps,
+  geometry,
+}: AllmapsOverlayViewerProps) {
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const basemapCleanupRef = useRef<(() => void) | null>(null);
+  const layerRef = useRef<{ setOpacity?: (opacity: number) => void } | null>(
+    null
+  );
+  const [opacity, setOpacity] = useState(DEFAULT_OPACITY);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const annotationUrl = useMemo(
+    () => getAllmapsAnnotationUrl(allmaps),
+    [allmaps]
+  );
+
+  useEffect(() => {
+    const container = mapContainerRef.current;
+    if (!container || !annotationUrl) {
+      setIsLoading(false);
+      setError(annotationUrl ? null : 'Map overlay is not available.');
+      return;
+    }
+
+    let cancelled = false;
+    let removeWarpedMapListener: (() => void) | null = null;
+    const fitTimeouts: number[] = [];
+    setIsLoading(true);
+    setError(null);
+
+    registerLeafletGestureHandling(L);
+    const map = L.map(container, {
+      ...leafletGestureMapOptions,
+      zoomAnimationThreshold: 1,
+      worldCopyJump: true,
+    }).setView(DEFAULT_CENTER, 5);
+    mapRef.current = map;
+    basemapCleanupRef.current = attachBasemapSwitcher(map, L);
+
+    const fallbackBounds = getGeometryBounds(geometry);
+    if (fallbackBounds) {
+      map.fitBounds(fallbackBounds, { padding: [24, 24] });
+    }
+
+    const refitToLayer = () => {
+      if (cancelled || !layerRef.current) return;
+      const layerBounds = getLayerBounds(layerRef.current);
+      if (layerBounds) {
+        map.fitBounds(layerBounds, {
+          padding: [28, 28],
+          maxZoom: 15,
+        });
+      } else if (fallbackBounds) {
+        map.fitBounds(fallbackBounds, { padding: [24, 24] });
+      }
+      map.invalidateSize();
+    };
+
+    async function addAllmapsLayer() {
+      try {
+        const { WarpedMapLayer } = await import('@allmaps/leaflet');
+        if (cancelled) return;
+
+        const layer = new WarpedMapLayer(annotationUrl, {
+          opacity: DEFAULT_OPACITY,
+        });
+        layerRef.current = layer as {
+          setOpacity?: (opacity: number) => void;
+        };
+
+        map.on('warpedmapadded', refitToLayer);
+        removeWarpedMapListener = () => map.off('warpedmapadded', refitToLayer);
+
+        layer.addTo(map);
+        window.requestAnimationFrame(() => {
+          if (!cancelled) {
+            map.invalidateSize();
+            refitToLayer();
+          }
+        });
+        [300, 900, 1600].forEach((delay) => {
+          fitTimeouts.push(
+            window.setTimeout(() => {
+              refitToLayer();
+            }, delay)
+          );
+        });
+      } catch (err) {
+        if (!cancelled) {
+          console.warn('Allmaps overlay failed to load:', err);
+          setError('Unable to load the Allmaps overlay.');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void addAllmapsLayer();
+
+    return () => {
+      cancelled = true;
+      fitTimeouts.forEach((id) => window.clearTimeout(id));
+      removeWarpedMapListener?.();
+      basemapCleanupRef.current?.();
+      basemapCleanupRef.current = null;
+      layerRef.current = null;
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [annotationUrl, geometry]);
+
+  useEffect(() => {
+    layerRef.current?.setOpacity?.(opacity);
+  }, [opacity]);
+
+  return (
+    <div className="pa11y-ignore-map-contrast">
+      <div className="border-b border-gray-200 bg-white px-4 py-3">
+        <h2 className="text-base font-semibold text-gray-900">
+          Allmaps georeferenced map overlay
+        </h2>
+      </div>
+      <div className="relative h-[600px] w-full bg-gray-100">
+        <div ref={mapContainerRef} className="h-full w-full" />
+
+        <label className="absolute bottom-4 left-4 z-[500] flex items-center gap-2 rounded-md border border-gray-200 bg-white/95 px-3 py-2 text-xs font-medium text-gray-700 shadow-sm">
+          <span>Opacity</span>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            value={opacity}
+            onChange={(event) => setOpacity(Number(event.target.value))}
+            className="w-28 accent-blue-600"
+            aria-label="Allmaps overlay opacity"
+          />
+          <span className="w-8 text-right">{Math.round(opacity * 100)}%</span>
+        </label>
+
+        {isLoading && (
+          <div className="absolute inset-0 z-[450] flex items-center justify-center bg-white/70 text-sm font-medium text-gray-600">
+            Loading overlay...
+          </div>
+        )}
+
+        {error && (
+          <div className="absolute inset-x-4 top-4 z-[500] rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 shadow-sm">
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AllmapsOverlayViewer;

--- a/frontend/src/components/resource/AllmapsOverlayViewer.tsx
+++ b/frontend/src/components/resource/AllmapsOverlayViewer.tsx
@@ -1,0 +1,38 @@
+import React, { Suspense, useEffect, useState } from 'react';
+import type { AllmapsAttributes } from '../../utils/allmaps';
+
+type AllmapsGeometry =
+  | string
+  | GeoJSON.Geometry
+  | GeoJSON.Feature
+  | { wkt: string }
+  | null
+  | undefined;
+
+interface AllmapsOverlayViewerProps {
+  allmaps: AllmapsAttributes | null | undefined;
+  geometry?: AllmapsGeometry;
+}
+
+const AllmapsOverlayViewerClient = React.lazy(
+  () => import('./AllmapsOverlayViewer.client')
+);
+
+export function AllmapsOverlayViewer(props: AllmapsOverlayViewerProps) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <div className="h-[600px] bg-gray-100 text-sm text-gray-500">
+        Loading overlay...
+      </div>
+    );
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <AllmapsOverlayViewerClient {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/src/pages/ResourceView.tsx
+++ b/frontend/src/pages/ResourceView.tsx
@@ -17,7 +17,10 @@ import { useApi } from '../context/ApiContext';
 import { ResourceViewer } from '../components/resource/ResourceViewer';
 import { ResourceBreadcrumbs } from '../components/resource/ResourceBreadcrumbs';
 import { ResourceSubtitle } from '../components/resource/ResourceSubtitle';
-import { CitationTable } from '../components/resource/CitationTable';
+import {
+  CitationTable,
+  type CitationStyle,
+} from '../components/resource/CitationTable';
 import { FullDetailsTable } from '../components/resource/FullDetailsTable';
 import { LocationMap } from '../components/resource/LocationMap';
 import { DownloadsTable } from '../components/resource/DownloadsTable';
@@ -31,6 +34,9 @@ import { DataDictionariesSection } from '../components/resource/DataDictionaries
 import { LightboxModal } from '../components/ui/LightboxModal';
 import { scheduleAnalyticsBatch } from '../services/analytics';
 import { SEARCH_RESULTS_PER_PAGE } from '../constants/search';
+import { AllmapsOverlayViewer } from '../components/resource/AllmapsOverlayViewer';
+import { AllmapsLinksCard } from '../components/resource/AllmapsLinksCard';
+import { hasAllmapsOverlay } from '../utils/allmaps';
 
 // Define types for search results
 interface SearchResult {
@@ -75,8 +81,15 @@ interface ResourceData extends GeoDocument {
         legacy_friendlier_id?: string | null;
       }>;
       citation?: string;
+      citations?: Partial<Record<CitationStyle, string>>;
       thumbnail_url?: string;
       static_map?: string;
+      allmaps?: {
+        allmaps_id?: string | null;
+        allmaps_annotated?: boolean;
+        allmaps_manifest_uri?: string | null;
+        allmaps_annotation_url?: string | null;
+      };
       links?: Record<
         string,
         Array<{
@@ -175,6 +188,9 @@ export function ResourceView({
   const [errorStatus, setErrorStatus] = useState<number | null>(null);
   const [isDataDictionaryModalOpen, setIsDataDictionaryModalOpen] =
     useState(false);
+  const [activeViewerTab, setActiveViewerTab] = useState<
+    'item' | 'allmaps'
+  >('item');
   const { setLastApiUrl } = useApi();
   const trackedResourceViewRef = useRef<string | null>(null);
 
@@ -446,6 +462,14 @@ export function ResourceView({
     });
   }, [absoluteCurrentIndex, data?.id, searchState]);
 
+  useEffect(() => {
+    if (!data?.id) return;
+    const nextViewerProtocol = data.meta?.ui?.viewer?.protocol;
+    setActiveViewerTab(
+      !nextViewerProtocol && hasAllmapsOverlay(data) ? 'allmaps' : 'item'
+    );
+  }, [data]);
+
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -496,6 +520,19 @@ export function ResourceView({
   // Extract data from the new structure
   const viewerProtocol = data?.meta?.ui?.viewer?.protocol;
   const dataDictionaries = data?.attributes?.b1g?.data_dictionaries || [];
+  const allmapsAttributes = data?.meta?.ui?.allmaps;
+  const hasAllmapsViewer = hasAllmapsOverlay(data);
+  const resourceGeometry =
+    data?.meta?.ui?.viewer?.geometry ||
+    data?.attributes?.ogm?.locn_geometry_original ||
+    data?.attributes?.ogm?.locn_geometry ||
+    null;
+  const showViewerTabs = Boolean(viewerProtocol && hasAllmapsViewer);
+  const showItemViewer =
+    Boolean(viewerProtocol) &&
+    (!showViewerTabs || activeViewerTab === 'item');
+  const showAllmapsViewer =
+    hasAllmapsViewer && (!showViewerTabs || activeViewerTab === 'allmaps');
 
   // Open Graph / Twitter card image: prefer thumbnail; when none or placeholder, use static map when available
   const thumbnailUrl = data?.meta?.ui?.thumbnail_url;
@@ -608,20 +645,89 @@ export function ResourceView({
 
                 {/* Viewer section */}
                 <div className="lg:col-span-8 space-y-6">
-                  {viewerProtocol && (
+                  {(viewerProtocol || hasAllmapsViewer) && (
                     <div className="bg-white rounded-lg shadow-md overflow-hidden">
-                      <div className="">
-                        <ResourceViewer data={data} pageValue="SHOW" />
-                      </div>
+                      {showViewerTabs && (
+                        <div
+                          role="tablist"
+                          aria-label="Resource viewer modes"
+                          className="flex border-b border-gray-200 bg-white px-4 pt-3"
+                        >
+                          <button
+                            type="button"
+                            role="tab"
+                            id="resource-viewer-item-tab"
+                            aria-controls="resource-viewer-item-panel"
+                            aria-selected={activeViewerTab === 'item'}
+                            onClick={() => setActiveViewerTab('item')}
+                            className={`-mb-px border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
+                              activeViewerTab === 'item'
+                                ? 'border-blue-600 text-blue-700'
+                                : 'border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-900'
+                            }`}
+                          >
+                            Item Viewer
+                          </button>
+                          <button
+                            type="button"
+                            role="tab"
+                            id="resource-viewer-allmaps-tab"
+                            aria-controls="resource-viewer-allmaps-panel"
+                            aria-selected={activeViewerTab === 'allmaps'}
+                            onClick={() => setActiveViewerTab('allmaps')}
+                            className={`-mb-px border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
+                              activeViewerTab === 'allmaps'
+                                ? 'border-blue-600 text-blue-700'
+                                : 'border-transparent text-gray-600 hover:border-gray-300 hover:text-gray-900'
+                            }`}
+                          >
+                            Map Overlay
+                          </button>
+                        </div>
+                      )}
+
+                      {showItemViewer && (
+                        <div
+                          role={showViewerTabs ? 'tabpanel' : undefined}
+                          id="resource-viewer-item-panel"
+                          aria-labelledby={
+                            showViewerTabs
+                              ? 'resource-viewer-item-tab'
+                              : undefined
+                          }
+                        >
+                          <ResourceViewer data={data} pageValue="SHOW" />
+                        </div>
+                      )}
+
+                      {showAllmapsViewer && (
+                        <div
+                          role={showViewerTabs ? 'tabpanel' : undefined}
+                          id="resource-viewer-allmaps-panel"
+                          aria-labelledby={
+                            showViewerTabs
+                              ? 'resource-viewer-allmaps-tab'
+                              : undefined
+                          }
+                        >
+                          <AllmapsOverlayViewer
+                            allmaps={allmapsAttributes}
+                            geometry={resourceGeometry}
+                          />
+                        </div>
+                      )}
                     </div>
                   )}
 
                   {/* Conditionally render the attribute table if the protocol is 'wms' or 'arcgis_feature_layer' */}
-                  {(viewerProtocol === 'wms' ||
-                    viewerProtocol === 'arcgis_feature_layer') && (
-                    <AttributeTable />
+                  {showItemViewer &&
+                    (viewerProtocol === 'wms' ||
+                      viewerProtocol === 'arcgis_feature_layer') && (
+                      <AttributeTable />
+                    )}
+                  {showItemViewer && viewerProtocol === 'open_index_map' && (
+                    <IndexMap />
                   )}
-                  {viewerProtocol === 'open_index_map' && <IndexMap />}
 
                   {/* Add Full Details table */}
                   <FullDetailsTable
@@ -633,14 +739,10 @@ export function ResourceView({
                 <div className="lg:col-span-4">
                   <div className="lg:sticky lg:top-[88px] space-y-6">
                     {/* Location Map - using geometry from viewer, original geometry, or locn_geometry */}
-                    {(data?.meta?.ui?.viewer?.geometry ||
-                      data?.attributes?.ogm?.locn_geometry_original ||
-                      data?.attributes?.ogm?.locn_geometry) && (
+                    {resourceGeometry && (
                       <LocationMap
                         geometry={
-                          (data?.meta?.ui?.viewer?.geometry ||
-                            data?.attributes?.ogm?.locn_geometry_original ||
-                            data?.attributes?.ogm?.locn_geometry) as
+                          resourceGeometry as
                             | string
                             | GeoJSON.Polygon
                             | GeoJSON.MultiPolygon
@@ -711,6 +813,14 @@ export function ResourceView({
                           searchId={searchState?.searchId}
                         />
                       </div>
+                    )}
+
+                    {hasAllmapsViewer && (
+                      <AllmapsLinksCard
+                        allmaps={allmapsAttributes}
+                        resourceId={data.id}
+                        searchId={searchState?.searchId}
+                      />
                     )}
                   </div>
                 </div>

--- a/frontend/src/utils/allmaps.ts
+++ b/frontend/src/utils/allmaps.ts
@@ -1,0 +1,76 @@
+import type { GeoDocumentDetails } from '../types/api';
+
+export interface AllmapsAttributes {
+  allmaps_id?: string | null;
+  allmaps_annotated?: boolean;
+  allmaps_manifest_uri?: string | null;
+  allmaps_annotation_url?: string | null;
+}
+
+interface AllmapsResource {
+  meta?: {
+    ui?: {
+      allmaps?: AllmapsAttributes | null;
+    };
+  };
+}
+
+export function getAllmapsAttributes(
+  resource: AllmapsResource | GeoDocumentDetails | null | undefined
+): AllmapsAttributes | null {
+  return resource?.meta?.ui?.allmaps ?? null;
+}
+
+export function getAllmapsAnnotationUrl(
+  allmaps: AllmapsAttributes | null | undefined
+): string | null {
+  if (!allmaps) return null;
+
+  if (allmaps.allmaps_annotation_url) {
+    return allmaps.allmaps_annotation_url;
+  }
+
+  if (allmaps.allmaps_manifest_uri) {
+    return `https://annotations.allmaps.org/?url=${encodeURIComponent(
+      allmaps.allmaps_manifest_uri
+    )}`;
+  }
+
+  if (allmaps.allmaps_id) {
+    return `https://annotations.allmaps.org/manifests/${encodeURIComponent(
+      allmaps.allmaps_id
+    )}`;
+  }
+
+  return null;
+}
+
+export function hasAllmapsOverlay(
+  resource: AllmapsResource | GeoDocumentDetails | null | undefined
+): boolean {
+  const allmaps = getAllmapsAttributes(resource);
+  return Boolean(
+    allmaps?.allmaps_annotated && getAllmapsAnnotationUrl(allmaps)
+  );
+}
+
+export function getAllmapsViewerUrl(
+  allmaps: AllmapsAttributes | null | undefined
+): string | null {
+  const annotationUrl = getAllmapsAnnotationUrl(allmaps);
+  if (!annotationUrl) return null;
+
+  const viewerUrl = new URL('https://viewer.allmaps.org/');
+  viewerUrl.searchParams.set('url', annotationUrl);
+  return viewerUrl.toString();
+}
+
+export function getAllmapsEditorUrl(
+  allmaps: AllmapsAttributes | null | undefined
+): string | null {
+  if (!allmaps?.allmaps_manifest_uri) return null;
+
+  return `https://editor.allmaps.org/#/collection?url=${encodeURIComponent(
+    allmaps.allmaps_manifest_uri
+  )}`;
+}


### PR DESCRIPTION
## Summary

Closes #72.

This re-adds Allmaps support to the new Geoportal resource page:

- adds Item Viewer / Map Overlay tabs when a resource has `meta.ui.allmaps`
- renders an Allmaps georeferenced overlay with `@allmaps/leaflet`, basemap controls, and opacity control
- adds a sidebar Map Overlay card with links to the Allmaps viewer and editor
- centralizes Allmaps URL generation in a small frontend utility
- covers the tabs, sidebar links, and overlay rendering path in ResourceView tests

## Validation

- `npm test -- ResourceView.test.tsx`
- `./node_modules/.bin/eslint src/pages/ResourceView.tsx src/components/resource/AllmapsOverlayViewer.tsx src/components/resource/AllmapsOverlayViewer.client.tsx src/components/resource/AllmapsLinksCard.tsx src/utils/allmaps.ts src/__tests__/components/ResourceView.test.tsx`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `npm run build`
- visually checked `p16022coll230:4038` in a production preview against the dev API; the Map Overlay tab rendered the Allmaps layer and the sidebar viewer/editor links were present