### PR TITLE
Fix Kithe Bridge relationship sync and index refresh

### DIFF
--- a/backend/app/services/bridge_sync/batched.py
+++ b/backend/app/services/bridge_sync/batched.py
@@ -8,9 +8,12 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import requests
 
+from app.services.bridge_sync.cache_refresh import refresh_cache_for_changed_resources
+from app.services.bridge_sync.changed_resources import resource_ids_for_bridge_records
 from app.services.bridge_sync.client import KitheBridgeClient
 from app.services.bridge_sync.importer import BridgeResourceImporter
 from app.services.bridge_sync.repository import BridgeSyncRepository
+from app.services.bridge_sync.search_index import index_changed_resources
 from db.database import database
 
 logger = logging.getLogger(__name__)
@@ -20,6 +23,7 @@ MAX_BATCH_SIZE = 1000
 VALID_RESOURCE_SCOPES = {"all", "published", "bridge_active"}
 FETCH_5XX_MAX_ATTEMPTS_ENV = "KITHE_BRIDGE_BATCH_FETCH_5XX_MAX_ATTEMPTS"
 FETCH_5XX_RETRY_BACKOFF_SECONDS_ENV = "KITHE_BRIDGE_BATCH_FETCH_5XX_RETRY_BACKOFF_SECONDS"
+BATCH_CACHE_REFRESH_ENABLED_ENV = "BRIDGE_BATCH_CACHE_REFRESH_ENABLED"
 
 BatchEnqueuer = Callable[..., Optional[str]]
 
@@ -67,6 +71,13 @@ def _fetch_5xx_retry_backoff_seconds() -> float:
         return max(0.0, float(os.getenv(FETCH_5XX_RETRY_BACKOFF_SECONDS_ENV, "2.0")))
     except ValueError:
         return 2.0
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "t", "yes", "y"}
 
 
 def _http_status_code(exc: Exception) -> Optional[int]:
@@ -427,6 +438,37 @@ async def sync_bridge_resource_batch(
         )
         batch_stats["missing"] = len(missing_ids)
         batch_stats["retired"] = retired_count
+
+    search_refresh_ids = resource_ids_for_bridge_records(records) + missing_ids
+    if search_refresh_ids:
+        try:
+            batch_stats["search_index_refresh"] = await index_changed_resources(search_refresh_ids)
+        except Exception as index_exc:
+            logger.warning(
+                "Bridge batched search index refresh failed for bridge_id=%s batch_number=%s: %s",
+                bridge_id,
+                batch_number,
+                index_exc,
+            )
+            batch_stats["search_index_refresh"] = {"enabled": True, "error": str(index_exc)}
+
+    if _env_bool(BATCH_CACHE_REFRESH_ENABLED_ENV, False):
+        cache_refresh_ids = (
+            resource_ids_for_bridge_records(records, include_related=True) + missing_ids
+        )
+        if cache_refresh_ids:
+            try:
+                batch_stats["cache_refresh"] = await refresh_cache_for_changed_resources(
+                    cache_refresh_ids
+                )
+            except Exception as cache_exc:
+                logger.warning(
+                    "Bridge batched cache refresh failed for bridge_id=%s batch_number=%s: %s",
+                    bridge_id,
+                    batch_number,
+                    cache_exc,
+                )
+                batch_stats["cache_refresh"] = {"enabled": True, "error": str(cache_exc)}
 
     _finalize_error_stats(batch_stats)
     parent_stats = await repo.record_batched_batch_result(

--- a/backend/app/services/bridge_sync/changed_resources.py
+++ b/backend/app/services/bridge_sync/changed_resources.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from app.services.relationship_sync import RELATIONSHIP_FAMILIES
+
+RELATIONSHIP_FIELD_NAMES: tuple[str, ...] = tuple(
+    field_name for field_name, _predicate, _inverse_predicate in RELATIONSHIP_FAMILIES
+)
+
+
+def _append_clean_id(resource_ids: list[str], value: Any) -> None:
+    cleaned = str(value or "").strip()
+    if cleaned:
+        resource_ids.append(cleaned)
+
+
+def _append_values(resource_ids: list[str], value: Any) -> None:
+    if value is None:
+        return
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            _append_clean_id(resource_ids, item)
+        return
+    _append_clean_id(resource_ids, value)
+
+
+def resource_ids_for_bridge_records(
+    records: Iterable[dict[str, Any]],
+    *,
+    include_related: bool = False,
+) -> list[str]:
+    resource_ids: list[str] = []
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        _append_clean_id(resource_ids, record.get("id"))
+        if include_related:
+            for field_name in RELATIONSHIP_FIELD_NAMES:
+                _append_values(resource_ids, record.get(field_name))
+    return resource_ids

--- a/backend/app/services/bridge_sync/harvest.py
+++ b/backend/app/services/bridge_sync/harvest.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from app.services.bridge_sync.cache_refresh import refresh_cache_for_changed_resources
+from app.services.bridge_sync.changed_resources import resource_ids_for_bridge_records
 from app.services.bridge_sync.client import KitheBridgeClient
 from app.services.bridge_sync.importer import BridgeResourceImporter
 from app.services.bridge_sync.repository import BridgeSyncRepository
@@ -88,7 +89,8 @@ async def sync_bridge(
     last_cursor: Optional[str] = None
     pages_processed = 0
     stats: Dict[str, Any] = {"processed": 0, "imported": 0, "skipped": 0, "errors": 0}
-    changed_resource_ids: list[str] = []
+    search_refresh_resource_ids: list[str] = []
+    cache_refresh_resource_ids: list[str] = []
     if resource_id_norm:
         stats["scope"] = "single"
         stats["estimated_total"] = 1
@@ -124,10 +126,9 @@ async def sync_bridge(
             pages_processed = 1
             found_resource = bool(record)
             page_records = [record] if record else []
-            changed_resource_ids.extend(
-                str(item.get("id")).strip()
-                for item in page_records
-                if isinstance(item, dict) and item.get("id")
+            search_refresh_resource_ids.extend(resource_ids_for_bridge_records(page_records))
+            cache_refresh_resource_ids.extend(
+                resource_ids_for_bridge_records(page_records, include_related=True)
             )
             page_stats = await importer.upsert_records(
                 page_records,
@@ -160,11 +161,10 @@ async def sync_bridge(
                 pages_processed += 1
 
                 page_records = page.data
+                search_refresh_resource_ids.extend(resource_ids_for_bridge_records(page_records))
                 if changed_since_norm:
-                    changed_resource_ids.extend(
-                        str(item.get("id")).strip()
-                        for item in page_records
-                        if isinstance(item, dict) and item.get("id")
+                    cache_refresh_resource_ids.extend(
+                        resource_ids_for_bridge_records(page_records, include_related=True)
                     )
                 page_stats = await importer.upsert_records(
                     page_records,
@@ -206,6 +206,8 @@ async def sync_bridge(
             retired_count = await repo.retire_missing_resources(
                 missing_ids, retired_at=datetime.utcnow()
             )
+            search_refresh_resource_ids.extend(missing_ids)
+            cache_refresh_resource_ids.extend(missing_ids)
         stats.update(
             {
                 "stage": "complete",
@@ -218,16 +220,20 @@ async def sync_bridge(
         if resource_id_norm:
             stats["found"] = found_resource
 
-        if changed_resource_ids:
-            stats["changed_resources"] = len({rid for rid in changed_resource_ids if rid})
+        if search_refresh_resource_ids:
+            stats["changed_resources"] = len({rid for rid in search_refresh_resource_ids if rid})
             try:
-                stats["search_index_refresh"] = await index_changed_resources(changed_resource_ids)
+                stats["search_index_refresh"] = await index_changed_resources(
+                    search_refresh_resource_ids
+                )
             except Exception as index_exc:
                 logger.warning("Bridge search index refresh failed; continuing. err=%s", index_exc)
                 stats["search_index_refresh"] = {"enabled": True, "error": str(index_exc)}
+
+        if cache_refresh_resource_ids:
             try:
                 stats["cache_refresh"] = await refresh_cache_for_changed_resources(
-                    changed_resource_ids
+                    cache_refresh_resource_ids
                 )
             except Exception as cache_exc:
                 logger.warning("Bridge cache refresh failed; continuing. err=%s", cache_exc)

--- a/backend/app/services/bridge_sync/importer.py
+++ b/backend/app/services/bridge_sync/importer.py
@@ -22,6 +22,7 @@ from app.services.reference_reconstruction import (
     build_effective_reference_payload,
     serialize_reference_payload,
 )
+from app.services.relationship_sync import sync_relationships_for_batch
 from db.database import database
 from db.models import resources
 
@@ -306,6 +307,13 @@ class BridgeResourceImporter:
                         logger.warning(
                             "Nested bridge sync failed for batch; continuing. err=%s",
                             str(nested_err),
+                        )
+                    try:
+                        await sync_relationships_for_batch(rows)
+                    except Exception as rel_err:
+                        logger.warning(
+                            "Relationship sync failed for bridge batch; continuing. err=%s",
+                            str(rel_err),
                         )
                     await self.repo.upsert_resources_seen_batch(seen)
                 return len(rows)

--- a/backend/app/services/bridge_sync/repository.py
+++ b/backend/app/services/bridge_sync/repository.py
@@ -389,6 +389,12 @@ class BridgeSyncRepository:
                         break
                     retry_samples.append(sample)
                 stats["fetch_5xx_retry_samples"] = retry_samples
+            for refresh_key in ("search_index_refresh", "cache_refresh"):
+                if isinstance(batch_stats.get(refresh_key), dict):
+                    stats[refresh_key] = self._merge_refresh_stats(
+                        stats.get(refresh_key),
+                        batch_stats[refresh_key],
+                    )
 
             if failed:
                 stats["batches_failed"] = int(stats.get("batches_failed") or 0) + 1
@@ -518,6 +524,29 @@ class BridgeSyncRepository:
                     :10
                 ]
             ]
+
+    @staticmethod
+    def _merge_refresh_stats(existing: Any, update: Dict[str, Any]) -> Dict[str, Any]:
+        merged: Dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+        for key, value in update.items():
+            if key == "enabled":
+                merged[key] = bool(merged.get(key, True)) and bool(value)
+            elif key == "batch_size":
+                merged[key] = value
+            elif isinstance(value, bool):
+                merged[key] = value
+            elif isinstance(value, (int, float)):
+                merged[key] = int(merged.get(key) or 0) + value
+            elif isinstance(value, dict):
+                merged[key] = BridgeSyncRepository._merge_refresh_stats(
+                    merged.get(key),
+                    value,
+                )
+            elif key not in merged:
+                merged[key] = value
+            else:
+                merged[key] = value
+        return merged
 
     async def mark_missing_stale(self, run_started_at: datetime) -> List[str]:
         now = datetime.utcnow()

--- a/backend/tests/services/test_bridge_sync_service.py
+++ b/backend/tests/services/test_bridge_sync_service.py
@@ -27,6 +27,7 @@ from db.models import (
     resource_distributions,
     resource_downloads,
     resource_licensed_accesses,
+    resource_relationships,
     resources,
 )
 
@@ -255,6 +256,7 @@ class TestBridgeSyncService:
             assert result["stats"]["imported"] == 1
             assert result["stats"]["missing"] == 1
             assert result["stats"]["retired"] == 1
+            assert result["stats"]["search_index_refresh"]["enabled"] is False
 
             run = await repo.get_sync_run(run_id)
             assert run is not None
@@ -266,6 +268,8 @@ class TestBridgeSyncService:
             assert stats["imported"] == 1
             assert stats["missing"] == 1
             assert stats["retired"] == 1
+            assert stats["search_index_refresh"]["enabled"] is False
+            assert stats["search_index_refresh"]["resource_ids"] == 0
 
             found = await database.fetch_one(
                 select(resources.c.id, resources.c.dct_title_s).where(resources.c.id == found_id)
@@ -283,6 +287,109 @@ class TestBridgeSyncService:
             assert missing["publication_state"] == "retired"
             assert missing["b1g_publication_state_s"] == "retired"
         finally:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_sync_bridge_populates_inverse_replacement_relationships(self):
+        repo = BridgeSyncRepository()
+        importer = BridgeResourceImporter(repo=repo)
+        old_id = "bridge-replaced-old"
+        new_id = "bridge-replaced-new"
+        resource_ids = [old_id, new_id]
+
+        old_record = {
+            "id": old_id,
+            "import_id": "replace-old",
+            "publication_state": "unpublished",
+            "b1g_publication_state_s": "unpublished",
+            "dct_title_s": "Old Bridge Record",
+            "dct_description_sm": ["Retired record"],
+            "dct_references_s": "[]",
+        }
+        new_record = {
+            "id": new_id,
+            "import_id": "replace-new",
+            "publication_state": "published",
+            "dct_title_s": "New Bridge Record",
+            "dct_description_sm": ["Replacement record"],
+            "dct_replaces_sm": [old_id],
+            "dct_references_s": "[]",
+        }
+
+        if not database.is_connected:
+            await database.connect()
+
+        try:
+            await database.execute(
+                delete(resource_relationships).where(
+                    (resource_relationships.c.subject_id.in_(resource_ids))
+                    | (resource_relationships.c.object_id.in_(resource_ids))
+                )
+            )
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
+
+            client = FakeBridgeClient(
+                {
+                    "__first__": BridgePage(
+                        data=[old_record, new_record],
+                        next_cursor=None,
+                        has_more=False,
+                    )
+                }
+            )
+
+            result = await sync_bridge(
+                trigger="manual",
+                limit=10,
+                changed_since="2026-06-15T00:00:00Z",
+                client=client,
+                importer=importer,
+                repo=repo,
+            )
+
+            assert result["stats"]["imported"] == 2
+            rows = await database.fetch_all(
+                select(
+                    resource_relationships.c.subject_id,
+                    resource_relationships.c.predicate,
+                    resource_relationships.c.object_id,
+                )
+                .where(resource_relationships.c.subject_id.in_(resource_ids))
+                .where(resource_relationships.c.object_id.in_(resource_ids))
+                .order_by(
+                    resource_relationships.c.subject_id,
+                    resource_relationships.c.predicate,
+                    resource_relationships.c.object_id,
+                )
+            )
+
+            relationships = {
+                (row["subject_id"], row["predicate"], row["object_id"]) for row in rows
+            }
+            assert (new_id, "dct:replaces", old_id) in relationships
+            assert (old_id, "dct:isReplacedBy", new_id) in relationships
+            assert result["stats"]["changed_resources"] == 2
+            assert result["stats"]["search_index_refresh"]["enabled"] is False
+            assert result["stats"]["cache_refresh"]["enabled"] is False
+        finally:
+            await database.execute(
+                delete(resource_relationships).where(
+                    (resource_relationships.c.subject_id.in_(resource_ids))
+                    | (resource_relationships.c.object_id.in_(resource_ids))
+                )
+            )
             await database.execute(
                 delete(bridge_resource_state).where(
                     bridge_resource_state.c.bridge_resource_id.in_(resource_ids)

--- a/docs/backend/kamal_deployment.md
+++ b/docs/backend/kamal_deployment.md
@@ -365,9 +365,12 @@ Python-path, and bridge settings before the job starts.
 Bridge/blog cron triggers enqueue Celery tasks with `apply_async(ignore_result=True)` so
 they do not depend on a result-backend subscription just to queue fire-and-forget work.
 
-Bridge delta syncs update changed resources in Elasticsearch, invalidate and re-warm cache
-entries tagged with changed `resource:<id>` values, plus the canonical resource detail
-response for each changed resource.
+Bridge syncs update imported and retired resources in Elasticsearch as the sync completes.
+Delta and single-record syncs also invalidate and re-warm cache entries tagged with changed
+or relationship-linked `resource:<id>` values, plus the canonical resource detail response
+for those resources. Batched bridge reconciliation refreshes Elasticsearch per completed
+batch; set `BRIDGE_BATCH_CACHE_REFRESH_ENABLED=true` only when a batched run should also
+invalidate and re-warm changed resource caches.
 
 The Kithe Bridge server moved to `https://geomg.lib.umn.edu/` in June 2026.
 The worker reads records from the collection endpoint configured in

--- a/docs/backend/relationships.md
+++ b/docs/backend/relationships.md
@@ -9,7 +9,10 @@ The field `dct_isPartOf_sm` is defined in the index mapping (text + keyword subf
 ## Building relationships
 
 - **DB table**: `resource_relationships` (subject_id, predicate, object_id). Populated from the `resources` table columns (e.g. `dct_isPartOf_sm`, `pcdm_memberOf_sm`).
-- **OGM harvest behavior**: OpenGeoMetadata harvests now sync `resource_relationships` automatically for the harvested records and any unchanged resources that point at them.
+- **Import behavior**: OpenGeoMetadata harvests and Kithe Bridge syncs sync
+  `resource_relationships` automatically for imported records and unchanged
+  resources that point at them. This includes inverse replacement links such as
+  `dct:isReplacedBy` from a new record's `dct_replaces_sm` value.
 - **Make task** (from project root):
   ```bash
   make populate-relationships
@@ -19,8 +22,8 @@ The field `dct_isPartOf_sm` is defined in the index mapping (text + keyword subf
   - **Has part**: `include_filters[dct_isPartOf_sm][]=<parent_id>` — children must have the parent ID in `resources.dct_isPartOf_sm`.
   - **Collection records**: `include_filters[pcdm_memberOf_sm][]=<collection_id>` — member resources must have the collection ID in `resources.pcdm_memberOf_sm`.
   Filters are applied in Elasticsearch using the indexed fields (with `.keyword` for exact match). So:
-  1. Run `make populate-relationships` so the UI relationship lists are correct (from `resource_relationships`).
-  2. Run `make reindex` so Elasticsearch has up-to-date `dct_isPartOf_sm` and `pcdm_memberOf_sm` for the search filters.
+  1. Run `make populate-relationships` after manual/bulk DB edits that bypass the normal importers.
+  2. Run `make reindex` after manual/bulk DB edits so Elasticsearch has up-to-date `dct_isPartOf_sm` and `pcdm_memberOf_sm` for the search filters.
 
 ## Querying the database
 

--- a/docs/make_tasks.md
+++ b/docs/make_tasks.md
@@ -178,19 +178,22 @@ Useful bridge variables:
 | `BRIDGE_STATUS_POLL_SECONDS` | Defaults to `5`. |
 | `KITHE_BRIDGE_URL` | Upstream Kithe Bridge endpoint used by the worker. |
 | `KITHE_BRIDGE_VERIFY_SSL` | Defaults to `true` in code. Set to `false` only for temporary hostname/certificate mismatches. |
+| `BRIDGE_BATCH_CACHE_REFRESH_ENABLED` | Defaults to `false`; set to `true` only when a batched run should also invalidate and rewarm changed resource caches. |
 
 For remote reconciliation, run `make kamal-bridge-sync-batched KAMAL_DEST=dev1`
-and then monitor with `make kamal-bridge-status-watch KAMAL_DEST=dev1`. Run
-`make kamal-reindex` after the batched sync completes so Elasticsearch reflects
-the corrected database rows. The batched target reconciles existing local IDs;
-keep the normal bridge crawl/delta sync for discovering newly added Bridge
-records. Batched resource fetches retry transient Kithe Bridge `5xx` responses
-as a group before counting a record error; tune with
+and then monitor with `make kamal-bridge-status-watch KAMAL_DEST=dev1`. Bridge
+syncs now refresh Elasticsearch for imported and retired resource IDs as the sync
+completes; batched reconciliation does this per completed batch, while cache
+refresh for batched runs is opt-in via `BRIDGE_BATCH_CACHE_REFRESH_ENABLED`.
+The batched target reconciles existing local IDs; keep the normal bridge
+crawl/delta sync for discovering newly added Bridge records. Batched resource
+fetches retry transient Kithe Bridge `5xx` responses as a group before counting
+a record error; tune with
 `KITHE_BRIDGE_BATCH_FETCH_5XX_MAX_ATTEMPTS` and
 `KITHE_BRIDGE_BATCH_FETCH_5XX_RETRY_BACKOFF_SECONDS` when an upstream outage
 requires slower or faster retry pacing. A batched run that completes with
-record errors now finishes with `bridge_status=failed`, so do not reindex from
-that run until the failed records have been retried.
+record errors now finishes with `bridge_status=failed`, so retry the failed
+records before treating that run as complete.
 
 June 2026 bridge cutover note: the Kithe Bridge server moved to
 `https://geomg.lib.umn.edu/`, and Kamal points `KITHE_BRIDGE_URL` at the


### PR DESCRIPTION
## Summary

Fixes issue #277 by making Kithe Bridge imports keep relationship data and search state current after syncs.

## Root Cause

Kithe Bridge imports updated `resources` and nested bridge tables, but did not refresh `resource_relationships`. New replacement records with `dct_replaces_sm` therefore did not create the inverse `dct:isReplacedBy` relationship shown on the retired record. Full and batched bridge syncs also mutated database rows without guaranteeing the corresponding Elasticsearch documents were refreshed, which left unpublished or retired records visible until a manual reindex.

## Changes

- Sync `resource_relationships` during Bridge imports, matching the existing OGM importer behavior.
- Refresh Elasticsearch for Bridge-imported and retired resource IDs when syncs complete.
- Include relationship-linked IDs in delta and single-record cache invalidation so retired/replaced resource pages update when a new record points at them.
- Refresh Elasticsearch per completed batched reconciliation batch; keep batched cache refresh opt-in with `BRIDGE_BATCH_CACHE_REFRESH_ENABLED`.
- Update bridge and relationship docs for the new operational behavior.
- Add integration coverage for inverse replacement relationships and batched refresh stats.

## Validation

- `python -m pytest backend/tests/services/test_bridge_sync_service.py backend/tests/services/test_bridge_search_index.py backend/tests/services/test_bridge_importer_normalization.py`
- `make lint-check`