### PR TITLE
Improve search result page titles

### DIFF
--- a/frontend/app/routes/search.tsx
+++ b/frontend/app/routes/search.tsx
@@ -6,6 +6,7 @@ import { useApi } from '../../src/context/ApiContext';
 import { getThemeConfigFromRequest } from '../lib/theme.server';
 import { buildSeoMeta } from '../../src/config/seo';
 import { SEARCH_RESULTS_PER_PAGE } from '../../src/constants/search';
+import { buildSearchPageTitleFromUrl } from '../../src/utils/searchPageTitle';
 
 /**
  * Loader function for the search page shell.
@@ -73,7 +74,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 export const meta: MetaFunction<typeof loader> = ({ data }) =>
   buildSeoMeta({
-    title: data?.query ? `Search: ${data.query}` : 'Search Results',
+    title: data?.currentUrl
+      ? buildSearchPageTitleFromUrl(data.currentUrl)
+      : data?.query
+        ? `Search: ${data.query}`
+        : 'Search Results',
     description:
       'Search existing resources in the Big Ten Academic Alliance Geoportal.',
     url: data?.currentUrl,

--- a/frontend/src/__tests__/pages/page-titles.test.tsx
+++ b/frontend/src/__tests__/pages/page-titles.test.tsx
@@ -141,6 +141,68 @@ describe('Page titles', () => {
     });
   });
 
+  it('SearchPage title lists facet constraints when q is empty', async () => {
+    const routes = [
+      {
+        path: '/search',
+        element: (
+          <HelmetProvider>
+            <ApiProvider>
+              <DebugProvider>
+                <MapProvider>
+                  <SearchPage />
+                </MapProvider>
+              </DebugProvider>
+            </ApiProvider>
+          </HelmetProvider>
+        ),
+      },
+    ];
+    const router = createMemoryRouter(routes, {
+      initialEntries: [
+        '/search?include_filters[dct_spatial_sm][]=Wisconsin&include_filters[gbl_resourceClass_sm][]=Maps&include_filters[gbl_resourceType_sm][]=Topographic+maps&q=',
+      ],
+    });
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(document.title).toBe(
+        'Place: Wisconsin / Resource Class: Maps / Resource Type: Topographic maps - Big Ten Academic Alliance Geoportal'
+      );
+    });
+  });
+
+  it('SearchPage title lists a legacy bounding box when q is missing', async () => {
+    const routes = [
+      {
+        path: '/search',
+        element: (
+          <HelmetProvider>
+            <ApiProvider>
+              <DebugProvider>
+                <MapProvider>
+                  <SearchPage />
+                </MapProvider>
+              </DebugProvider>
+            </ApiProvider>
+          </HelmetProvider>
+        ),
+      },
+    ];
+    const router = createMemoryRouter(routes, {
+      initialEntries: [
+        '/search?bbox=-87.1418%2028.265814%20-50.799027%2060.34877',
+      ],
+    });
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(document.title).toBe(
+        'Bounding Box: -87.1418 28.265814 -50.799027 60.34877 - Big Ten Academic Alliance Geoportal'
+      );
+    });
+  });
+
   it('ResourceView has a title', async () => {
     const routes = [
       {

--- a/frontend/src/__tests__/utils/searchPageTitle.test.ts
+++ b/frontend/src/__tests__/utils/searchPageTitle.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSearchPageTitle,
+  buildSearchPageTitleFromUrl,
+} from '../../utils/searchPageTitle';
+
+describe('searchPageTitle', () => {
+  it('uses a keyword query when q has a value', () => {
+    const params = new URLSearchParams('q=lakes');
+
+    expect(buildSearchPageTitle(params)).toBe('Search: lakes');
+  });
+
+  it('lists current facet constraints when q is missing', () => {
+    const params = new URLSearchParams(
+      'include_filters[dct_spatial_sm][]=Wisconsin&include_filters[gbl_resourceClass_sm][]=Maps&include_filters[gbl_resourceType_sm][]=Topographic+maps'
+    );
+
+    expect(buildSearchPageTitle(params)).toBe(
+      'Place: Wisconsin / Resource Class: Maps / Resource Type: Topographic maps'
+    );
+  });
+
+  it('lists legacy Geoportal facet constraints when q is empty', () => {
+    const params = new URLSearchParams(
+      'f%5Bdct_spatial_sm%5D%5B%5D=Wisconsin&f%5Bgbl_resourceClass_sm%5D%5B%5D=Maps&f%5Bgbl_resourceType_sm%5D%5B%5D=Topographic+maps&q=&search_field=all_fields'
+    );
+
+    expect(buildSearchPageTitle(params)).toBe(
+      'Place: Wisconsin / Resource Class: Maps / Resource Type: Topographic maps'
+    );
+  });
+
+  it('uses legacy bbox coordinates as a bounding box title', () => {
+    const title = buildSearchPageTitleFromUrl(
+      'https://geo.btaa.org/?bbox=-87.1418%2028.265814%20-50.799027%2060.34877'
+    );
+
+    expect(title).toBe('Bounding Box: -87.1418 28.265814 -50.799027 60.34877');
+  });
+
+  it('formats current geo filter params as west south east north', () => {
+    const params = new URLSearchParams();
+    params.set('include_filters[geo][type]', 'bbox');
+    params.set('include_filters[geo][top_left][lat]', '60.34877');
+    params.set('include_filters[geo][top_left][lon]', '-87.1418');
+    params.set('include_filters[geo][bottom_right][lat]', '28.265814');
+    params.set('include_filters[geo][bottom_right][lon]', '-50.799027');
+
+    expect(buildSearchPageTitle(params)).toBe(
+      'Bounding Box: -87.1418 28.265814 -50.799027 60.34877'
+    );
+  });
+
+  it('includes year range, exclusions, and advanced clauses when present', () => {
+    const params = new URLSearchParams();
+    params.set('include_filters[year_range][start]', '1910');
+    params.set('include_filters[year_range][end]', '1932');
+    params.append('exclude_filters[dct_accessRights_s][]', 'Restricted');
+    params.set(
+      'adv_q',
+      JSON.stringify([{ op: 'NOT', f: 'dct_title_s', q: 'draft' }])
+    );
+
+    expect(buildSearchPageTitle(params)).toBe(
+      'Year Range: 1910 - 1932 / Exclude Access: Restricted / NOT Title: draft'
+    );
+  });
+});

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -33,6 +33,7 @@ import {
   scheduleAnalyticsBatch,
   serializeSearchParams,
 } from '../services/analytics';
+import { buildSearchPageTitle } from '../utils/searchPageTitle';
 
 // Stable search identity for analytics. Page and per_page are excluded so a
 // paged result set remains part of the same search session.
@@ -83,6 +84,7 @@ function SearchContent({
   const viewParam = searchParams.get('view');
   const currentView = isViewMode(viewParam) ? viewParam : DEFAULT_VIEW;
   const normalizedQuery = query || '';
+  const searchPageTitle = buildSearchPageTitle(searchParams);
   const currentSearchParamsKey = searchParams.toString();
   const currentContext = getSearchContext(searchParams);
   const hasAnySearchCriteria =
@@ -536,7 +538,7 @@ function SearchContent({
   return (
     <div className="min-h-screen flex flex-col">
       <Seo
-        title={query ? `Search: ${query}` : 'Search Results'}
+        title={searchPageTitle}
         description="Search existing resources in the Big Ten Academic Alliance Geoportal."
       />
       <Header />

--- a/frontend/src/utils/searchPageTitle.ts
+++ b/frontend/src/utils/searchPageTitle.ts
@@ -1,0 +1,166 @@
+import { humanizeFieldName } from '../constants/fieldLabels';
+import { getFacetLabel } from './facetLabels';
+
+const SEARCH_RESULTS_TITLE = 'Search Results';
+
+type AdvancedTitleClause = {
+  op: string;
+  f: string;
+  q: string;
+};
+
+function cleanTitleValue(value: string | null): string {
+  return (value || '').trim().replace(/\s+/g, ' ');
+}
+
+function getFieldLabel(field: string): string {
+  const facetLabel = getFacetLabel(field);
+  if (facetLabel !== field) return facetLabel;
+
+  return humanizeFieldName(field);
+}
+
+function getBoundingBoxConstraint(
+  searchParams: URLSearchParams
+): string | null {
+  const legacyBbox = cleanTitleValue(searchParams.get('bbox'));
+  if (legacyBbox) {
+    return `Bounding Box: ${legacyBbox}`;
+  }
+
+  if (searchParams.get('include_filters[geo][type]') !== 'bbox') {
+    return null;
+  }
+
+  const north = cleanTitleValue(
+    searchParams.get('include_filters[geo][top_left][lat]')
+  );
+  const west = cleanTitleValue(
+    searchParams.get('include_filters[geo][top_left][lon]')
+  );
+  const south = cleanTitleValue(
+    searchParams.get('include_filters[geo][bottom_right][lat]')
+  );
+  const east = cleanTitleValue(
+    searchParams.get('include_filters[geo][bottom_right][lon]')
+  );
+
+  if (!north || !west || !south || !east) {
+    return null;
+  }
+
+  return `Bounding Box: ${west} ${south} ${east} ${north}`;
+}
+
+function getYearRangeConstraint(searchParams: URLSearchParams): string | null {
+  const start = cleanTitleValue(
+    searchParams.get('include_filters[year_range][start]')
+  );
+  const end = cleanTitleValue(
+    searchParams.get('include_filters[year_range][end]')
+  );
+
+  if (!start && !end) {
+    return null;
+  }
+
+  return `Year Range: ${start || '?'} - ${end || '?'}`;
+}
+
+function getFacetConstraints(searchParams: URLSearchParams): string[] {
+  const constraints: string[] = [];
+  const seen = new Set<string>();
+
+  searchParams.forEach((rawValue, key) => {
+    const match = key.match(
+      /^(include_filters|exclude_filters|fq|f)\[([^\]]+)\]/
+    );
+    if (!match) return;
+
+    const [, kind, field] = match;
+    if (!field || field === 'geo' || field === 'year_range') return;
+
+    const value = cleanTitleValue(rawValue);
+    if (!value) return;
+
+    const labelPrefix = kind === 'exclude_filters' ? 'Exclude ' : '';
+    const constraint = `${labelPrefix}${getFieldLabel(field)}: ${value}`;
+    const dedupeKey = constraint;
+
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    constraints.push(constraint);
+  });
+
+  return constraints;
+}
+
+function parseAdvancedTitleClauses(
+  rawValue: string | null
+): AdvancedTitleClause[] {
+  if (!rawValue) return [];
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (item): item is AdvancedTitleClause =>
+        item &&
+        typeof item === 'object' &&
+        typeof item.op === 'string' &&
+        typeof item.f === 'string' &&
+        typeof item.q === 'string' &&
+        Boolean(cleanTitleValue(item.q))
+    );
+  } catch {
+    return [];
+  }
+}
+
+function getAdvancedConstraints(searchParams: URLSearchParams): string[] {
+  return parseAdvancedTitleClauses(searchParams.get('adv_q')).map(
+    (clause) =>
+      `${clause.op.toUpperCase()} ${humanizeFieldName(clause.f)}: ${cleanTitleValue(
+        clause.q
+      )}`
+  );
+}
+
+export function getSearchTitleConstraints(
+  searchParams: URLSearchParams
+): string[] {
+  return [
+    getBoundingBoxConstraint(searchParams),
+    getYearRangeConstraint(searchParams),
+    ...getFacetConstraints(searchParams),
+    ...getAdvancedConstraints(searchParams),
+  ].filter((constraint): constraint is string => Boolean(constraint));
+}
+
+export function buildSearchPageTitle(searchParams: URLSearchParams): string {
+  const query = cleanTitleValue(searchParams.get('q'));
+
+  if (query) {
+    return `Search: ${query}`;
+  }
+
+  const constraints = getSearchTitleConstraints(searchParams);
+  if (constraints.length > 0) {
+    return constraints.join(' / ');
+  }
+
+  return SEARCH_RESULTS_TITLE;
+}
+
+export function buildSearchPageTitleFromUrl(url: string | undefined): string {
+  if (!url) {
+    return SEARCH_RESULTS_TITLE;
+  }
+
+  try {
+    return buildSearchPageTitle(new URL(url).searchParams);
+  } catch {
+    return SEARCH_RESULTS_TITLE;
+  }
+}


### PR DESCRIPTION
## Summary

- Add a shared search page title builder for keyword, facet-only, advanced, year range, exclusion, and bounding-box searches.
- Use the shared builder in both the client-side `Seo` fallback and the React Router `meta` export so browser titles and SSR metadata stay aligned.
- Cover the legacy Geoportal-style `f[...]` and `bbox=` URL shapes as well as current `include_filters[...]` geo/facet params.

## Impact

Facet-only and bounding-box search pages now produce distinct page titles such as `Place: Wisconsin / Resource Class: Maps / Resource Type: Topographic maps` and `Bounding Box: -87.1418 28.265814 -50.799027 60.34877`, which should make Google Analytics page-title reporting easier to segment.

## Validation

- `npm test -- searchPageTitle page-titles`
- `./node_modules/.bin/prettier --check src/utils/searchPageTitle.ts src/__tests__/utils/searchPageTitle.test.ts src/pages/SearchPage.tsx src/__tests__/pages/page-titles.test.tsx app/routes/search.tsx`
- `./node_modules/.bin/eslint src/utils/searchPageTitle.ts src/pages/SearchPage.tsx src/__tests__/utils/searchPageTitle.test.ts src/__tests__/pages/page-titles.test.tsx app/routes/search.tsx` (0 errors; existing route Fast Refresh warnings remain)
- `git diff --check`

Note: full `npm run lint` still reports existing unrelated lint errors across other frontend files.