### PR TITLE
Add Turnstile bot exemptions and update Kithe bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,11 @@ OPENAI_MODEL=gpt-3.5-turbo
 BTAA_GEOSPATIAL_API_KEY="<secret>"
 
 # Geoportal bridge sync
-KITHE_BRIDGE_URL="https://geo.btaa.org/api/kithe_bridge"
+KITHE_BRIDGE_URL="https://geomg.lib.umn.edu/api/kithe_bridge"
 KITHE_BRIDGE_TOKEN="<secret>"
 KITHE_BRIDGE_PAGE_SIZE=500
 KITHE_BRIDGE_REQUEST_TIMEOUT=30
+KITHE_BRIDGE_VERIFY_SSL=true
 
 # =============================================================================
 # Application

--- a/backend/app/middleware/turnstile_middleware.py
+++ b/backend/app/middleware/turnstile_middleware.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
@@ -13,6 +14,25 @@ DEFAULT_PROTECTED_PATHS = (
     "/api/v1/search",
     "/api/v1/suggest",
     "/api/v1/map/h3",
+)
+FRIENDLY_BOT_USER_AGENT_PATTERN = re.compile(
+    r"""
+    WormlyBot|           # External uptime monitoring
+    AppSignalBot|        # AppSignal monitoring
+    Googlebot|           # Google Search, Images, Video, News
+    Googlebot-Image|
+    Googlebot-Video|
+    Bingbot|             # Microsoft Bing
+    Slurp|               # Yahoo
+    DuckDuckBot|         # DuckDuckGo
+    Baiduspider|         # Baidu
+    YandexBot|           # Yandex
+    facebookexternalhit| # Facebook sharing
+    Twitterbot|          # Twitter cards
+    LinkedInBot|         # LinkedIn
+    Applebot             # Apple Search / Siri
+    """,
+    re.IGNORECASE | re.VERBOSE,
 )
 LOCAL_DEV_HOSTNAMES = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
 LOCAL_APP_ENV_VALUES = {"development", "dev", "local", "test"}
@@ -38,6 +58,11 @@ def _is_frontend_gate_request(request: Request) -> bool:
     if request.headers.get("X-BTAA-Client-Channel", "").lower() == "browser":
         return True
     return bool(request.headers.get("X-Visit-Token"))
+
+
+def _is_friendly_bot_request(request: Request) -> bool:
+    user_agent = request.headers.get("User-Agent", "")
+    return bool(user_agent and FRIENDLY_BOT_USER_AGENT_PATTERN.search(user_agent))
 
 
 def _local_turnstile_enabled() -> bool:
@@ -106,6 +131,9 @@ class TurnstileMiddleware(BaseHTTPMiddleware):
             return False
 
         if not _is_frontend_gate_request(request):
+            return False
+
+        if _is_friendly_bot_request(request):
             return False
 
         return True

--- a/backend/app/services/bridge_sync/client.py
+++ b/backend/app/services/bridge_sync/client.py
@@ -19,6 +19,13 @@ BRIDGE_FETCH_RETRY_BACKOFF_SECONDS = float(
 )
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
 @dataclass
 class BridgePage:
     data: List[Dict[str, Any]]
@@ -44,12 +51,19 @@ class KitheBridgeClient:
         self.request_timeout = int(
             request_timeout or os.getenv("KITHE_BRIDGE_REQUEST_TIMEOUT", "30")
         )
+        self.verify_ssl = _env_bool("KITHE_BRIDGE_VERIFY_SSL", True)
         self.session = session or requests.Session()
 
         if not self.base_url:
             raise ValueError("KITHE_BRIDGE_URL is required")
         if not self.token:
             raise ValueError("KITHE_BRIDGE_TOKEN is required")
+        if not self.verify_ssl:
+            logger.warning(
+                "KITHE_BRIDGE_VERIFY_SSL=false; Kithe Bridge TLS certificate "
+                "verification is disabled for %s",
+                self.base_url,
+            )
 
     def _request_json(
         self, *, url: str, params: Optional[Dict[str, Any]] = None
@@ -61,6 +75,7 @@ class KitheBridgeClient:
                     params=params,
                     headers={"X-Bridge-Token": self.token},
                     timeout=self.request_timeout,
+                    verify=self.verify_ssl,
                 )
                 return response
             except (

--- a/backend/tests/middleware/test_turnstile_middleware.py
+++ b/backend/tests/middleware/test_turnstile_middleware.py
@@ -230,6 +230,67 @@ def test_turnstile_middleware_bypasses_qgis_user_agent_without_api_key(monkeypat
 
 
 @pytest.mark.parametrize(
+    "user_agent",
+    [
+        "Mozilla/5.0 AppleWebKit/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+        "Googlebot-Image/1.0",
+        "Mozilla/5.0 AppleWebKit/537.36 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
+        "DuckDuckBot/1.1; (+http://duckduckgo.com/duckduckbot.html)",
+        "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+        "Twitterbot/1.0",
+        "LinkedInBot/1.0",
+        "Applebot/0.1",
+    ],
+)
+def test_turnstile_middleware_bypasses_friendly_crawlers_for_frontend_gate_requests(
+    monkeypatch,
+    user_agent,
+):
+    monkeypatch.setenv("TURNSTILE_ENABLED", "true")
+
+    async def session_invalid(self, request):
+        raise AssertionError("Friendly crawlers should bypass Turnstile session lookup")
+
+    monkeypatch.setattr(TurnstileService, "is_session_valid", session_invalid)
+
+    client = TestClient(_make_app())
+    response = client.get(
+        "/api/v1/search",
+        headers={
+            "User-Agent": user_agent,
+            "X-BTAA-Turnstile-Gate": "frontend-search",
+            "X-BTAA-Client-Channel": "browser",
+        },
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("user_agent", ["WormlyBot/1.0", "AppSignalBot/1.0"])
+def test_turnstile_middleware_bypasses_monitoring_bots_for_frontend_gate_requests(
+    monkeypatch,
+    user_agent,
+):
+    monkeypatch.setenv("TURNSTILE_ENABLED", "true")
+
+    async def session_invalid(self, request):
+        raise AssertionError("Monitoring bots should bypass Turnstile session lookup")
+
+    monkeypatch.setattr(TurnstileService, "is_session_valid", session_invalid)
+
+    client = TestClient(_make_app())
+    response = client.get(
+        "/api/v1/search",
+        headers={
+            "User-Agent": user_agent,
+            "X-BTAA-Turnstile-Gate": "frontend-search",
+        },
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
     ("headers", "params"),
     [
         ({"X-BTAA-Client-Channel": "browser"}, None),

--- a/backend/tests/services/test_bridge_sync_client.py
+++ b/backend/tests/services/test_bridge_sync_client.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from app.services.bridge_sync.client import KitheBridgeClient
+
+
+class FakeResponse:
+    status_code = 200
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"data": [], "has_more": False, "next_cursor": None}
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def get(
+        self,
+        url: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        headers: Optional[dict[str, str]] = None,
+        timeout: Optional[int] = None,
+        verify: Optional[bool] = None,
+    ) -> FakeResponse:
+        self.calls.append(
+            {
+                "url": url,
+                "params": params,
+                "headers": headers,
+                "timeout": timeout,
+                "verify": verify,
+            }
+        )
+        return FakeResponse()
+
+
+def test_kithe_bridge_client_verifies_ssl_by_default(monkeypatch):
+    monkeypatch.delenv("KITHE_BRIDGE_VERIFY_SSL", raising=False)
+    session = FakeSession()
+    client = KitheBridgeClient(
+        base_url="https://example.test/api/kithe_bridge",
+        token="secret",
+        session=session,
+    )
+
+    client.fetch_page()
+
+    assert session.calls[0]["verify"] is True
+
+
+def test_kithe_bridge_client_can_disable_ssl_verification(monkeypatch):
+    monkeypatch.setenv("KITHE_BRIDGE_VERIFY_SSL", "false")
+    session = FakeSession()
+    client = KitheBridgeClient(
+        base_url="https://geomg.lib.umn.edu/api/kithe_bridge",
+        token="secret",
+        session=session,
+    )
+
+    client.fetch_page()
+
+    assert session.calls[0]["verify"] is False
+    assert session.calls[0]["url"] == "https://geomg.lib.umn.edu/api/kithe_bridge"

--- a/backend/tests/services/test_bridge_sync_service.py
+++ b/backend/tests/services/test_bridge_sync_service.py
@@ -50,7 +50,7 @@ class FakeBridgeClient:
         return self.records.get(resource_id)
 
 
-def _http_error(status_code: int, url: str = "https://geo.btaa.org/api/kithe_bridge/test"):
+def _http_error(status_code: int, url: str = "https://geomg.lib.umn.edu/test"):
     response = requests.Response()
     response.status_code = status_code
     response.url = url

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -121,7 +121,8 @@ env:
     APP_MODE:              production
     APPLICATION_URL:       https://<%= ENV['KAMAL_HOST'] %>
     SEARCH_ENGINE_INDEXING_ENABLED: "<%= ENV.fetch('SEARCH_ENGINE_INDEXING_ENABLED', 'false') %>"
-    KITHE_BRIDGE_URL:      https://geo.btaa.org/api/kithe_bridge
+    KITHE_BRIDGE_URL:      https://geomg.lib.umn.edu/api/kithe_bridge
+    KITHE_BRIDGE_VERIFY_SSL: "<%= ENV.fetch('KITHE_BRIDGE_VERIFY_SSL', 'true') %>"
     PYTHONUNBUFFERED:      "1"
     PYTHONPATH:            /app
     # IMPORTANT: tells db/config.py not to rewrite Docker hostnames to localhost:2345

--- a/docs/backend/kamal_deployment.md
+++ b/docs/backend/kamal_deployment.md
@@ -344,6 +344,12 @@ Bridge delta syncs update changed resources in Elasticsearch, invalidate and re-
 entries tagged with changed `resource:<id>` values, plus the canonical resource detail
 response for each changed resource.
 
+The Kithe Bridge server moved to `https://geomg.lib.umn.edu/` in June 2026.
+The worker reads records from the collection endpoint configured in
+`KITHE_BRIDGE_URL`, currently `https://geomg.lib.umn.edu/api/kithe_bridge`.
+Keep `KITHE_BRIDGE_VERIFY_SSL=true` unless there is a temporary certificate
+mismatch during an infrastructure change.
+
 To send the styled nightly bridge report after the Celery sync task concludes, prd enables
 sendmail delivery:
 

--- a/docs/backend/turnstile.md
+++ b/docs/backend/turnstile.md
@@ -31,6 +31,13 @@ normal browser-origin requests to public API endpoints, such as examples running
 from the MkDocs site. Turnstile is not an API authentication layer and must not
 interfere with public direct API access.
 
+Friendly crawler and monitoring user agents also bypass Turnstile, even when
+they hit a frontend-gated hot path. This keeps search indexing and external
+monitoring from depending on an interactive browser challenge. The built-in
+allowlist includes `Googlebot`, `Googlebot-Image`, `Googlebot-Video`, `Bingbot`,
+`Slurp`, `DuckDuckBot`, `Baiduspider`, `YandexBot`, `facebookexternalhit`,
+`Twitterbot`, `LinkedInBot`, `Applebot`, `WormlyBot`, and `AppSignalBot`.
+
 The single-host nginx `/search/results` BFF route and the React Router
 `/search/results` loader add a frontend gate marker for normal browser traffic,
 so frontend search traffic is still protected. When a caller supplies its own

--- a/docs/make_tasks.md
+++ b/docs/make_tasks.md
@@ -170,6 +170,8 @@ Useful bridge variables:
 | `BRIDGE_RESOURCE_SCOPE` | Batched reconciliation source: `all`, `published`, or `bridge_active`. Defaults to `all`. |
 | `BRIDGE_MAX_RESOURCES` | Optional cap for trial batched reconciliation runs. |
 | `BRIDGE_STATUS_POLL_SECONDS` | Defaults to `5`. |
+| `KITHE_BRIDGE_URL` | Upstream Kithe Bridge endpoint used by the worker. |
+| `KITHE_BRIDGE_VERIFY_SSL` | Defaults to `true` in code. Set to `false` only for temporary hostname/certificate mismatches. |
 
 For remote reconciliation, run `make kamal-bridge-sync-batched KAMAL_DEST=dev1`
 and then monitor with `make kamal-bridge-status-watch KAMAL_DEST=dev1`. Run
@@ -183,6 +185,12 @@ as a group before counting a record error; tune with
 requires slower or faster retry pacing. A batched run that completes with
 record errors now finishes with `bridge_status=failed`, so do not reindex from
 that run until the failed records have been retried.
+
+June 2026 bridge cutover note: the Kithe Bridge server moved to
+`https://geomg.lib.umn.edu/`, and Kamal points `KITHE_BRIDGE_URL` at the
+collection endpoint `https://geomg.lib.umn.edu/api/kithe_bridge` with
+`KITHE_BRIDGE_VERIFY_SSL=true`. Set verification to `false` only for a
+temporary hostname/certificate mismatch during an infrastructure change.
 
 ## Analytics
 


### PR DESCRIPTION
## Summary

- Allow friendly crawler and monitoring user agents to bypass the Turnstile browser gate even when requests are marked as frontend-gated traffic.
- Update Kithe Bridge defaults and deployment docs to use `https://geomg.lib.umn.edu/api/kithe_bridge` with SSL verification enabled by default.
- Add focused tests for crawler/monitoring Turnstile bypasses and Bridge client SSL verification behavior.

## Why

The old Rails Geoportal allowed search crawlers and trusted monitoring bots to reach real content without an interactive challenge. The FastAPI Turnstile middleware needed the same behavior so indexing and monitoring do not depend on a browser challenge.

The Kithe Bridge service has moved to `https://geomg.lib.umn.edu/`; the worker needs the concrete collection endpoint at `/api/kithe_bridge`.

## Validation

- `python -m pytest backend/tests/middleware/test_turnstile_middleware.py backend/tests/services/test_bridge_sync_client.py`
- `python -m ruff check backend/app/middleware/turnstile_middleware.py backend/app/services/bridge_sync/client.py backend/tests/middleware/test_turnstile_middleware.py backend/tests/services/test_bridge_sync_client.py backend/tests/services/test_bridge_sync_service.py`
- `python -m ruff format --check backend/app/middleware/turnstile_middleware.py backend/app/services/bridge_sync/client.py backend/tests/middleware/test_turnstile_middleware.py backend/tests/services/test_bridge_sync_client.py backend/tests/services/test_bridge_sync_service.py`
- Verified `https://geomg.lib.umn.edu/api/kithe_bridge` returns `401` unauthenticated and `200` with the configured Bridge token for `?limit=1`.