### PR TITLE
Add restricted resource lock indicators

### DIFF
--- a/frontend/src/__tests__/components/ResourceView.test.tsx
+++ b/frontend/src/__tests__/components/ResourceView.test.tsx
@@ -1306,11 +1306,14 @@ describe('ResourceView Component', () => {
       await waitFor(() => {
         expect(
           screen.getByRole('heading', {
-            name: 'Restricted raster layer with WMS and metadata',
+            name: /Restricted raster layer with WMS and metadata/,
           })
         ).toBeInTheDocument();
       });
 
+      expect(
+        screen.getByRole('img', { name: 'Restricted access' })
+      ).toBeInTheDocument();
       // Should render Stanford-specific content
       expect(screen.getAllByText('Raster Data')).toHaveLength(2);
       // "Documentation" appears both in the resource UI and in the global footer link;

--- a/frontend/src/__tests__/components/SearchResults.test.tsx
+++ b/frontend/src/__tests__/components/SearchResults.test.tsx
@@ -114,6 +114,7 @@ const mockFixtureData: GeoDocument[] = [
         dc_publisher_sm: ['Stanford University'],
         gbl_resourceClass_sm: ['Raster Data'],
         gbl_indexYear_im: [2021],
+        dct_accessRights_s: 'Restricted',
       },
     },
     meta: {
@@ -266,6 +267,29 @@ describe('SearchResults Component', () => {
       expect(
         screen.getByText('Restricted raster layer with WMS and metadata')
       ).toBeInTheDocument();
+    });
+
+    it('shows a restricted access indicator for restricted results', () => {
+      render(
+        <TestWrapper>
+          <SearchResults
+            results={mockFixtureData}
+            isLoading={false}
+            totalResults={4}
+            currentPage={1}
+          />
+        </TestWrapper>
+      );
+
+      const restrictedTitle = screen.getByText(
+        'Restricted raster layer with WMS and metadata'
+      );
+      const restrictedArticle = restrictedTitle.closest('article');
+
+      expect(restrictedArticle).toContainElement(
+        screen.getByRole('img', { name: 'Restricted access' })
+      );
+      expect(restrictedArticle).toHaveTextContent('4.');
     });
 
     it('displays result numbers correctly', () => {

--- a/frontend/src/__tests__/components/resource/FullDetailsTable.test.tsx
+++ b/frontend/src/__tests__/components/resource/FullDetailsTable.test.tsx
@@ -161,6 +161,24 @@ describe('FullDetailsTable', () => {
     );
   });
 
+  it('renders Access Rights in document metadata', () => {
+    const data = {
+      ...baseData,
+      attributes: {
+        ...baseData.attributes,
+        ogm: {
+          ...baseData.attributes.ogm,
+          dct_accessRights_s: 'Restricted',
+        },
+      },
+    };
+
+    renderWithRouter(<FullDetailsTable data={data} />);
+
+    expect(screen.getByText('Access Rights')).toBeInTheDocument();
+    expect(screen.getByText('Restricted')).toBeInTheDocument();
+  });
+
   it('metadata facet labels use sequential heading level (h3 under h2)', () => {
     const data = {
       ...baseData,

--- a/frontend/src/__tests__/components/search/GalleryView.test.tsx
+++ b/frontend/src/__tests__/components/search/GalleryView.test.tsx
@@ -67,6 +67,27 @@ describe('GalleryView', () => {
     expect(screen.getAllByText('Result 1').length).toBeGreaterThan(0);
   });
 
+  it('shows a restricted access indicator for restricted items', () => {
+    const restrictedResult: GeoDocument = {
+      ...mockResults[0],
+      attributes: {
+        ogm: {
+          ...mockResults[0].attributes.ogm,
+          dct_accessRights_s: 'Restricted',
+        },
+      },
+    };
+
+    renderGallery({
+      results: [restrictedResult],
+      totalResults: 1,
+    });
+
+    expect(
+      screen.getByRole('img', { name: 'Restricted access' })
+    ).toBeInTheDocument();
+  });
+
   it('uses the resource-class static-map fallback when a result has no real thumbnail', () => {
     const { container } = renderGallery({
       results: [mockResults[0]],

--- a/frontend/src/components/RestrictedAccessIndicator.tsx
+++ b/frontend/src/components/RestrictedAccessIndicator.tsx
@@ -1,0 +1,40 @@
+import { LockKeyhole } from 'lucide-react';
+
+interface RestrictedAccessIndicatorProps {
+  className?: string;
+  iconClassName?: string;
+  showLabel?: boolean;
+}
+
+function classes(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(' ');
+}
+
+export function RestrictedAccessIndicator({
+  className,
+  iconClassName,
+  showLabel = false,
+}: RestrictedAccessIndicatorProps) {
+  const label = 'Restricted access';
+
+  return (
+    <span
+      className={classes(
+        'inline-flex shrink-0 items-center justify-center border border-amber-300 bg-amber-50 text-amber-700',
+        showLabel
+          ? 'gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold'
+          : 'h-5 w-5 rounded-full',
+        className
+      )}
+      aria-label={label}
+      role={showLabel ? undefined : 'img'}
+      title={label}
+    >
+      <LockKeyhole
+        className={classes('h-3.5 w-3.5', iconClassName)}
+        aria-hidden="true"
+      />
+      {showLabel ? <span>Restricted</span> : null}
+    </span>
+  );
+}

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -14,6 +14,8 @@ import { scheduleAnalyticsBatch } from '../services/analytics';
 import { StaticResultMap } from './search/StaticResultMap';
 import { ResultCardPill } from './search/ResultCardPill';
 import { SEARCH_RESULTS_PER_PAGE } from '../constants/search';
+import { isRestrictedAccessResource } from '../utils/accessRights';
+import { RestrictedAccessIndicator } from './RestrictedAccessIndicator';
 
 interface SearchResultsProps {
   results: GeoDocument[];
@@ -106,6 +108,7 @@ export function SearchResults({
         const ogm = result?.attributes?.ogm;
         const title = ogm?.dct_title_s ?? '(Untitled)';
         const resourceClass = ogm?.gbl_resourceClass_sm?.[0];
+        const isRestricted = isRestrictedAccessResource(result);
         const description =
           ogm?.dct_description_sm &&
           Array.isArray(ogm.dct_description_sm) &&
@@ -240,6 +243,9 @@ export function SearchResults({
                     <h2
                       className={`${titleClass} font-semibold text-blue-600 hover:text-blue-800`}
                     >
+                      {isRestricted && (
+                        <RestrictedAccessIndicator className="mr-1 align-[-0.125rem]" />
+                      )}
                       {typeof title === 'string' ? title : String(title)}
                     </h2>
                   </Link>

--- a/frontend/src/components/resource/FullDetailsTable.tsx
+++ b/frontend/src/components/resource/FullDetailsTable.tsx
@@ -86,6 +86,7 @@ export function FullDetailsTable({ data }: FullDetailsTableProps) {
     'dct_creator_sm',
     'dct_issued_s',
     'dct_temporal_sm',
+    'dct_accessRights_s',
     'b1g_language_sm',
     'b1g_dct_conformsTo_sm',
     'b1g_dcat_spatialResolutionInMeters_sm',

--- a/frontend/src/components/resource/ResourceView.tsx
+++ b/frontend/src/components/resource/ResourceView.tsx
@@ -19,6 +19,8 @@ import { FullDetailsTable } from './FullDetailsTable';
 import type { GeoDocumentDetails } from '../../types/api';
 import { formatCount } from '../../utils/formatNumber';
 import { DataDictionariesSection } from './DataDictionariesSection';
+import { isRestrictedAccessResource } from '../../utils/accessRights';
+import { RestrictedAccessIndicator } from '../RestrictedAccessIndicator';
 
 interface SearchState {
   searchResults: Array<{ id: string }>;
@@ -230,6 +232,7 @@ export function ResourceView() {
 
   const viewerProtocol = data?.data?.meta?.ui?.viewer?.protocol;
   const dataDictionaries = data?.data?.attributes?.b1g?.data_dictionaries || [];
+  const isRestricted = isRestrictedAccessResource(data?.data);
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -293,8 +296,14 @@ export function ResourceView() {
 
               {/* Title section */}
               <div className="mb-6">
-                <h1 className="text-3xl font-bold text-gray-900">
-                  {data.data.attributes.ogm.dct_title_s}
+                <h1 className="flex items-start gap-2 text-3xl font-bold text-gray-900">
+                  {isRestricted && (
+                    <RestrictedAccessIndicator
+                      className="mt-1 h-7 w-7"
+                      iconClassName="h-4 w-4"
+                    />
+                  )}
+                  <span>{data.data.attributes.ogm.dct_title_s}</span>
                 </h1>
                 <ResourceSubtitle item={data.data} />
               </div>

--- a/frontend/src/components/search/GalleryView.tsx
+++ b/frontend/src/components/search/GalleryView.tsx
@@ -8,6 +8,8 @@ import { BookmarkButton } from '../BookmarkButton';
 import { useBookmarks } from '../../context/BookmarkContext';
 import { scheduleAnalyticsBatch } from '../../services/analytics';
 import { SEARCH_RESULTS_PER_PAGE } from '../../constants/search';
+import { isRestrictedAccessResource } from '../../utils/accessRights';
+import { RestrictedAccessIndicator } from '../RestrictedAccessIndicator';
 
 interface GalleryViewProps {
   results: GeoDocument[];
@@ -267,6 +269,7 @@ export const GalleryView: React.FC<GalleryViewProps> = ({
           const imageUrl = getResultPrimaryImageUrl(r, 'gallery');
           const absIndex = getAbsoluteIndex(index);
           const bookmarked = isBookmarked(r.id);
+          const isRestricted = isRestrictedAccessResource(r);
 
           return (
             <div
@@ -330,6 +333,9 @@ export const GalleryView: React.FC<GalleryViewProps> = ({
                     <span className="text-sm text-slate-600 dark:text-slate-400 font-semibold mr-1">
                       {absIndex}.
                     </span>
+                    {isRestricted && (
+                      <RestrictedAccessIndicator className="mr-1 align-[-0.125rem]" />
+                    )}
                     {title}
                   </h3>
                   <div className="mt-auto">

--- a/frontend/src/pages/ResourceView.tsx
+++ b/frontend/src/pages/ResourceView.tsx
@@ -37,6 +37,8 @@ import { SEARCH_RESULTS_PER_PAGE } from '../constants/search';
 import { AllmapsOverlayViewer } from '../components/resource/AllmapsOverlayViewer';
 import { AllmapsLinksCard } from '../components/resource/AllmapsLinksCard';
 import { hasAllmapsOverlay } from '../utils/allmaps';
+import { isRestrictedAccessResource } from '../utils/accessRights';
+import { RestrictedAccessIndicator } from '../components/RestrictedAccessIndicator';
 
 // Define types for search results
 interface SearchResult {
@@ -188,9 +190,9 @@ export function ResourceView({
   const [errorStatus, setErrorStatus] = useState<number | null>(null);
   const [isDataDictionaryModalOpen, setIsDataDictionaryModalOpen] =
     useState(false);
-  const [activeViewerTab, setActiveViewerTab] = useState<
-    'item' | 'allmaps'
-  >('item');
+  const [activeViewerTab, setActiveViewerTab] = useState<'item' | 'allmaps'>(
+    'item'
+  );
   const { setLastApiUrl } = useApi();
   const trackedResourceViewRef = useRef<string | null>(null);
 
@@ -529,8 +531,7 @@ export function ResourceView({
     null;
   const showViewerTabs = Boolean(viewerProtocol && hasAllmapsViewer);
   const showItemViewer =
-    Boolean(viewerProtocol) &&
-    (!showViewerTabs || activeViewerTab === 'item');
+    Boolean(viewerProtocol) && (!showViewerTabs || activeViewerTab === 'item');
   const showAllmapsViewer =
     hasAllmapsViewer && (!showViewerTabs || activeViewerTab === 'allmaps');
 
@@ -545,6 +546,7 @@ export function ResourceView({
     : hasStaticMap
       ? `/resources/${data.id}/static-map`
       : undefined;
+  const isRestricted = isRestrictedAccessResource(data);
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -630,8 +632,14 @@ export function ResourceView({
               <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
                 {/* Title section */}
                 <div className="lg:col-span-8">
-                  <h1 className="text-3xl font-bold text-gray-900">
-                    {data.attributes.ogm.dct_title_s}
+                  <h1 className="flex items-start gap-2 text-3xl font-bold text-gray-900">
+                    {isRestricted && (
+                      <RestrictedAccessIndicator
+                        className="mt-1 h-7 w-7"
+                        iconClassName="h-4 w-4"
+                      />
+                    )}
+                    <span>{data.attributes.ogm.dct_title_s}</span>
                   </h1>
                   <ResourceSubtitle item={data} />
                   {/* Display notes from OGM Aardvark (gbl_displayNote_sm) */}

--- a/frontend/src/utils/accessRights.ts
+++ b/frontend/src/utils/accessRights.ts
@@ -1,0 +1,20 @@
+import type { GeoDocument } from '../types/api';
+
+export function isRestrictedAccessValue(value: unknown): boolean {
+  const values = Array.isArray(value) ? value : [value];
+
+  return values.some(
+    (item) =>
+      typeof item === 'string' && item.trim().toLowerCase() === 'restricted'
+  );
+}
+
+export function isRestrictedAccessResource(
+  resource: Pick<GeoDocument, 'attributes' | 'meta'> | null | undefined
+): boolean {
+  const ogm = resource?.attributes?.ogm;
+
+  return isRestrictedAccessValue(
+    ogm?.dct_accessRights_s ?? ogm?.dct_accessrights_s
+  );
+}


### PR DESCRIPTION
## Summary

- Add a reusable restricted-access lock indicator for resources with `dct_accessRights_s: Restricted`
- Show the lock to the left of restricted resource titles in list, gallery, and resource detail views
- Include Access Rights in the resource Full Details table
- Add focused coverage for the search result, gallery, resource view, and Full Details behavior

Closes #206

## Validation

- `npm test -- --run src/__tests__/components/SearchResults.test.tsx src/__tests__/components/search/GalleryView.test.tsx src/__tests__/components/ResourceView.test.tsx src/__tests__/components/resource/FullDetailsTable.test.tsx`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/eslint src/utils/accessRights.ts src/components/RestrictedAccessIndicator.tsx src/components/SearchResults.tsx src/components/search/GalleryView.tsx src/pages/ResourceView.tsx src/components/resource/ResourceView.tsx src/components/resource/FullDetailsTable.tsx src/__tests__/components/SearchResults.test.tsx src/__tests__/components/search/GalleryView.test.tsx src/__tests__/components/ResourceView.test.tsx src/__tests__/components/resource/FullDetailsTable.test.tsx`
- Browser checked `localhost:3000` restricted resource page and restricted search results

## Notes

`npm run lint` still fails on pre-existing unrelated lint issues outside this change.