### PR TITLE
Remove Resource Class selectors from search pages

### DIFF
--- a/frontend/src/__tests__/components/layout/Header.test.tsx
+++ b/frontend/src/__tests__/components/layout/Header.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { Header } from '../../../components/layout/Header';
+
+vi.mock('../../../components/SearchField', () => ({
+  SearchField: () => <input aria-label="Search" />,
+}));
+
+vi.mock('../../../components/search/ResourceClassFilterTabs', () => ({
+  ResourceClassFilterTabs: ({ layout }: { layout?: string }) => (
+    <div data-testid={`resource-class-filter-tabs-${layout ?? 'horizontal'}`}>
+      Resource Class Tabs
+    </div>
+  ),
+}));
+
+function renderHeader(initialEntry: string) {
+  const router = createMemoryRouter([{ path: '*', element: <Header /> }], {
+    initialEntries: [initialEntry],
+  });
+
+  return render(<RouterProvider router={router} />);
+}
+
+describe('Header', () => {
+  it('shows Resource Class tabs on the homepage', () => {
+    renderHeader('/');
+
+    expect(screen.getAllByTestId(/resource-class-filter-tabs/)).toHaveLength(2);
+  });
+
+  it('hides Resource Class tabs on the search results page', () => {
+    renderHeader('/search?q=lakes');
+
+    expect(
+      screen.queryByTestId('resource-class-filter-tabs-horizontal')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('resource-class-filter-tabs-vertical')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -28,6 +28,7 @@ export function Header() {
   const headerCfg = theme.institution?.header;
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const navPanelRef = useRef<HTMLDivElement>(null);
+  const showResourceClassTabs = location.pathname !== '/search';
 
   // Close mobile nav on route or query change (e.g. clicking Bookmarks, selecting resource type)
   useEffect(() => {
@@ -269,9 +270,11 @@ export function Header() {
           </div>
 
           {/* Resource Class Filter Tabs (row 2) — desktop only */}
-          <div className="hidden xl:block col-span-6 col-start-4 self-end min-w-0">
-            <ResourceClassFilterTabs variant="header" />
-          </div>
+          {showResourceClassTabs && (
+            <div className="hidden xl:block col-span-6 col-start-4 self-end min-w-0">
+              <ResourceClassFilterTabs variant="header" />
+            </div>
+          )}
         </div>
       </div>
 
@@ -325,9 +328,11 @@ export function Header() {
             )
           )}
         </nav>
-        <div className="px-4 py-4 border-t border-white/20">
-          <ResourceClassFilterTabs variant="header" layout="vertical" />
-        </div>
+        {showResourceClassTabs && (
+          <div className="px-4 py-4 border-t border-white/20">
+            <ResourceClassFilterTabs variant="header" layout="vertical" />
+          </div>
+        )}
       </div>
 
       {/* Backdrop when mobile nav open */}


### PR DESCRIPTION
## Summary
- Hide the header Resource Class selector tabs on `/search` while keeping them visible on the homepage.
- Cover the route-specific header behavior with a focused test.

## Why
Internal discussions and user testing found that selecting a Resource Class from the search-results header can accidentally lead users to zero-result pages. The homepage has no search constraints, so the selector remains useful there.

Fixes #230.

## Validation
- `npm test -- Header.test.tsx SearchPage.test.tsx`
- `./node_modules/.bin/eslint src/components/layout/Header.tsx src/__tests__/components/layout/Header.test.tsx`
- `./node_modules/.bin/prettier --check src/components/layout/Header.tsx src/__tests__/components/layout/Header.test.tsx`
- Browser check on `localhost:3000`: Resource Class tabs present on `/`, absent on `/search?q=lakes`

Note: `npm run lint -- src/components/layout/Header.tsx src/__tests__/components/layout/Header.test.tsx` expands to the full frontend `src` tree in this project and still reports pre-existing unrelated lint errors outside this change.