### PR TITLE
Prepare GTM for production cutover

### DIFF
--- a/backend/tests/api/v1/test_admin_endpoints.py
+++ b/backend/tests/api/v1/test_admin_endpoints.py
@@ -7,6 +7,7 @@ These tests cover cache management, reindexing, and resource processing endpoint
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests.utils.route_helpers import route_paths
 
 client = TestClient(app)
 
@@ -70,7 +71,7 @@ class TestAdminEndpoints:
     def test_admin_endpoints_structure(self):
         """Test that admin endpoints are properly configured."""
         # Check that admin routes exist
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
 
         # Check if admin routes are present (they might not be included in the main app)
         admin_routes = [route for route in routes if "/admin" in route]

--- a/backend/tests/api/v1/test_citation_endpoints.py
+++ b/backend/tests/api/v1/test_citation_endpoints.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests.utils.route_helpers import route_paths
 
 client = TestClient(app)
 
@@ -18,9 +19,9 @@ def assert_public_error(data, *, status: int, code: str):
 @pytest.mark.unit
 def test_citation_endpoint_paths_exist():
     """Test that citation endpoints are registered."""
-    routes = [route.path for route in app.routes]
+    routes = route_paths(app)
     assert "/api/v1/resources/{id}" in routes
-    resource_routes = [r.path for r in app.routes if "citation" in str(r.path)]
+    resource_routes = [path for path in routes if "citation" in path]
     assert len(resource_routes) >= 1
 
 

--- a/backend/tests/api/v1/test_endpoint_modules_resources.py
+++ b/backend/tests/api/v1/test_endpoint_modules_resources.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 # Create test app
 from app.api.v1.endpoint_modules.resources import router
+from tests.utils.route_helpers import route_paths, routes_with_paths
 
 app = FastAPI()
 app.include_router(router)
@@ -191,7 +192,7 @@ class TestResourcesEndpoints:
 
     def test_endpoint_paths_exist(self):
         """Test that all expected endpoint paths exist."""
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
 
         expected_paths = [
             "/resources/",
@@ -210,11 +211,9 @@ class TestResourcesEndpoints:
 
     def test_endpoint_http_methods(self):
         """Test that endpoints use correct HTTP methods."""
-        routes = [route for route in app.routes if hasattr(route, "methods")]
-
         # All resource endpoints should be GET methods
-        for route in routes:
-            if "/resources" in route.path:
+        for path, route in routes_with_paths(app):
+            if "/resources" in path:
                 assert "GET" in route.methods
 
     def test_function_signatures(self):

--- a/backend/tests/api/v1/test_endpoint_modules_root.py
+++ b/backend/tests/api/v1/test_endpoint_modules_root.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 # Create test app
 from app.api.v1.endpoint_modules.root import router
+from tests.utils.route_helpers import route_by_path, route_paths
 
 app = FastAPI()
 app.include_router(router)
@@ -171,16 +172,14 @@ class TestRootEndpoints:
 
     def test_api_root_endpoint_path_exists(self):
         """Test that root endpoint path exists."""
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
         assert "/" in routes
 
     def test_api_root_endpoint_http_method(self):
         """Test that root endpoint uses correct HTTP method."""
-        routes = [route for route in app.routes if hasattr(route, "methods")]
-
-        for route in routes:
-            if route.path == "/":
-                assert "GET" in route.methods
+        route = route_by_path(app, "/")
+        assert route is not None
+        assert "GET" in route.methods
 
     def test_function_signature(self):
         """Test function signature for root endpoint."""

--- a/backend/tests/api/v1/test_gazetteer_endpoints.py
+++ b/backend/tests/api/v1/test_gazetteer_endpoints.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests.utils.route_helpers import route_paths
 
 client = TestClient(app)
 
@@ -311,7 +312,7 @@ class TestGazetteerEndpointsEnhanced:
 
     def test_gazetteer_endpoints_structure(self):
         """Test that gazetteer endpoints are properly configured."""
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
 
         assert "/api/v1/gazetteers" in routes
         assert "/api/v1/gazetteers/search" in routes

--- a/backend/tests/api/v1/test_mcp_endpoints.py
+++ b/backend/tests/api/v1/test_mcp_endpoints.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from app.api.v1.endpoint_modules.mcp import router
 from app.main import app
+from tests.utils.route_helpers import route_paths
 
 client = TestClient(app)
 
@@ -19,7 +20,7 @@ class TestMCPEndpoints:
     def test_mcp_endpoint_structure(self):
         """Test that the MCP endpoint is properly configured."""
         # Test that the app has the expected routes
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
 
         # Check that MCP routes exist
         assert "/api/v1/mcp" in routes
@@ -119,7 +120,7 @@ class TestMCPEndpoints:
     def test_mcp_websocket_endpoint_exists(self):
         """Test that the WebSocket endpoint is properly configured."""
         # Check that the WebSocket route exists
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
         assert "/api/v1/mcp/ws" in routes
 
         # Note: WebSocket testing requires a different approach

--- a/backend/tests/api/v1/test_resource_distributions_endpoint.py
+++ b/backend/tests/api/v1/test_resource_distributions_endpoint.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from tests.utils.route_helpers import route_by_path, route_paths
 
 
 class TestResourceDistributionsEndpoint:
@@ -22,23 +23,18 @@ class TestResourceDistributionsEndpoint:
     def test_endpoint_exists(self, client):
         """Test that the distributions endpoint is properly configured."""
         # Check that the endpoint route exists
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
         assert "/api/v1/resources/{id}/distributions" in routes
 
     def test_endpoint_route_registration(self, client):
         """Test that the distributions endpoint route is properly registered."""
         # This test verifies the endpoint exists without making database calls
         # that could conflict with other tests in the suite
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
         assert "/api/v1/resources/{id}/distributions" in routes
 
         # Verify it's a GET endpoint
-        distributions_route = None
-        for route in app.routes:
-            if hasattr(route, "path") and route.path == "/api/v1/resources/{id}/distributions":
-                distributions_route = route
-                break
-
+        distributions_route = route_by_path(app, "/api/v1/resources/{id}/distributions")
         assert distributions_route is not None
         assert hasattr(distributions_route, "methods")
         assert "GET" in distributions_route.methods

--- a/backend/tests/api/v1/test_resource_endpoints.py
+++ b/backend/tests/api/v1/test_resource_endpoints.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 from app.services.relationship_service import RelationshipService
+from tests.utils.route_helpers import route_by_path, route_paths
 
 client = TestClient(app)
 
@@ -37,7 +38,7 @@ def test_relationship_service_initialization():
 def test_resource_endpoints_exist():
     """Test that the resource endpoints are properly configured."""
     # Test that the app has the expected routes
-    routes = [route.path for route in app.routes]
+    routes = route_paths(app)
 
     # Check that resource routes exist
     assert "/api/v1/resources/" in routes
@@ -73,7 +74,7 @@ async def test_resource_endpoint_404_handling():
     # without requiring actual database connections
 
     # Test that the endpoint structure is correct
-    routes = [route.path for route in app.routes]
+    routes = route_paths(app)
     assert "/api/v1/resources/{id}" in routes
 
     # Verify that the app has proper error handling
@@ -83,15 +84,11 @@ async def test_resource_endpoint_404_handling():
 @pytest.mark.unit
 def test_ogm_endpoint_structure():
     """Test that the metadata endpoint is properly configured (formerly OGM)."""
-    routes = [route.path for route in app.routes]
+    routes = route_paths(app)
     assert "/api/v1/resources/{id}/metadata" in routes
 
     # Find the metadata route and verify its configuration
-    metadata_route = None
-    for route in app.routes:
-        if route.path == "/api/v1/resources/{id}/metadata":
-            metadata_route = route
-            break
+    metadata_route = route_by_path(app, "/api/v1/resources/{id}/metadata")
 
     assert metadata_route is not None
     assert metadata_route.methods == {"GET"}
@@ -100,15 +97,11 @@ def test_ogm_endpoint_structure():
 @pytest.mark.unit
 def test_viewer_endpoint_structure():
     """Test that the viewer endpoint is properly configured."""
-    routes = [route.path for route in app.routes]
+    routes = route_paths(app)
     assert "/api/v1/resources/{id}/viewer" in routes
 
     # Find the viewer route and verify its configuration
-    viewer_route = None
-    for route in app.routes:
-        if route.path == "/api/v1/resources/{id}/viewer":
-            viewer_route = route
-            break
+    viewer_route = route_by_path(app, "/api/v1/resources/{id}/viewer")
 
     assert viewer_route is not None
     assert viewer_route.methods == {"GET"}
@@ -582,7 +575,7 @@ class TestResourceEndpointsEnhanced:
 
     def test_resource_endpoints_structure(self):
         """Test that resource endpoints are properly configured."""
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
 
         assert "/api/v1/resources/" in routes
         assert "/api/v1/resources/{id}" in routes

--- a/backend/tests/api/v1/test_search_endpoints.py
+++ b/backend/tests/api/v1/test_search_endpoints.py
@@ -9,6 +9,7 @@ from starlette.requests import Request
 from app.api.v1.endpoint_modules.search import _handle_search
 from app.main import app
 from app.services.resource_representation_cache import RESOURCE_SEARCH_RESULT_REPRESENTATION_PROFILE
+from tests.utils.route_helpers import route_paths
 
 client = TestClient(app)
 
@@ -732,7 +733,7 @@ class TestSearchEndpointsEnhanced:
 
     def test_search_endpoints_structure(self):
         """Test that search endpoints are properly configured."""
-        routes = [route.path for route in app.routes]
+        routes = route_paths(app)
 
         assert "/api/v1/search" in routes
         assert "/api/v1/suggest" in routes

--- a/backend/tests/utils/route_helpers.py
+++ b/backend/tests/utils/route_helpers.py
@@ -1,0 +1,38 @@
+from collections.abc import Iterator
+from typing import Any
+
+
+def route_paths(route_owner: Any) -> list[str]:
+    """Return registered route paths, including routes nested by include_router."""
+    return [path for path, _route in routes_with_paths(route_owner)]
+
+
+def route_by_path(route_owner: Any, path: str) -> Any | None:
+    """Find a registered route by path, including nested include_router routes."""
+    for route_path, route in routes_with_paths(route_owner):
+        if route_path == path:
+            return route
+    return None
+
+
+def routes_with_paths(route_owner: Any, prefix: str = "") -> Iterator[tuple[str, Any]]:
+    for route in getattr(route_owner, "routes", []):
+        route_prefix = getattr(route, "prefix", "") or ""
+        nested_prefix = _join_route_path(prefix, route_prefix)
+
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            yield _join_route_path(prefix, path), route
+
+        if getattr(route, "routes", None):
+            yield from routes_with_paths(route, nested_prefix)
+
+
+def _join_route_path(prefix: str, path: str) -> str:
+    if not prefix:
+        return path
+    if not path:
+        return prefix
+    if path == prefix or path.startswith(f"{prefix.rstrip('/')}/"):
+        return path
+    return f"{prefix.rstrip('/')}/{path.lstrip('/')}"

--- a/backend/tests/utils/route_helpers.py
+++ b/backend/tests/utils/route_helpers.py
@@ -17,12 +17,19 @@ def route_by_path(route_owner: Any, path: str) -> Any | None:
 
 def routes_with_paths(route_owner: Any, prefix: str = "") -> Iterator[tuple[str, Any]]:
     for route in getattr(route_owner, "routes", []):
-        route_prefix = getattr(route, "prefix", "") or ""
+        include_context = getattr(route, "include_context", None)
+        route_prefix = (
+            getattr(route, "prefix", None) or getattr(include_context, "prefix", None) or ""
+        )
         nested_prefix = _join_route_path(prefix, route_prefix)
 
         path = getattr(route, "path", None)
         if isinstance(path, str):
             yield _join_route_path(prefix, path), route
+
+        original_router = getattr(route, "original_router", None)
+        if original_router is not None:
+            yield from routes_with_paths(original_router, nested_prefix)
 
         if getattr(route, "routes", None):
             yield from routes_with_paths(route, nested_prefix)

--- a/config/deploy.prd.yml
+++ b/config/deploy.prd.yml
@@ -44,11 +44,11 @@ servers:
     cmd: celery -A app.tasks.worker flower --port=5555
 
 proxy:
-  host: lib-geoportal-prd-web-01.oit.umn.edu
+  host: geo.btaa.org,lib-geoportal-prd-web-01.oit.umn.edu
 
 builder:
   args:
-    VITE_API_BASE_URL: "https://lib-geoportal-prd-web-01.oit.umn.edu/api/v1"
+    VITE_API_BASE_URL: "https://geo.btaa.org/api/v1"
     VITE_TURNSTILE_ACTION: "geoportal_gate"
     VITE_TURNSTILE_ENABLED: "true"
     VITE_TURNSTILE_PUBLIC_SITE: "0x4AAAAAADJqCBiv8czDm2ZG"
@@ -57,7 +57,7 @@ builder:
 
 env:
   clear:
-    APPLICATION_URL: https://lib-geoportal-prd-web-01.oit.umn.edu
+    APPLICATION_URL: https://geo.btaa.org
     APP_ENV: production
     KAMAL_DEST: prd
     BRIDGE_SYNC_REPORT_ENABLED: "true"
@@ -72,7 +72,7 @@ env:
     SEARCH_ENGINE_INDEXING_ENABLED: "false"
     RATE_LIMIT_ENABLED: "true"
     TURNSTILE_ENABLED: "true"
-    TURNSTILE_ALLOWED_HOSTNAMES: lib-geoportal-prd-web-01.oit.umn.edu
+    TURNSTILE_ALLOWED_HOSTNAMES: geo.btaa.org,lib-geoportal-prd-web-01.oit.umn.edu
     TURNSTILE_COOKIE_SECURE: "true"
     TURNSTILE_EXPECTED_ACTION: geoportal_gate
     CACHE_DEBUG_HEADERS: "false"

--- a/docs/backend/kamal_deployment.md
+++ b/docs/backend/kamal_deployment.md
@@ -14,7 +14,7 @@ It intentionally omits older generic Kamal guidance that does not match how thes
 |-------------|-------------|---------------|--------|--------------|
 | `dev1` | `lib-btaageoapi-dev-app-01.oit.umn.edu` | `https://lib-btaageoapi-dev-app-01.oit.umn.edu` | `config/deploy.dev1.yml` | `.kamal/secrets.dev1` |
 | `dev2` | `lib-geoportal-dev-web-01.oit.umn.edu` | `https://geodev.btaa.org` | `config/deploy.dev2.yml` | `.kamal/secrets.dev2` |
-| `prd` | `lib-geoportal-prd-web-01.oit.umn.edu` | `https://lib-geoportal-prd-web-01.oit.umn.edu` | `config/deploy.prd.yml` | `.kamal/secrets.prd` |
+| `prd` | `lib-geoportal-prd-web-01.oit.umn.edu` | `https://geo.btaa.org` | `config/deploy.prd.yml` | `.kamal/secrets.prd` |
 
 Shared secrets live in `.kamal/secrets-common`.
 
@@ -145,9 +145,9 @@ export KAMAL_HOST=lib-geoportal-prd-web-01.oit.umn.edu
 export KAMAL_SSH_USER=deploy
 ```
 
-`KAMAL_HOST` is the SSH/deployment target. For `dev2`, keep it set to
-`lib-geoportal-dev-web-01.oit.umn.edu`; the public BTAA origin is configured in
-`config/deploy.dev2.yml`.
+`KAMAL_HOST` is the SSH/deployment target. For `dev2` and `prd`, keep it set to
+the VM hostname; the public BTAA origins are configured in the destination
+deploy files.
 
 The exact shared secret set is defined by `config/deploy.yml`:
 
@@ -258,7 +258,7 @@ kamal accessory details -d prd redis
 Then confirm the public app is responding:
 
 ```bash
-curl -sS -o /dev/null -D - https://lib-geoportal-prd-web-01.oit.umn.edu/api/docs
+curl -sS -o /dev/null -D - https://geo.btaa.org/api/docs
 ```
 
 Use the matching public origin for `dev1` or `dev2` when checking those
@@ -430,7 +430,7 @@ Current differences:
 
 - `dev1`: host `lib-btaageoapi-dev-app-01.oit.umn.edu`, prd-sized performance profile for `web`/`worker` limits, Elasticsearch heap, `WEB_UVICORN_WORKERS=3`, `WEB_INTERNAL_UVICORN_WORKERS=4`, and `WEB_SSR_WORKERS=3`
 - `dev2`: deploy host `lib-geoportal-dev-web-01.oit.umn.edu` with public origin `https://geodev.btaa.org`, same prd-sized performance profile as `dev1`, with `RATE_LIMIT_ENABLED=true` and bounded DB pool settings for production-like k6 capacity tests
-- `prd`: host `lib-geoportal-prd-web-01.oit.umn.edu`, 12-vCPU production performance profile with `web cpus: 8`, `worker cpus: 1.75`, `WEB_UVICORN_WORKERS=4`, `WEB_INTERNAL_UVICORN_WORKERS=6`, and `WEB_SSR_WORKERS=4`, plus production-only behavior overrides such as `RATE_LIMIT_ENABLED=true`, `CACHE_DEBUG_HEADERS=false`, `CACHE_LOG_EVENTS=false`, and bridge-report delivery
+- `prd`: deploy host `lib-geoportal-prd-web-01.oit.umn.edu` with public origin `https://geo.btaa.org`, 12-vCPU production performance profile with `web cpus: 8`, `worker cpus: 1.75`, `WEB_UVICORN_WORKERS=4`, `WEB_INTERNAL_UVICORN_WORKERS=6`, and `WEB_SSR_WORKERS=4`, plus production-only behavior overrides such as `RATE_LIMIT_ENABLED=true`, `CACHE_DEBUG_HEADERS=false`, `CACHE_LOG_EVENTS=false`, and bridge-report delivery
 
 If a new destination needs a persistent behavior difference, put only that override in `config/deploy.<dest>.yml` and keep the shared behavior in `config/deploy.yml`.
 
@@ -454,7 +454,7 @@ Check:
 ```bash
 kamal app details -d prd
 kamal app logs -d prd --roles web
-curl -sS -o /dev/null -D - https://lib-geoportal-prd-web-01.oit.umn.edu/api/docs
+curl -sS -o /dev/null -D - https://geo.btaa.org/api/docs
 ```
 
 ### Accessory problem

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -25,6 +25,22 @@ const isGoogleTagManagerEnabled =
   KAMAL_DESTINATION === 'prd' &&
   GOOGLE_TAG_MANAGER_ID_PATTERN.test(GOOGLE_TAG_MANAGER_ID);
 
+function buildGoogleTagManagerSnippet(containerId: string) {
+  return `
+    (function(w,d,s,l,i){
+      w[l]=w[l]||[];
+      w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+      var f=d.getElementsByTagName(s)[0];
+      var j=d.createElement(s);
+      var dl=l!='dataLayer'?'&l='+encodeURIComponent(l):'';
+      j.id='google-tag-manager';
+      j.async=true;
+      j.src='https://www.googletagmanager.com/gtm.js?id='+encodeURIComponent(i)+dl;
+      f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer',${JSON.stringify(containerId)});
+  `;
+}
+
 function GoogleTagManagerClient({ containerId }: { containerId: string }) {
   useEffect(() => {
     if (!containerId || document.getElementById('google-tag-manager')) return;
@@ -72,6 +88,14 @@ function RootDocument({
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        {isGoogleTagManagerEnabled && !isMiradorRoute && (
+          <script
+            id="google-tag-manager-bootstrap"
+            dangerouslySetInnerHTML={{
+              __html: buildGoogleTagManagerSnippet(GOOGLE_TAG_MANAGER_ID),
+            }}
+          />
+        )}
         <link rel="manifest" href="/manifest.webmanifest" />
         <link rel="icon" href="/favicon.ico" sizes="48x48" />
         <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />


### PR DESCRIPTION
## Summary

- Point production public-origin settings at `https://geo.btaa.org` while keeping the VM hostname accepted during cutover.
- Move Google Tag Manager bootstrap into the SSR document head so initial page loads can fire GTM before React hydration.
- Update the Kamal deployment runbook to match the new production public origin.

## Why

The production launch changes DNS from `https://lib-geoportal-prd-web-01.oit.umn.edu` to `https://geo.btaa.org`. The frontend build and backend runtime need to agree on the public origin so GTM, analytics beacons, API calls, canonical app URLs, and Turnstile verification behave correctly after cutover.

## Validation

- `npm run build`
- `git diff --cached --check`

## Notes

Cloudflare Turnstile has been updated separately to allow `geo.btaa.org`. The production deploy config also allows both `geo.btaa.org` and `lib-geoportal-prd-web-01.oit.umn.edu` during the transition.