### PR TITLE
Add Allmaps map overlay search facet

### DIFF
--- a/backend/app/api/v1/strong_params.py
+++ b/backend/app/api/v1/strong_params.py
@@ -29,6 +29,7 @@ SEARCH_ALLOWED_PARAMS = [
     "fq[b1g_code_s][]",
     "fq[dct_accessRights_s][]",
     "fq[gbl_georeferenced_b][]",
+    "fq[b1g_georeferenced_allmaps_b][]",
     # Spatial facets
     "fq[geo_country][]",
     "fq[geo_region][]",
@@ -62,6 +63,7 @@ FACET_ALLOWED_PARAMS = [
     "fq[b1g_code_s][]",
     "fq[dct_accessRights_s][]",
     "fq[gbl_georeferenced_b][]",
+    "fq[b1g_georeferenced_allmaps_b][]",
     # Spatial facets
     "fq[geo_country][]",
     "fq[geo_region][]",

--- a/backend/app/elasticsearch/index.py
+++ b/backend/app/elasticsearch/index.py
@@ -233,7 +233,11 @@ async def process_resource(resource_dict):
 
     date_fields = {"gbl_mdmodified_dt", "b1g_dateAccessioned_s", "b1g_dateRetired_s"}
     integer_fields = {"gbl_indexYear_im"}
-    boolean_fields = {"gbl_georeferenced_b", "b1g_child_record_b"}
+    boolean_fields = {
+        "gbl_georeferenced_b",
+        "b1g_child_record_b",
+        "b1g_georeferenced_allmaps_b",
+    }
 
     for key, value in resource_dict.items():
         if isinstance(value, (list, tuple)):
@@ -320,6 +324,10 @@ async def process_resource(resource_dict):
         first = summaries[0]
         processed_dict["summary"] = first.get("summary") or None
 
+    processed_dict["b1g_georeferenced_allmaps_b"] = await get_allmaps_overlay_status(
+        processed_dict["id"]
+    )
+
     # Calculate and add time_period facet
     time_period = _calculate_time_period_from_year(processed_dict.get("gbl_indexYear_im"))
     if time_period:
@@ -387,6 +395,25 @@ async def get_resource_summaries(resource_id):
     except Exception as e:
         print(f"Error getting summaries for resource {resource_id}: {str(e)}")
         return []
+
+
+async def get_allmaps_overlay_status(resource_id):
+    """Return whether a resource has an annotated Allmaps overlay."""
+    try:
+        query = """
+            SELECT annotated
+            FROM resource_allmaps
+            WHERE resource_id = :resource_id
+            ORDER BY id DESC
+            LIMIT 1
+        """
+        result = await database.fetch_one(query, {"resource_id": resource_id})
+        if not result:
+            return False
+        return bool(dict(result).get("annotated"))
+    except Exception as e:
+        logger.error(f"Error getting Allmaps status for resource {resource_id}: {str(e)}")
+        return False
 
 
 async def get_spatial_facets(resource_id):

--- a/backend/app/elasticsearch/mappings.py
+++ b/backend/app/elasticsearch/mappings.py
@@ -50,6 +50,7 @@ INDEX_MAPPING = {
                 "fields": {"keyword": {"type": "keyword", "ignore_above": 8191}},
             },
             "gbl_georeferenced_b": {"type": "boolean"},
+            "b1g_georeferenced_allmaps_b": {"type": "boolean"},
             "dct_alternative_sm": {
                 "type": "text",
                 "fields": {

--- a/backend/app/elasticsearch/search.py
+++ b/backend/app/elasticsearch/search.py
@@ -193,6 +193,10 @@ def get_facet_aggregation_config(facet_name: str) -> dict:
             "field": "gbl_georeferenced_b",
             "size": DEFAULT_FACET_SIZE,
         },
+        "b1g_georeferenced_allmaps_b": {
+            "field": "b1g_georeferenced_allmaps_b",
+            "size": DEFAULT_FACET_SIZE,
+        },
         "dct_subject_sm": {
             "field": "dct_subject_sm.keyword",
             "size": DEFAULT_FACET_SIZE,
@@ -284,6 +288,12 @@ def _build_search_aggregations() -> dict:
         },
         "gbl_georeferenced_b": {
             "terms": {"field": "gbl_georeferenced_b", "size": DEFAULT_FACET_SIZE}
+        },
+        "b1g_georeferenced_allmaps_b": {
+            "terms": {
+                "field": "b1g_georeferenced_allmaps_b",
+                "size": DEFAULT_FACET_SIZE,
+            }
         },
         "geo_country": {"terms": {"field": "geo_country.keyword", "size": GEO_COUNTRY_FACET_SIZE}},
         "geo_region": {"terms": {"field": "geo_region.keyword", "size": GEO_REGION_FACET_SIZE}},
@@ -2555,6 +2565,8 @@ def process_aggregations(aggregations, search_context: dict):
         "ogm_repo": "OGM Repo",
         "access_rights_agg": "Access Rights",
         "georeferenced_agg": "Georeferenced",
+        "gbl_georeferenced_b": "Georeferenced",
+        "b1g_georeferenced_allmaps_b": "Map Overlay",
         "geo_country_agg": "Country",
         "geo_region_agg": "Region",
         "geo_county_agg": "County",

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -427,6 +427,7 @@ class SearchService:
             "b1g_code_agg": "b1g_code_s",
             "access_rights_agg": "dct_accessRights_s",
             "georeferenced_agg": "gbl_georeferenced_b",
+            "map_overlay_agg": "b1g_georeferenced_allmaps_b",
             # Spatial facet fields
             "geo_country_agg": "geo_country",
             "geo_region_agg": "geo_region",

--- a/backend/scripts/reindex_atomic.py
+++ b/backend/scripts/reindex_atomic.py
@@ -11,7 +11,7 @@ Flow:
 
 Performance:
 - Bulk indexing via Elasticsearch `_bulk`
-- Chunk-level prefetch of summaries/spatial facets to avoid N+1 DB queries
+- Chunk-level prefetch of summaries/spatial/Allmaps facets to avoid N+1 DB queries
 - Optional temporary fast index settings during ingest
 """
 
@@ -249,10 +249,28 @@ async def _prefetch_spatial_facets_by_id(ids: list[str]) -> dict[str, dict[str, 
     return {str(row["resource_id"]): _format_spatial_facets_row(dict(row)) for row in rows}
 
 
+async def _prefetch_allmaps_overlay_status_by_id(ids: list[str]) -> dict[str, bool]:
+    if not ids:
+        return {}
+
+    placeholders = ", ".join([f":id{i}" for i, _ in enumerate(ids)])
+    params = {f"id{i}": rid for i, rid in enumerate(ids)}
+    sql = f"""
+        SELECT resource_id, annotated
+        FROM resource_allmaps
+        WHERE resource_id IN ({placeholders})
+        ORDER BY id ASC
+    """
+    rows = await database.fetch_all(sql, params)
+
+    return {str(row["resource_id"]): bool(row["annotated"]) for row in rows}
+
+
 async def _prepare_documents_for_chunk(ids: list[str]) -> list[tuple[str, dict[str, Any]]]:
     rows_by_id = await _db_rows_for_ids(ids)
     summaries_by_id = await _prefetch_summaries_by_id(ids)
     facets_by_id = await _prefetch_spatial_facets_by_id(ids)
+    allmaps_overlay_by_id = await _prefetch_allmaps_overlay_status_by_id(ids)
 
     async def _cached_get_resource_summaries(resource_id: str):
         return summaries_by_id.get(str(resource_id), [])
@@ -260,11 +278,16 @@ async def _prepare_documents_for_chunk(ids: list[str]) -> list[tuple[str, dict[s
     async def _cached_get_spatial_facets(resource_id: str):
         return facets_by_id.get(str(resource_id))
 
+    async def _cached_get_allmaps_overlay_status(resource_id: str):
+        return allmaps_overlay_by_id.get(str(resource_id), False)
+
     original_get_resource_summaries = index_module.get_resource_summaries
     original_get_spatial_facets = index_module.get_spatial_facets
+    original_get_allmaps_overlay_status = index_module.get_allmaps_overlay_status
 
     index_module.get_resource_summaries = _cached_get_resource_summaries
     index_module.get_spatial_facets = _cached_get_spatial_facets
+    index_module.get_allmaps_overlay_status = _cached_get_allmaps_overlay_status
 
     documents: list[tuple[str, dict[str, Any]]] = []
     try:
@@ -278,6 +301,7 @@ async def _prepare_documents_for_chunk(ids: list[str]) -> list[tuple[str, dict[s
     finally:
         index_module.get_resource_summaries = original_get_resource_summaries
         index_module.get_spatial_facets = original_get_spatial_facets
+        index_module.get_allmaps_overlay_status = original_get_allmaps_overlay_status
 
     return documents
 

--- a/backend/tests/api/v1/test_facet_endpoint.py
+++ b/backend/tests/api/v1/test_facet_endpoint.py
@@ -495,6 +495,7 @@ class TestFacetEndpointSuccess:
             "b1g_code_s",
             "dct_accessRights_s",
             "gbl_georeferenced_b",
+            "b1g_georeferenced_allmaps_b",
             "geo_country",
             "geo_region",
             "geo_county",

--- a/backend/tests/api/v1/test_strong_params.py
+++ b/backend/tests/api/v1/test_strong_params.py
@@ -43,6 +43,7 @@ class TestStrongParams:
         assert "fq[b1g_code_s][]" in SEARCH_ALLOWED_PARAMS
         assert "fq[dct_accessRights_s][]" in SEARCH_ALLOWED_PARAMS
         assert "fq[gbl_georeferenced_b][]" in SEARCH_ALLOWED_PARAMS
+        assert "fq[b1g_georeferenced_allmaps_b][]" in SEARCH_ALLOWED_PARAMS
 
     def test_search_allowed_params_spatial_facets(self):
         """Test that SEARCH_ALLOWED_PARAMS contains spatial facet parameters."""

--- a/backend/tests/elasticsearch/test_facet_functions.py
+++ b/backend/tests/elasticsearch/test_facet_functions.py
@@ -38,6 +38,7 @@ class TestGetFacetAggregationConfig:
             "b1g_localCollectionLabel_sm",
             "dct_accessRights_s",
             "gbl_georeferenced_b",
+            "b1g_georeferenced_allmaps_b",
             "geo_country",
             "geo_region",
             "geo_county",
@@ -74,6 +75,10 @@ class TestGetFacetAggregationConfig:
 
         config = get_facet_aggregation_config("gbl_georeferenced_b")
         assert config["field"] == "gbl_georeferenced_b"
+        assert ".keyword" not in config["field"]
+
+        config = get_facet_aggregation_config("b1g_georeferenced_allmaps_b")
+        assert config["field"] == "b1g_georeferenced_allmaps_b"
         assert ".keyword" not in config["field"]
 
     def test_direct_keyword_field(self):

--- a/backend/tests/elasticsearch/test_index.py
+++ b/backend/tests/elasticsearch/test_index.py
@@ -1,0 +1,41 @@
+"""
+Tests for Elasticsearch indexing transformations.
+"""
+
+import pytest
+
+import app.elasticsearch.index as index_module
+
+
+@pytest.mark.asyncio
+async def test_process_resource_adds_allmaps_overlay_status(monkeypatch):
+    async def fake_get_resource_summaries(resource_id):
+        return []
+
+    async def fake_get_spatial_facets(resource_id):
+        return None
+
+    async def fake_get_allmaps_overlay_status(resource_id):
+        return resource_id == "allmaps-map"
+
+    monkeypatch.setattr(
+        index_module,
+        "get_resource_summaries",
+        fake_get_resource_summaries,
+    )
+    monkeypatch.setattr(index_module, "get_spatial_facets", fake_get_spatial_facets)
+    monkeypatch.setattr(
+        index_module,
+        "get_allmaps_overlay_status",
+        fake_get_allmaps_overlay_status,
+    )
+
+    indexed = await index_module.process_resource(
+        {
+            "id": "allmaps-map",
+            "dct_title_s": "Annotated map",
+            "gbl_indexYear_im": "1929",
+        }
+    )
+
+    assert indexed["b1g_georeferenced_allmaps_b"] is True

--- a/backend/tests/elasticsearch/test_mappings.py
+++ b/backend/tests/elasticsearch/test_mappings.py
@@ -90,6 +90,7 @@ class TestMappings:
             "b1g_dateAccessioned_s",
             "b1g_dateRetired_s",
             "b1g_child_record_b",
+            "b1g_georeferenced_allmaps_b",
             "b1g_dct_mediator_sm",
             "b1g_access_s",
             "b1g_image_ss",
@@ -194,7 +195,11 @@ class TestMappings:
                 assert properties[field]["fields"]["keyword"]["type"] == "keyword"
 
         # Boolean fields should be configured as booleans
-        boolean_fields = ["gbl_georeferenced_b", "b1g_child_record_b"]
+        boolean_fields = [
+            "gbl_georeferenced_b",
+            "b1g_child_record_b",
+            "b1g_georeferenced_allmaps_b",
+        ]
 
         for field in boolean_fields:
             if field in properties:

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -689,6 +689,7 @@ class TestSearchService:
             "fq[b1g_code_s][]=BTAA&"
             "fq[access_rights_agg][]=Public&"
             "fq[georeferenced_agg][]=true&"
+            "fq[map_overlay_agg][]=true&"
             "fq[geo_country_agg][]=USA&"
             "fq[geo_region_agg][]=Midwest&"
             "fq[geo_county_agg][]=Hennepin"
@@ -708,6 +709,7 @@ class TestSearchService:
         assert result["b1g_code_s"] == ["BTAA"]
         assert result["dct_accessRights_s"] == ["Public"]
         assert result["gbl_georeferenced_b"] == ["true"]
+        assert result["b1g_georeferenced_allmaps_b"] == ["true"]
         assert result["geo_country"] == ["USA"]
         assert result["geo_region"] == ["Midwest"]
         assert result["geo_county"] == ["Hennepin"]

--- a/frontend/src/__tests__/components/FacetList.test.tsx
+++ b/frontend/src/__tests__/components/FacetList.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 import { axeWithWCAG22 } from '../../test-utils/axe';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router';
-import { FacetList } from '../../components/FacetList';
+import { FacetList, type JsonApiFacet } from '../../components/FacetList';
 import { vi } from 'vitest';
 
 // Mock useSearchParams
@@ -24,9 +24,11 @@ vi.mock('../../utils/facetLabels', () => ({
     dc_publisher_sm: 'Publisher',
     dct_temporal_sm: 'Year',
     dct_spatial_sm: 'Location',
+    b1g_georeferenced_allmaps_b: 'Map Overlay',
   },
   // For unit tests we keep facet IDs stable (no remapping).
-  normalizeFacetId: (id: string) => id,
+  normalizeFacetId: (id: string) =>
+    id === 'map_overlay_agg' ? 'b1g_georeferenced_allmaps_b' : id,
 }));
 
 vi.mock('../../constants/facets', () => ({
@@ -37,6 +39,7 @@ vi.mock('../../constants/facets', () => ({
     'year_histogram',
     'dct_spatial_sm',
     'georeferenced_agg',
+    'b1g_georeferenced_allmaps_b',
   ],
 }));
 
@@ -204,7 +207,7 @@ const mockFacetData = [
   },
 ];
 
-const mockTimelineFacetData: any = [
+const mockTimelineFacetData: JsonApiFacet[] = [
   {
     type: 'timeline' as const,
     id: 'year_histogram',
@@ -296,7 +299,7 @@ describe('FacetList Component', () => {
 
       render(
         <TestWrapper>
-          <FacetList facets={compactFacetData as any} />
+          <FacetList facets={compactFacetData as JsonApiFacet[]} />
         </TestWrapper>
       );
 
@@ -351,7 +354,7 @@ describe('FacetList Component', () => {
     it('displays message when facets is null', () => {
       render(
         <TestWrapper>
-          <FacetList facets={null as any} />
+          <FacetList facets={null as unknown as JsonApiFacet[]} />
         </TestWrapper>
       );
 
@@ -663,6 +666,38 @@ describe('FacetList Component', () => {
       ).toBeInTheDocument(); // Value "false" renamed
     });
 
+    it('renders map overlay facet with true and false values', () => {
+      const mapOverlayFacet = [
+        {
+          type: 'facet' as const,
+          id: 'b1g_georeferenced_allmaps_b',
+          attributes: {
+            label: 'Map Overlay',
+            items: [
+              [1, 10],
+              [0, 5],
+            ] as [number, number][],
+          },
+        },
+      ];
+
+      render(
+        <TestWrapper>
+          <FacetList facets={mapOverlayFacet} />
+        </TestWrapper>
+      );
+
+      expect(
+        screen.getByRole('heading', { level: 3, name: 'Map Overlay' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /true\s*\(\d+\)/ })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /false\s*\(\d+\)/ })
+      ).toBeInTheDocument();
+    });
+
     it('handles facets with missing items attribute', () => {
       const facetsWithMissingItems = [
         {
@@ -677,7 +712,9 @@ describe('FacetList Component', () => {
 
       render(
         <TestWrapper>
-          <FacetList facets={facetsWithMissingItems as any} />
+          <FacetList
+            facets={facetsWithMissingItems as unknown as JsonApiFacet[]}
+          />
         </TestWrapper>
       );
 

--- a/frontend/src/__tests__/utils/facetDisplay.test.ts
+++ b/frontend/src/__tests__/utils/facetDisplay.test.ts
@@ -47,6 +47,19 @@ describe('getFacetValueDisplayLabel', () => {
     );
   });
 
+  it('normalizes map overlay values to true and false labels', () => {
+    const item1 = { id: '1', attributes: { value: '1', hits: 10 } };
+    const item0 = { id: '0', attributes: { value: '0', hits: 5 } };
+
+    expect(
+      getFacetValueDisplayLabel(item1, 'b1g_georeferenced_allmaps_b')
+    ).toBe('true');
+    expect(
+      getFacetValueDisplayLabel(item0, 'b1g_georeferenced_allmaps_b')
+    ).toBe('false');
+    expect(getFacetValueDisplayLabel(item1, 'map_overlay_agg')).toBe('true');
+  });
+
   it('ignores other facet IDs', () => {
     const item = { id: '1', attributes: { value: '1', hits: 5 } };
     // Should return "1" because it's not the georeferenced facet

--- a/frontend/src/__tests__/utils/facetLabels.test.ts
+++ b/frontend/src/__tests__/utils/facetLabels.test.ts
@@ -28,6 +28,7 @@ describe('facetLabels', () => {
       expect(getFacetLabel('schema_provider_s')).toBe('Provider');
       expect(getFacetLabel('dct_publisher_sm')).toBe('Publisher');
       expect(getFacetLabel('b1g_language_sm')).toBe('Language');
+      expect(getFacetLabel('b1g_georeferenced_allmaps_b')).toBe('Map Overlay');
     });
 
     it('returns normalized field when no label is defined', () => {
@@ -37,6 +38,7 @@ describe('facetLabels', () => {
     it('normalizes legacy agg IDs and returns label', () => {
       expect(getFacetLabel('spatial_agg')).toBe('Place');
       expect(getFacetLabel('resource_class_agg')).toBe('Resource Class');
+      expect(getFacetLabel('map_overlay_agg')).toBe('Map Overlay');
     });
   });
 
@@ -48,6 +50,9 @@ describe('facetLabels', () => {
       );
       expect(normalizeFacetId('publisher_agg')).toBe('dct_publisher_sm');
       expect(normalizeFacetId('language_agg')).toBe('b1g_language_sm');
+      expect(normalizeFacetId('map_overlay_agg')).toBe(
+        'b1g_georeferenced_allmaps_b'
+      );
     });
 
     it('returns field name unchanged when not in map', () => {
@@ -60,6 +65,9 @@ describe('facetLabels', () => {
       expect(getLegacyFacetName('dct_spatial_sm')).toBe('spatial_agg');
       expect(getLegacyFacetName('dct_publisher_sm')).toBe('publisher_agg');
       expect(getLegacyFacetName('b1g_language_sm')).toBe('language_agg');
+      expect(getLegacyFacetName('b1g_georeferenced_allmaps_b')).toBe(
+        'map_overlay_agg'
+      );
     });
 
     it('returns field name unchanged when no legacy mapping', () => {

--- a/frontend/src/__tests__/utils/searchParams.test.ts
+++ b/frontend/src/__tests__/utils/searchParams.test.ts
@@ -522,6 +522,25 @@ describe('searchParams', () => {
         'Dataset'
       );
     });
+
+    it('normalizes map overlay boolean facet values', () => {
+      const params: SearchParams = {
+        query: 'maps',
+        page: 1,
+        perPage: 20,
+        facets: [{ field: 'b1g_georeferenced_allmaps_b', value: '1' }],
+        excludeFacets: [{ field: 'b1g_georeferenced_allmaps_b', value: '0' }],
+      };
+
+      const result = buildSearchParams(params);
+
+      expect(result.get('include_filters[b1g_georeferenced_allmaps_b][]')).toBe(
+        'true'
+      );
+      expect(result.get('exclude_filters[b1g_georeferenced_allmaps_b][]')).toBe(
+        'false'
+      );
+    });
   });
 
   describe('Integration Tests', () => {

--- a/frontend/src/constants/facets.ts
+++ b/frontend/src/constants/facets.ts
@@ -11,4 +11,5 @@ export const CONFIGURED_FACETS = [
   'schema_provider_s',
   'dct_accessRights_s',
   'gbl_georeferenced_b',
+  'b1g_georeferenced_allmaps_b',
 ] as const;

--- a/frontend/src/constants/fieldLabels.ts
+++ b/frontend/src/constants/fieldLabels.ts
@@ -85,6 +85,11 @@ export const FIELD_LABELS: Record<string, FieldConfig> = {
     display: true,
     facet: 'gbl_georeferenced_b',
   },
+  b1g_georeferenced_allmaps_b: {
+    label: 'Map Overlay',
+    display: true,
+    facet: 'b1g_georeferenced_allmaps_b',
+  },
   gbl_wxsidentifier_s: { label: 'WXS Identifier', display: true },
 
   // Schema.org

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -579,6 +579,7 @@ export async function fetchSearchResults(
     institution_agg: 'schema_provider_s',
     format_agg: 'dct_format_s',
     georeferenced_agg: 'gbl_georeferenced_b',
+    map_overlay_agg: 'b1g_georeferenced_allmaps_b',
     id_agg: 'id',
   };
 

--- a/frontend/src/utils/facetDisplay.ts
+++ b/frontend/src/utils/facetDisplay.ts
@@ -23,6 +23,14 @@ export function getFacetValueDisplayLabel(
       return 'Not georeferenced';
   }
 
+  if (
+    facetId === 'b1g_georeferenced_allmaps_b' ||
+    facetId === 'map_overlay_agg'
+  ) {
+    if (String(value) === 'true' || String(value) === '1') return 'true';
+    if (String(value) === 'false' || String(value) === '0') return 'false';
+  }
+
   if (typeof label === 'string') {
     const trimmed = label.trim();
     // If the label is literally the count, it's not a label.

--- a/frontend/src/utils/facetLabels.ts
+++ b/frontend/src/utils/facetLabels.ts
@@ -15,6 +15,7 @@ export const FACET_LABELS: Record<string, string> = {
   dct_subjects_sm: 'Subject',
   dcat_theme_sm: 'Theme',
   gbl_georeferenced_b: 'Georeferenced',
+  b1g_georeferenced_allmaps_b: 'Map Overlay',
   // Relationship / collection filters (Active Filters display)
   dct_isPartOf_sm: 'Is part of',
   pcdm_memberOf_sm: 'Collection records',
@@ -37,6 +38,7 @@ export const FACET_ID_MAP: Record<string, string> = {
   institution_agg: 'schema_provider_s',
   format_agg: 'dct_format_s',
   georeferenced_agg: 'gbl_georeferenced_b',
+  map_overlay_agg: 'b1g_georeferenced_allmaps_b',
 };
 
 export function normalizeFacetId(id: string): string {
@@ -65,6 +67,7 @@ const REVERSE_FACET_ID_MAP: Record<string, string> = {
   dct_subject_sm: 'subject_agg',
   dct_format_s: 'format_agg',
   gbl_georeferenced_b: 'georeferenced_agg',
+  b1g_georeferenced_allmaps_b: 'map_overlay_agg',
 };
 
 export function getLegacyFacetName(fieldName: string): string {

--- a/frontend/src/utils/searchParams.ts
+++ b/frontend/src/utils/searchParams.ts
@@ -2,9 +2,12 @@ import { AdvancedClause, SearchParams } from '../types/search';
 import { SEARCH_RESULTS_PER_PAGE } from '../constants/search';
 
 /** Boolean facet fields must send "true"/"false" to the API, not "1"/"0". */
-const BOOLEAN_FACET_FIELDS = ['gbl_georeferenced_b'];
+const BOOLEAN_FACET_FIELDS = [
+  'gbl_georeferenced_b',
+  'b1g_georeferenced_allmaps_b',
+];
 
-/** Normalize facet value for URL/API (e.g. gbl_georeferenced_b: "1" -> "true", "0" -> "false"). */
+/** Normalize facet value for URL/API (e.g. boolean facets: "1" -> "true", "0" -> "false"). */
 export function normalizeFacetValueForUrl(
   field: string,
   value: string


### PR DESCRIPTION
## Summary

Adds the missing `Map Overlay` search facet so users can filter search results down to Allmaps-annotated maps from the main results page.

## What changed

- Indexes `b1g_georeferenced_allmaps_b` from `resource_allmaps.annotated` for Elasticsearch documents.
- Adds the field to mappings, default search aggregations, facet endpoint validation, and legacy alias handling via `map_overlay_agg`.
- Adds the frontend `Map Overlay` facet label/order and boolean value handling for `true` / `false` buckets.
- Adds focused backend and frontend coverage for the new facet path.

## Notes

Existing deployments will need a reindex before the facet counts appear, since the field is populated at index time.

Refs #72.

## Validation

- `/Users/ewlarson/.pyenv/versions/3.13.1/bin/python -m pytest backend/tests/elasticsearch/test_index.py backend/tests/elasticsearch/test_facet_functions.py backend/tests/elasticsearch/test_mappings.py backend/tests/services/test_search_service.py backend/tests/api/v1/test_strong_params.py backend/tests/api/v1/test_facet_endpoint.py`
- `npm test -- --run src/__tests__/utils/facetLabels.test.ts src/__tests__/utils/facetDisplay.test.ts src/__tests__/utils/searchParams.test.ts src/__tests__/components/FacetList.test.tsx`
- `./node_modules/.bin/eslint src/constants/facets.ts src/constants/fieldLabels.ts src/services/api.ts src/utils/facetDisplay.ts src/utils/facetLabels.ts src/utils/searchParams.ts src/__tests__/utils/facetLabels.test.ts src/__tests__/utils/facetDisplay.test.ts src/__tests__/utils/searchParams.test.ts src/__tests__/components/FacetList.test.tsx`
- `/Users/ewlarson/.pyenv/versions/3.13.1/bin/python -m ruff check backend/app/api/v1/strong_params.py backend/app/elasticsearch/index.py backend/app/elasticsearch/mappings.py backend/app/elasticsearch/search.py backend/app/services/search_service.py backend/scripts/reindex_atomic.py backend/tests/api/v1/test_facet_endpoint.py backend/tests/api/v1/test_strong_params.py backend/tests/elasticsearch/test_facet_functions.py backend/tests/elasticsearch/test_mappings.py backend/tests/elasticsearch/test_index.py backend/tests/services/test_search_service.py`
- `npm run build`