### PR TITLE
Fix similar items missing Elasticsearch docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,16 @@ This file gives agents a single reference for how to lint, format, test, run Doc
 
 ---
 
+## Git workflow and pull requests
+
+This repository uses **git-flow**. Treat `develop` as the normal integration branch for feature and bugfix work.
+
+- **Open pull requests against `develop`**, not `main`, unless the user explicitly asks for a different base branch.
+- Before creating or retargeting a PR, verify the base branch is `develop`.
+- If a PR is accidentally opened against another branch, retarget it to `develop` and make sure GitHub Actions actually run afterward. If checks do not appear, close and reopen the PR or push a follow-up commit to trigger a fresh `pull_request` event.
+
+---
+
 ## Lint, format, and test
 
 ### Backend (Python)

--- a/backend/app/elasticsearch/search.py
+++ b/backend/app/elasticsearch/search.py
@@ -3038,14 +3038,12 @@ async def find_similar_resources(resource_id: str, limit: int = 12) -> list:
     index_name = os.getenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
 
     try:
-        # First, check if the resource exists in Elasticsearch
-        try:
-            doc = await es.get(index=index_name, id=resource_id)
-            if not doc:
-                logger.warning(f"Resource {resource_id} not found in Elasticsearch")
-                return []
-        except NotFoundError:
-            logger.warning(f"Resource {resource_id} not found in Elasticsearch")
+        # First, check if the resource exists in Elasticsearch. Use HEAD/exists
+        # instead of GET so retired DB records that are intentionally absent from
+        # the search index do not create traced NotFoundError exceptions.
+        resource_exists = await es.exists(index=index_name, id=resource_id)
+        if not resource_exists:
+            logger.warning("Resource %s not found in Elasticsearch", resource_id)
             return []
 
         # Build more_like_this query

--- a/backend/tests/elasticsearch/test_search.py
+++ b/backend/tests/elasticsearch/test_search.py
@@ -13,6 +13,7 @@ from app.elasticsearch.search import (
     _compute_bbox_spatial_metrics,
     _escape_query_string_brackets,
     _normalize_geo_bbox_bounds,
+    find_similar_resources,
     get_search_criteria,
     map_h3_aggregation,
     search_resources,
@@ -64,6 +65,26 @@ class TestElasticsearchSearch:
         assert criteria["query"] == "test query"
         assert criteria["filters"] == {"dct_spatial_sm": ["Minnesota"]}
         assert criteria["sort"] == [{"_score": "desc"}]
+
+    @pytest.mark.asyncio
+    async def test_find_similar_resources_short_circuits_missing_source_doc(self, monkeypatch):
+        """Missing source docs should not emit traced Elasticsearch GET 404s."""
+        monkeypatch.setenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
+        mock_es = AsyncMock()
+        mock_es.exists.return_value = False
+        mock_es.get = AsyncMock()
+        mock_es.search = AsyncMock()
+
+        with patch("app.elasticsearch.search.es", mock_es):
+            result = await find_similar_resources("retired-resource-id")
+
+        assert result == []
+        mock_es.exists.assert_awaited_once_with(
+            index="btaa_geospatial_api",
+            id="retired-resource-id",
+        )
+        mock_es.get.assert_not_awaited()
+        mock_es.search.assert_not_awaited()
 
     def test_compute_bbox_spatial_metrics_rewards_containment(self):
         """Contained extents should still score well even when query bbox is larger."""


### PR DESCRIPTION
## Summary

- Restore the Similar Items Elasticsearch source-document check to use `exists` instead of `get`.
- Add a regression test that proves missing source docs short-circuit without calling `es.get` or running the similarity search.

## Root Cause

v0.8.4 reverted the earlier fix and changed `find_similar_resources` back to an Elasticsearch `get` call before the `more_like_this` query. Retired or unpublished resources can remain in Postgres while intentionally absent from the active Elasticsearch index, so rendering Similar Items for those detail pages produced traced Elasticsearch `NotFoundError` samples in AppSignal even though the code caught the exception.

## Impact

The endpoint now returns an empty Similar Items list for resources missing from Elasticsearch without emitting noisy traced 404 exceptions.

## Validation

- `python -m pytest backend/tests/elasticsearch/test_search.py::TestElasticsearchSearch::test_find_similar_resources_short_circuits_missing_source_doc backend/tests/services/test_similar_items_service.py`
- `make lint-check`
