### PR TITLE
Bump API version to 0.8.0

### DIFF
--- a/backend/app/api/v1/endpoint_modules/root.py
+++ b/backend/app/api/v1/endpoint_modules/root.py
@@ -20,7 +20,7 @@ async def api_root(request: Request):
         "id": "root",
         "attributes": {
             "api": "BTAA Geospatial API",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "description": (
                 "A RESTful API that provides access to digitized maps and geospatial data "
                 "resources curated by Big Ten Academic Alliance member libraries."

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -151,7 +151,7 @@ async def lifespan(app: FastAPI):
 # Create FastAPI application
 app = FastAPI(
     title="BTAA Geospatial API",
-    version="0.7.0",
+    version="0.8.0",
     lifespan=lifespan,
     docs_url=None,
     redoc_url="/api/redoc",

--- a/backend/app/services/mcp_service.py
+++ b/backend/app/services/mcp_service.py
@@ -26,7 +26,7 @@ from db.session import async_session as app_async_session
 logger = logging.getLogger(__name__)
 
 MCP_SERVICE_NAME = "btaa-geospatial-api"
-MCP_SERVICE_VERSION = "0.7.0"
+MCP_SERVICE_VERSION = "0.8.0"
 MCP_SERVICE_DESCRIPTION = "BTAA Geospatial API MCP Service"
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-api"
-version = "0.7.0"
+version = "0.8.0"
 description = "BTAA OpenGeoMetadata API"
 requires-python = ">=3.11"
 authors = [

--- a/backend/tests/api/v1/test_endpoint_modules_root.py
+++ b/backend/tests/api/v1/test_endpoint_modules_root.py
@@ -87,7 +87,7 @@ class TestRootEndpoints:
         # Check attributes
         attributes = api_info["attributes"]
         assert attributes["api"] == "BTAA Geospatial API"
-        assert attributes["version"] == "0.7.0"
+        assert attributes["version"] == "0.8.0"
         assert "description" in attributes
         assert "endpoints" in attributes
         assert isinstance(attributes["endpoints"], list)
@@ -137,7 +137,7 @@ class TestRootEndpoints:
         attributes = data["data"]["attributes"]
         version = attributes["version"]
 
-        assert version == "0.7.0"
+        assert version == "0.8.0"
 
     def test_api_root_with_request_url(self):
         """Test API root with request URL in response."""

--- a/backend/tests/api/v1/test_mcp_endpoints.py
+++ b/backend/tests/api/v1/test_mcp_endpoints.py
@@ -35,7 +35,7 @@ class TestMCPEndpoints:
 
         # Check basic service information
         assert data["name"] == "btaa-geospatial-api"
-        assert data["version"] == "0.7.0"
+        assert data["version"] == "0.8.0"
         assert data["description"] == "BTAA Geospatial API MCP Service"
         assert data["protocol"] == "mcp"
         assert "stdio" in data["transports"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -655,7 +655,7 @@ wheels = [
 
 [[package]]
 name = "data-api"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ewlarson/btaa-geospatial-api:0.7.0
+    image: ewlarson/btaa-geospatial-api:0.8.0
     container_name: btaa-geospatial-api-app
     environment:
       - DATABASE_URL=postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@paradedb:5432/btaa_geospatial_api

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ Core runtime technologies:
 
 | Layer | Current implementation |
 | --- | --- |
-| API | FastAPI 0.7.0 app mounted at `/api/v1`, with custom Swagger at `/api/docs` and OpenAPI JSON at `/api/openapi.json`. |
+| API | API 0.8.0 app mounted at `/api/v1`, with custom Swagger at `/api/docs` and OpenAPI JSON at `/api/openapi.json`. |
 | Public web app | React 19, React Router 7, TypeScript, Vite 7, MUI 7, Leaflet, GeoBlacklight frontend components, H3 map visualization. |
 | Search | Elasticsearch 9.0.0, versioned index build plus alias swap through `scripts/reindex_atomic.py`. |
 | Database | ParadeDB/PostgreSQL, SQLAlchemy table metadata in `backend/db/models.py`, script-based migrations in `backend/db/migrations/`. |

--- a/docs/backend/kamal_deployment.md
+++ b/docs/backend/kamal_deployment.md
@@ -213,20 +213,20 @@ kamal deploy -d prd
 ```
 
 When prompted, enter the tag or branch you intend to deploy, for example
-`v0.7.0` or `main`.
+`v0.8.0` or `main`.
 
 For non-interactive shells, pass the ref explicitly:
 
 ```bash
-PRD_DEPLOY_REF=v0.7.0 kamal deploy -d prd
+PRD_DEPLOY_REF=v0.8.0 kamal deploy -d prd
 ```
 
 The production deploy hook verifies that the selected ref matches both the
 current checkout and `KAMAL_VERSION`. To deploy an older tag, check it out first:
 
 ```bash
-git switch --detach v0.7.0
-PRD_DEPLOY_REF=v0.7.0 kamal deploy -d prd
+git switch --detach v0.8.0
+PRD_DEPLOY_REF=v0.8.0 kamal deploy -d prd
 git switch main
 ```
 

--- a/mkdocs/docs/specification/index.md
+++ b/mkdocs/docs/specification/index.md
@@ -2,7 +2,7 @@
 
 {% include-markdown "includes/wip.md" %}
 
-**Version:** 0.7.0   **Status:** *DRAFT*   **Release Date:** 2026-05-08
+**Version:** 0.8.0   **Status:** *DRAFT*   **Release Date:** 2026-06-15
 
 ## Editors
 
@@ -50,6 +50,7 @@ The goal of this specification is to enable consistent client and server impleme
 
 | Version | Date | Notes |
 | :---- | :---- | :---- |
+| 0.8.0 | 2026-06-15 | Release version metadata updated for the production launch. |
 | 0.7.0 | 2026-05-08 | Release version metadata updated for the API service, MCP service, Docker image, and public specification. |
 | 0.6.0 | 2026-04-06 | Major API and documentation refresh, including expanded endpoint documentation, versioned publishing updates, and introduction of the OGC Records API facade under `/api/v1/ogc`. |
 | 0.3.0-pre-alpha | 2025-12-09 | Endpoints added for facet pagination, search supporting adv_q param for advanced search, lots of polish and refinement. |

--- a/mkdocs/docs/specification/model_context_protocol.md
+++ b/mkdocs/docs/specification/model_context_protocol.md
@@ -11,7 +11,7 @@ The BTAA Geospatial API supports [Model Context Protocol (MCP)](https://modelcon
 ```
 {
   "name": "btaa-geospatial-api",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "BTAA Geospatial API MCP Service",
   "protocol": "mcp",
   "transports": [


### PR DESCRIPTION
## Summary
- bump backend package/API/MCP version metadata to 0.8.0
- update version assertions and public spec/deploy docs for v0.8.0
- update docker-compose image tag to 0.8.0

## Validation
- uv run --extra dev pytest tests/api/v1/test_endpoint_modules_root.py::TestRootEndpoints::test_api_root_response_content tests/api/v1/test_endpoint_modules_root.py::TestRootEndpoints::test_api_root_version tests/api/v1/test_mcp_endpoints.py::TestMCPEndpoints::test_mcp_info_endpoint -q
- make lint-check