### PR TITLE
Fix Kithe Bridge deletion reconciliation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help lint lint-check format test lint-test test-coverage-compare wait-local-db clear-thumbnail-cache thumbnail-completeness-report prime-thumbnail-cache prime-static-map-cache prime-resource-cache prime-visual-caches visual-assets-export visual-assets-import visual-assets-stream-import visual-assets-sync-all db-export db-import db-sync gbl-admin-db-download gbl-admin-db-unzip gbl-admin-db-restore gbl-admin-db-sync gbl-admin-db-add-latest-btaa-fields gbl-admin-db-import-resources populate-distributions backfill-distributions populate-data-dictionaries gbl-admin-db-import-all reindex reindex-benchmark local-clear-search-cache sitemap-generate analytics-maintenance analytics-size-report es-unblock populate-relationships verify-h3-index kamal-reindex kamal-verify-h3-index kamal-clear-cache kamal-prime-thumbnail-cache kamal-prime-static-map-cache kamal-prime-visual-caches kamal-prime-resource-cache kamal-thumbnail-completeness-report kamal-api-response-cache-init kamal-api-response-cache-prune refresh-resource-caches kamal-refresh-resource-caches clear_cache frontend-reset ogm-refresh ogm-refresh-all ogm-refresh-repo ogm-status ogm-status-watch ogm-failures resource-aux-init resource-cache-init api-response-cache-init api-response-cache-prune bridge-init bridge-sync bridge-sync-batched bridge-cancel bridge-status bridge-status-watch bridge-failures blog-sync
-.PHONY: kamal-blog-sync kamal-purge-home-blog-cache kamal-bridge-sync-batched kamal-bridge-status kamal-bridge-status-watch kamal-backup-postgres kamal-backup-elasticsearch kamal-backup-list-elasticsearch kamal-cron-debug kamal-cron-test-bridge kamal-worker-logs kamal-network-sanity docs-serve docs-build k6-run k6-smoke k6-stress k6-endpoint-capacity cli-test cli-lint cli-format cli-build cli-man
+.PHONY: kamal-blog-sync kamal-purge-home-blog-cache kamal-bridge-sync kamal-bridge-sync-batched kamal-bridge-status kamal-bridge-status-watch kamal-backup-postgres kamal-backup-elasticsearch kamal-backup-list-elasticsearch kamal-cron-debug kamal-cron-test-bridge kamal-worker-logs kamal-network-sanity docs-serve docs-build k6-run k6-smoke k6-stress k6-endpoint-capacity cli-test cli-lint cli-format cli-build cli-man
 
 # Load environment variables from .env file if it exists
 -include .env
@@ -1421,9 +1421,39 @@ bridge-status-watch: bridge-init ## Poll bridge sync status continuously (curren
 
 # Show bridge sync status on Kamal.
 # Usage:
+#   make kamal-bridge-sync
+#   make kamal-bridge-sync RESOURCE_ID=b1g_PJxxfKgpqpUT
+#   make kamal-bridge-sync BRIDGE_LIMIT=50
+#   make kamal-bridge-sync BRIDGE_CHANGED_SINCE=2026-04-01T00:00:00Z
 #   make kamal-bridge-status
 #   make kamal-bridge-status BRIDGE_RUNS_LIMIT=20
 #   make kamal-bridge-status BRIDGE_RUN_ID=<run_id>
+kamal-bridge-sync: ## Trigger bridge sync on Kamal
+	@echo "Triggering bridge sync on Kamal (dest: $(KAMAL_DEST))..."
+	@if [ -z "$$KAMAL_SSH_USER" ] || [ -z "$$KAMAL_HOST" ]; then \
+		echo "ERROR: KAMAL_SSH_USER and KAMAL_HOST environment variables must be set."; \
+		echo "$(KAMAL_DEST_HELP)"; \
+		exit 1; \
+	fi
+	@kamal app exec -d $(KAMAL_DEST) --roles $(KAMAL_APP_ROLE) --reuse "bash -lc '\
+		ADMIN_USER=\$${ADMIN_USERNAME:-admin}; \
+		ADMIN_PASS=\$${ADMIN_PASSWORD:-changeme}; \
+		API_BASE=\"$(KAMAL_API_URL)\"; \
+		if [ -z \"\$$API_BASE\" ]; then API_BASE=\"\$$APPLICATION_URL\"; fi; \
+		if [ -z \"\$$API_BASE\" ]; then echo \"ERROR: KAMAL_API_URL or APPLICATION_URL must be set.\"; exit 1; fi; \
+		API_BASE=\"\$${API_BASE%/}\"; \
+		BODY=\"{\\\"bridge_trigger\\\":\\\"$(BRIDGE_TRIGGER)\\\"\"; \
+		if [ -n \"$(BRIDGE_LIMIT)\" ]; then BODY=\"\$$BODY,\\\"limit\\\":$(BRIDGE_LIMIT)\"; fi; \
+		if [ -n \"$(BRIDGE_CHANGED_SINCE)\" ]; then BODY=\"\$$BODY,\\\"changed_since\\\":\\\"$(BRIDGE_CHANGED_SINCE)\\\"\"; fi; \
+		if [ -n \"$(BRIDGE_RESOURCE_ID)\" ]; then BODY=\"\$$BODY,\\\"resource_id\\\":\\\"$(BRIDGE_RESOURCE_ID)\\\"\"; fi; \
+		BODY=\"\$$BODY}\"; \
+		curl -fsS -u \"\$$ADMIN_USER:\$$ADMIN_PASS\" -X POST \
+			\"\$$API_BASE/api/v1/admin/bridge/sync\" \
+			-H \"Content-Type: application/json\" \
+			-d \"\$$BODY\"'"
+	@echo
+	@echo "Bridge sync request submitted on $(KAMAL_DEST)."
+
 kamal-bridge-sync-batched: ## Trigger batched bridge reconciliation on Kamal
 	@echo "Triggering batched bridge sync on Kamal (dest: $(KAMAL_DEST))..."
 	@if [ -z "$$KAMAL_SSH_USER" ] || [ -z "$$KAMAL_HOST" ]; then \

--- a/backend/app/services/bridge_sync/batched.py
+++ b/backend/app/services/bridge_sync/batched.py
@@ -263,6 +263,7 @@ async def queue_batched_bridge_sync(
         "skipped": 0,
         "errors": 0,
         "missing": 0,
+        "deleted": 0,
         "retired": 0,
         "updated_at": datetime.utcnow().isoformat() + "Z",
         "post_sync": "run a full Elasticsearch reindex after this batched sync completes",
@@ -398,6 +399,7 @@ async def sync_bridge_resource_batch(
         "skipped": 0,
         "errors": 0,
         "missing": 0,
+        "deleted": 0,
         "retired": 0,
         "total_batches": total_batches,
     }
@@ -430,14 +432,9 @@ async def sync_bridge_resource_batch(
             batch_stats.setdefault("error_signatures", []).extend(import_stats["error_signatures"])
 
     if missing_ids:
-        missing_since = datetime.utcnow()
-        await repo.mark_resources_missing(missing_ids, missing_since=missing_since)
-        retired_count = await repo.retire_missing_resources(
-            missing_ids,
-            retired_at=missing_since,
-        )
+        deleted_count = await repo.delete_missing_resources(missing_ids)
         batch_stats["missing"] = len(missing_ids)
-        batch_stats["retired"] = retired_count
+        batch_stats["deleted"] = deleted_count
 
     search_refresh_ids = resource_ids_for_bridge_records(records) + missing_ids
     if search_refresh_ids:

--- a/backend/app/services/bridge_sync/harvest.py
+++ b/backend/app/services/bridge_sync/harvest.py
@@ -52,7 +52,7 @@ async def sync_bridge(
     importer: Optional[BridgeResourceImporter] = None,
     repo: Optional[BridgeSyncRepository] = None,
 ) -> Dict[str, Any]:
-    """Page the bridge API, UPSERT resources, and retire records that disappear."""
+    """Page the bridge API, UPSERT resources, and delete bridge records that disappear."""
 
     if not database.is_connected:
         await database.connect()
@@ -88,7 +88,14 @@ async def sync_bridge(
     cursor: Optional[str] = None
     last_cursor: Optional[str] = None
     pages_processed = 0
-    stats: Dict[str, Any] = {"processed": 0, "imported": 0, "skipped": 0, "errors": 0}
+    stats: Dict[str, Any] = {
+        "processed": 0,
+        "imported": 0,
+        "skipped": 0,
+        "errors": 0,
+        "deleted": 0,
+        "retired": 0,
+    }
     search_refresh_resource_ids: list[str] = []
     cache_refresh_resource_ids: list[str] = []
     if resource_id_norm:
@@ -195,17 +202,18 @@ async def sync_bridge(
                 cursor = page.next_cursor
 
         missing_ids = []
-        retired_count = 0
+        deleted_count = 0
         # Delta crawl (`changed_since`) does not have a complete snapshot, so we
-        # must not retire "missing" resources that simply weren't returned.
+        # must not delete resources that simply weren't returned.
         if resource_id_norm:
             if not found_resource:
-                raise RuntimeError(f"Bridge resource {resource_id_norm} was not found")
+                missing_ids = [resource_id_norm]
+                deleted_count = await repo.delete_missing_resources(missing_ids)
+                search_refresh_resource_ids.append(resource_id_norm)
+                cache_refresh_resource_ids.append(resource_id_norm)
         elif not changed_since_norm:
             missing_ids = await repo.mark_missing_stale(run_started_at=run_started_at)
-            retired_count = await repo.retire_missing_resources(
-                missing_ids, retired_at=datetime.utcnow()
-            )
+            deleted_count = await repo.delete_missing_resources(missing_ids)
             search_refresh_resource_ids.extend(missing_ids)
             cache_refresh_resource_ids.extend(missing_ids)
         stats.update(
@@ -213,7 +221,7 @@ async def sync_bridge(
                 "stage": "complete",
                 "pages_processed": pages_processed,
                 "missing": len(missing_ids),
-                "retired": retired_count,
+                "deleted": deleted_count,
                 "updated_at": datetime.utcnow().isoformat() + "Z",
             }
         )
@@ -246,11 +254,11 @@ async def sync_bridge(
             bridge_last_cursor=last_cursor,
         )
         logger.info(
-            "Bridge sync completed run_id=%s pages=%s imported=%s retired=%s",
+            "Bridge sync completed run_id=%s pages=%s imported=%s deleted=%s",
             run_id,
             pages_processed,
             stats.get("imported"),
-            stats.get("retired"),
+            stats.get("deleted"),
         )
         return {"bridge_id": run_id, "stats": stats, "bridge_last_cursor": last_cursor}
     except Exception as exc:

--- a/backend/app/services/bridge_sync/report.py
+++ b/backend/app/services/bridge_sync/report.py
@@ -415,8 +415,12 @@ def build_bridge_sync_report_html(
                     ("Changed resources", f"{changed_resources:,}"),
                     ("Pages processed", f"{_coerce_int(stats.get('pages_processed')):,}"),
                     (
-                        "Missing / retired",
-                        f"{_coerce_int(stats.get('missing')):,} / {_coerce_int(stats.get('retired')):,}",
+                        "Missing / deleted / retired",
+                        (
+                            f"{_coerce_int(stats.get('missing')):,} / "
+                            f"{_coerce_int(stats.get('deleted')):,} / "
+                            f"{_coerce_int(stats.get('retired')):,}"
+                        ),
                     ),
                 ]
             ),

--- a/backend/app/services/bridge_sync/repository.py
+++ b/backend/app/services/bridge_sync/repository.py
@@ -1,47 +1,34 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Set, Tuple
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import func, select, text, update
+from sqlalchemy import delete, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from db.database import database
-from db.models import bridge_resource_state, bridge_sync_runs, resources
+from db.models import (
+    bridge_resource_state,
+    bridge_sync_runs,
+    generated_resource_representations,
+    generated_visual_asset_links,
+    resource_ai_enrichments,
+    resource_allmaps,
+    resource_assets,
+    resource_data_dictionaries,
+    resource_data_dictionary_entries,
+    resource_distributions,
+    resource_downloads,
+    resource_licensed_accesses,
+    resource_relationships,
+    resource_thumbnail_state,
+    resources,
+)
 
 
 class BridgeSyncRepository:
     """Async repository for bridge sync state and run tracking."""
-
-    def __init__(self) -> None:
-        self._resource_columns_cache: Optional[Set[str]] = None
-
-    async def _resource_columns_in_db(self) -> Set[str]:
-        if self._resource_columns_cache is not None:
-            return self._resource_columns_cache
-
-        rows = await database.fetch_all(
-            text(
-                """
-                SELECT column_name
-                FROM information_schema.columns
-                WHERE table_schema = 'public' AND table_name = 'resources'
-                """
-            )
-        )
-        cols = set()
-        for row in rows:
-            try:
-                name = row["column_name"]
-            except Exception:
-                name = None
-            if name:
-                cols.add(str(name))
-        if not cols:
-            cols = {c.name for c in resources.c}
-        self._resource_columns_cache = cols
-        return cols
 
     async def create_sync_run(self, bridge_trigger: str) -> int:
         stmt = (
@@ -341,6 +328,80 @@ class BridgeSyncRepository:
         await database.execute(stmt)
         return len(rows)
 
+    async def delete_missing_resources(self, resource_ids: List[str]) -> int:
+        ids = list(dict.fromkeys(str(resource_id or "").strip() for resource_id in resource_ids))
+        ids = [resource_id for resource_id in ids if resource_id]
+        if not ids:
+            return 0
+
+        async with database.transaction():
+            state_rows = await database.fetch_all(
+                select(bridge_resource_state.c.bridge_resource_id).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(ids)
+                )
+            )
+            resource_rows = await database.fetch_all(
+                select(resources.c.id, resources.c.import_id).where(resources.c.id.in_(ids))
+            )
+
+            eligible_ids = {str(row["bridge_resource_id"]) for row in state_rows}
+            eligible_ids.update(
+                str(row["id"])
+                for row in resource_rows
+                if str(row["id"] or "").strip() and str(row["import_id"] or "").strip()
+            )
+            if not eligible_ids:
+                return 0
+
+            target_ids = list(eligible_ids)
+            dictionary_rows = await database.fetch_all(
+                select(resource_data_dictionaries.c.id).where(
+                    resource_data_dictionaries.c.resource_id.in_(target_ids)
+                )
+            )
+            dictionary_ids = [row["id"] for row in dictionary_rows]
+            if dictionary_ids:
+                await database.execute(
+                    delete(resource_data_dictionary_entries).where(
+                        resource_data_dictionary_entries.c.resource_data_dictionary_id.in_(
+                            dictionary_ids
+                        )
+                    )
+                )
+
+            for table in (
+                resource_ai_enrichments,
+                resource_allmaps,
+                resource_assets,
+                resource_data_dictionaries,
+                resource_distributions,
+                resource_downloads,
+                resource_licensed_accesses,
+                resource_thumbnail_state,
+                generated_resource_representations,
+                generated_visual_asset_links,
+            ):
+                await database.execute(delete(table).where(table.c.resource_id.in_(target_ids)))
+
+            await database.execute(
+                delete(resource_relationships).where(
+                    or_(
+                        resource_relationships.c.subject_id.in_(target_ids),
+                        resource_relationships.c.object_id.in_(target_ids),
+                    )
+                )
+            )
+
+            deleted_rows = await database.fetch_all(
+                delete(resources).where(resources.c.id.in_(target_ids)).returning(resources.c.id)
+            )
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(target_ids)
+                )
+            )
+            return len(deleted_rows)
+
     async def record_batched_batch_result(
         self,
         *,
@@ -369,7 +430,15 @@ class BridgeSyncRepository:
             if current_status != "running":
                 return stats
 
-            for key in ("processed", "imported", "skipped", "errors", "missing", "retired"):
+            for key in (
+                "processed",
+                "imported",
+                "skipped",
+                "errors",
+                "missing",
+                "deleted",
+                "retired",
+            ):
                 stats[key] = int(stats.get(key) or 0) + int(batch_stats.get(key) or 0)
             for key in ("fetch_5xx_retries",):
                 if key in batch_stats:
@@ -416,6 +485,7 @@ class BridgeSyncRepository:
                 "imported": int(batch_stats.get("imported") or 0),
                 "errors": int(batch_stats.get("errors") or 0),
                 "missing": int(batch_stats.get("missing") or 0),
+                "deleted": int(batch_stats.get("deleted") or 0),
                 "retired": int(batch_stats.get("retired") or 0),
                 "fetch_5xx_retries": int(batch_stats.get("fetch_5xx_retries") or 0),
             }
@@ -559,41 +629,3 @@ class BridgeSyncRepository:
         )
         rows = await database.fetch_all(stmt)
         return [str(row["bridge_resource_id"]) for row in rows]
-
-    async def retire_missing_resources(self, resource_ids: List[str], retired_at: datetime) -> int:
-        if not resource_ids:
-            return 0
-
-        resource_columns = await self._resource_columns_in_db()
-        retired_date = date.fromisoformat(retired_at.date().isoformat())
-        state_stmt = (
-            update(bridge_resource_state)
-            .where(bridge_resource_state.c.bridge_resource_id.in_(resource_ids))
-            .where(bridge_resource_state.c.bridge_retired_at.is_(None))
-            .values(bridge_retired_at=retired_at, bridge_updated_at=retired_at)
-            .returning(bridge_resource_state.c.bridge_resource_id)
-        )
-        state_rows = await database.fetch_all(state_stmt)
-        retired_ids = [str(row["bridge_resource_id"]) for row in state_rows]
-        if not retired_ids:
-            return 0
-
-        update_values: Dict[str, Any] = {"publication_state": "retired"}
-        if "b1g_publication_state_s" in resource_columns:
-            update_values["b1g_publication_state_s"] = "retired"
-        if "b1g_dateRetired_dt" in resource_columns:
-            update_values["b1g_dateRetired_dt"] = func.coalesce(
-                resources.c.b1g_dateRetired_dt, retired_at
-            )
-        if "b1g_dateRetired_s" in resource_columns:
-            update_values["b1g_dateRetired_s"] = func.coalesce(
-                resources.c.b1g_dateRetired_s, retired_date
-            )
-        if "date_modified_dtsi" in resource_columns:
-            update_values["date_modified_dtsi"] = retired_at
-
-        resource_stmt = (
-            update(resources).where(resources.c.id.in_(retired_ids)).values(**update_values)
-        )
-        await database.execute(resource_stmt)
-        return len(retired_ids)

--- a/backend/app/tasks/bridge_sync.py
+++ b/backend/app/tasks/bridge_sync.py
@@ -228,6 +228,7 @@ async def _record_failed_bridge_sync_batch(
             "skipped": 0,
             "errors": 1,
             "missing": 0,
+            "deleted": 0,
             "retired": 0,
             "total_batches": total_batches,
             "error_samples": [

--- a/backend/scripts/bridge_status_summary.py
+++ b/backend/scripts/bridge_status_summary.py
@@ -159,6 +159,7 @@ def summarize_run(
     last_page_size = _coerce_int(stats.get("last_page_size"))
     matched_page_size = _coerce_int(stats.get("matched_page_size"))
     missing = _coerce_int(stats.get("missing"))
+    deleted = _coerce_int(stats.get("deleted"))
     retired = _coerce_int(stats.get("retired"))
     batches_completed = _coerce_int(stats.get("batches_completed"))
     batches_failed = _coerce_int(stats.get("batches_failed"))
@@ -217,6 +218,8 @@ def summarize_run(
         parts.append(f"rate={_format_rate(rate)}")
     if missing is not None:
         parts.append(f"missing={missing}")
+    if deleted is not None:
+        parts.append(f"deleted={deleted}")
     if retired is not None:
         parts.append(f"retired={retired}")
     if total_batches is not None:

--- a/backend/tests/scripts/test_bridge_status_summary.py
+++ b/backend/tests/scripts/test_bridge_status_summary.py
@@ -40,7 +40,8 @@ def test_render_payload_current_last_includes_progress_and_eta():
                     "errors": 0,
                     "pages_processed": 85,
                     "missing": 12,
-                    "retired": 12,
+                    "deleted": 12,
+                    "retired": 0,
                 },
             },
         ]
@@ -60,7 +61,7 @@ def test_render_payload_current_last_includes_progress_and_eta():
     assert "progress~=2.9%" in rendered
     assert "eta~=2h50m00s" in rendered
     assert "last:" in rendered
-    assert "missing=12 retired=12" in rendered
+    assert "missing=12 deleted=12 retired=0" in rendered
 
 
 def test_render_payload_current_only_omits_last_run():

--- a/backend/tests/services/test_bridge_sync_service.py
+++ b/backend/tests/services/test_bridge_sync_service.py
@@ -181,6 +181,72 @@ class TestBridgeSyncService:
             await database.execute(delete(bridge_sync_runs))
 
     @pytest.mark.asyncio(scope="session")
+    async def test_delete_missing_resources_skips_non_bridge_rows(self):
+        repo = BridgeSyncRepository()
+        bridge_id = "bridge-delete-guard-managed"
+        non_bridge_id = "bridge-delete-guard-nonbridge"
+        resource_ids = [bridge_id, non_bridge_id]
+
+        if not database.is_connected:
+            await database.connect()
+
+        try:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
+            await database.execute(
+                pg_insert(resources).values(
+                    [
+                        {
+                            "id": bridge_id,
+                            "dct_title_s": "Bridge Managed Row",
+                            "publication_state": "published",
+                            "b1g_publication_state_s": "published",
+                        },
+                        {
+                            "id": non_bridge_id,
+                            "dct_title_s": "Non-Bridge Row",
+                            "publication_state": "published",
+                            "b1g_publication_state_s": "published",
+                        },
+                    ]
+                )
+            )
+            await database.execute(
+                pg_insert(bridge_resource_state).values({"bridge_resource_id": bridge_id})
+            )
+
+            deleted_count = await repo.delete_missing_resources(resource_ids)
+
+            assert deleted_count == 1
+
+            bridge_row = await database.fetch_one(
+                select(resources.c.id).where(resources.c.id == bridge_id)
+            )
+            non_bridge_row = await database.fetch_one(
+                select(resources.c.id).where(resources.c.id == non_bridge_id)
+            )
+            bridge_state = await database.fetch_one(
+                select(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id == bridge_id
+                )
+            )
+
+            assert bridge_row is None
+            assert bridge_state is None
+            assert non_bridge_row is not None
+        finally:
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id.in_(resource_ids)
+                )
+            )
+            await database.execute(delete(resources).where(resources.c.id.in_(resource_ids)))
+
+    @pytest.mark.asyncio(scope="session")
     async def test_sync_bridge_resource_batch_imports_missing_and_finalizes_parent_run(self):
         repo = BridgeSyncRepository()
         importer = BridgeResourceImporter(repo=repo)
@@ -214,6 +280,7 @@ class TestBridgeSyncService:
                         "dct_title_s": "Bridge Batched Missing",
                         "publication_state": "published",
                         "b1g_publication_state_s": "published",
+                        "import_id": "batched-missing",
                     }
                 )
             )
@@ -236,6 +303,7 @@ class TestBridgeSyncService:
                     "skipped": 0,
                     "errors": 0,
                     "missing": 0,
+                    "deleted": 0,
                     "retired": 0,
                 },
             )
@@ -255,7 +323,8 @@ class TestBridgeSyncService:
             assert result["stats"]["processed"] == 2
             assert result["stats"]["imported"] == 1
             assert result["stats"]["missing"] == 1
-            assert result["stats"]["retired"] == 1
+            assert result["stats"]["deleted"] == 1
+            assert result["stats"]["retired"] == 0
             assert result["stats"]["search_index_refresh"]["enabled"] is False
 
             run = await repo.get_sync_run(run_id)
@@ -267,7 +336,8 @@ class TestBridgeSyncService:
             assert stats["processed"] == 2
             assert stats["imported"] == 1
             assert stats["missing"] == 1
-            assert stats["retired"] == 1
+            assert stats["deleted"] == 1
+            assert stats["retired"] == 0
             assert stats["search_index_refresh"]["enabled"] is False
             assert stats["search_index_refresh"]["resource_ids"] == 0
 
@@ -283,9 +353,7 @@ class TestBridgeSyncService:
             )
             assert found is not None
             assert found["dct_title_s"] == "Bridge Batched Found"
-            assert missing is not None
-            assert missing["publication_state"] == "retired"
-            assert missing["b1g_publication_state_s"] == "retired"
+            assert missing is None
         finally:
             await database.execute(
                 delete(bridge_resource_state).where(
@@ -605,7 +673,7 @@ class TestBridgeSyncService:
             await database.execute(delete(resources).where(resources.c.id == resource_id))
 
     @pytest.mark.asyncio(scope="session")
-    async def test_sync_bridge_paginates_and_retires_missing_records(self):
+    async def test_sync_bridge_paginates_and_deletes_missing_records(self):
         repo = BridgeSyncRepository()
         importer = BridgeResourceImporter(repo=repo)
 
@@ -744,7 +812,8 @@ class TestBridgeSyncService:
 
             assert second_result["stats"]["imported"] == 1
             assert second_result["stats"]["missing"] == 1
-            assert second_result["stats"]["retired"] == 1
+            assert second_result["stats"]["deleted"] == 1
+            assert second_result["stats"]["retired"] == 0
 
             downloads_a = await database.fetch_all(
                 select(resource_downloads).where(
@@ -779,12 +848,7 @@ class TestBridgeSyncService:
                 ).where(resources.c.id == "bridge-sync-a")
             )
             row_b = await database.fetch_one(
-                select(
-                    resources.c.id,
-                    resources.c.publication_state,
-                    resources.c.b1g_publication_state_s,
-                    resources.c.b1g_dateRetired_s,
-                ).where(resources.c.id == "bridge-sync-b")
+                select(resources.c.id).where(resources.c.id == "bridge-sync-b")
             )
             state_b = await database.fetch_one(
                 select(bridge_resource_state).where(
@@ -796,14 +860,8 @@ class TestBridgeSyncService:
             assert row_a["publication_state"] == "published"
             assert row_a["b1g_publication_state_s"] == "published"
 
-            assert row_b is not None
-            assert row_b["publication_state"] == "retired"
-            assert row_b["b1g_publication_state_s"] == "retired"
-            assert row_b["b1g_dateRetired_s"] is not None
-
-            assert state_b is not None
-            assert state_b["bridge_missing_since"] is not None
-            assert state_b["bridge_retired_at"] is not None
+            assert row_b is None
+            assert state_b is None
         finally:
             try:
                 await database.execute(
@@ -927,7 +985,7 @@ class TestBridgeSyncService:
                     await database.disconnect()
 
     @pytest.mark.asyncio(scope="session")
-    async def test_sync_bridge_delta_does_not_retire_missing_records(self):
+    async def test_sync_bridge_delta_does_not_delete_missing_records(self):
         repo = BridgeSyncRepository()
         importer = BridgeResourceImporter(repo=repo)
 
@@ -991,11 +1049,12 @@ class TestBridgeSyncService:
             )
 
             assert result["stats"]["missing"] == 0
+            assert result["stats"]["deleted"] == 0
             assert result["stats"]["retired"] == 0
             assert result["stats"]["search_index_refresh"]["enabled"] is False
             assert result["stats"]["cache_refresh"]["enabled"] is False
 
-            # record_b should remain published (i.e., not retired just because it
+            # record_b should remain published (i.e., not deleted just because it
             # wasn't returned in the delta crawl).
             row_b = await database.fetch_one(
                 select(
@@ -1793,33 +1852,72 @@ class TestBridgeSyncService:
                 pass
 
     @pytest.mark.asyncio(scope="session")
-    async def test_sync_bridge_resource_id_raises_when_record_missing(self):
+    async def test_sync_bridge_resource_id_deletes_when_record_missing(self):
         repo = BridgeSyncRepository()
         importer = BridgeResourceImporter(repo=repo)
+        resource_id = "bridge-sync-missing"
 
         if not database.is_connected:
             await database.connect()
 
         try:
             await database.execute(delete(bridge_sync_runs))
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id == resource_id
+                )
+            )
+            await database.execute(delete(resources).where(resources.c.id == resource_id))
+            await database.execute(
+                pg_insert(resources).values(
+                    {
+                        "id": resource_id,
+                        "dct_title_s": "Bridge Sync Missing",
+                        "publication_state": "published",
+                        "b1g_publication_state_s": "published",
+                        "import_id": "missing-import",
+                    }
+                )
+            )
             targeted_client = FakeBridgeClient({}, records={})
 
-            with pytest.raises(
-                RuntimeError, match="Bridge resource bridge-sync-missing was not found"
-            ):
-                await sync_bridge(
-                    trigger="manual",
-                    limit=1,
-                    resource_id="bridge-sync-missing",
-                    client=targeted_client,
-                    importer=importer,
-                    repo=repo,
-                )
+            result = await sync_bridge(
+                trigger="manual",
+                limit=1,
+                resource_id=resource_id,
+                client=targeted_client,
+                importer=importer,
+                repo=repo,
+            )
 
-            assert targeted_client.calls == [{"resource_id": "bridge-sync-missing"}]
+            assert targeted_client.calls == [{"resource_id": resource_id}]
+            assert result["stats"]["found"] is False
+            assert result["stats"]["missing"] == 1
+            assert result["stats"]["deleted"] == 1
+            assert result["stats"]["retired"] == 0
+            assert result["stats"]["search_index_refresh"]["enabled"] is False
+            assert result["stats"]["cache_refresh"]["enabled"] is False
+
+            row = await database.fetch_one(
+                select(resources.c.id).where(resources.c.id == resource_id)
+            )
+            state = await database.fetch_one(
+                select(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id == resource_id
+                )
+            )
+
+            assert row is None
+            assert state is None
         finally:
             try:
+                await database.execute(
+                    delete(bridge_resource_state).where(
+                        bridge_resource_state.c.bridge_resource_id == resource_id
+                    )
+                )
                 await database.execute(delete(bridge_sync_runs))
+                await database.execute(delete(resources).where(resources.c.id == resource_id))
             except Exception:
                 # Cleanup is best effort; test assertions should report the real failure.
                 pass

--- a/config/deploy.dev1.yml
+++ b/config/deploy.dev1.yml
@@ -13,7 +13,7 @@ servers:
   worker:
     hosts:
       - lib-btaageoapi-dev-app-01.oit.umn.edu
-    cmd: celery -A app.tasks.worker worker --loglevel=INFO
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: 0.75
       memory: 1536m
@@ -28,7 +28,7 @@ servers:
   flower:
     hosts:
       - lib-btaageoapi-dev-app-01.oit.umn.edu
-    cmd: celery -A app.tasks.worker flower --port=5555
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
 
 proxy:
   host: lib-btaageoapi-dev-app-01.oit.umn.edu

--- a/config/deploy.dev2.yml
+++ b/config/deploy.dev2.yml
@@ -13,7 +13,7 @@ servers:
   worker:
     hosts:
       - lib-geoportal-dev-web-01.oit.umn.edu
-    cmd: celery -A app.tasks.worker worker --loglevel=INFO
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: 0.75
       memory: 1536m
@@ -28,7 +28,7 @@ servers:
   flower:
     hosts:
       - lib-geoportal-dev-web-01.oit.umn.edu
-    cmd: celery -A app.tasks.worker flower --port=5555
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
 
 proxy:
   host: geodev.btaa.org,lib-geoportal-dev-web-01.oit.umn.edu

--- a/config/deploy.prd.yml
+++ b/config/deploy.prd.yml
@@ -26,7 +26,7 @@ servers:
   worker:
     hosts:
       - lib-geoportal-prd-web-01.oit.umn.edu
-    cmd: celery -A app.tasks.worker worker --loglevel=INFO
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: 1.75
       memory: 2048m
@@ -41,7 +41,7 @@ servers:
   flower:
     hosts:
       - lib-geoportal-prd-web-01.oit.umn.edu
-    cmd: celery -A app.tasks.worker flower --port=5555
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
 
 proxy:
   host: geo.btaa.org,lib-geoportal-prd-web-01.oit.umn.edu

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -54,7 +54,7 @@ servers:
   worker:
     hosts:
       - <%= ENV['KAMAL_HOST'] %>
-    cmd: celery -A app.tasks.worker worker --loglevel=INFO
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: <%= ENV.fetch('KAMAL_WORKER_CPUS', '1') %>
       memory: <%= ENV.fetch('KAMAL_WORKER_MEMORY', '1024m') %>
@@ -75,7 +75,7 @@ servers:
   flower:
     hosts:
       - <%= ENV['KAMAL_HOST'] %>
-    cmd: celery -A app.tasks.worker flower --port=5555
+    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
     options:
       cpus: <%= ENV.fetch('KAMAL_FLOWER_CPUS', '0.5') %>
       memory: <%= ENV.fetch('KAMAL_FLOWER_MEMORY', '512m') %>

--- a/docs/backend/kamal_deployment.md
+++ b/docs/backend/kamal_deployment.md
@@ -375,12 +375,15 @@ Python-path, and bridge settings before the job starts.
 Bridge/blog cron triggers enqueue Celery tasks with `apply_async(ignore_result=True)` so
 they do not depend on a result-backend subscription just to queue fire-and-forget work.
 
-Bridge syncs update imported and retired resources in Elasticsearch as the sync completes.
+Bridge syncs update imported and deleted resources in Elasticsearch as the sync completes.
 Delta and single-record syncs also invalidate and re-warm cache entries tagged with changed
 or relationship-linked `resource:<id>` values, plus the canonical resource detail response
 for those resources. Batched bridge reconciliation refreshes Elasticsearch per completed
 batch; set `BRIDGE_BATCH_CACHE_REFRESH_ENABLED=true` only when a batched run should also
-invalidate and re-warm changed resource caches.
+invalidate and re-warm changed resource caches. Delta windows do not prove that an omitted
+resource was deleted upstream; use a full bridge sync, batched reconciliation, or a
+targeted `make kamal-bridge-sync KAMAL_DEST=<dest> RESOURCE_ID=<id>` run to remove local
+bridge-managed records that no longer exist in Kithe Bridge.
 
 The Kithe Bridge server moved to `https://geomg.lib.umn.edu/` in June 2026.
 The worker reads records from the collection endpoint configured in

--- a/docs/make_tasks.md
+++ b/docs/make_tasks.md
@@ -254,6 +254,8 @@ Set `KAMAL_DEST=dev1`, `dev2`, or `prd`. The default is `dev1`.
 | `make kamal-backup-postgres` | Run the production-gated Postgres S3 backup in the cron container. |
 | `make kamal-backup-elasticsearch` | Run the production-gated Elasticsearch S3 snapshot in the cron container. |
 | `make kamal-backup-list-elasticsearch` | List Elasticsearch snapshots for the target destination. |
+| `make kamal-bridge-sync` | Trigger remote bridge sync. Supports `RESOURCE_ID`, `BRIDGE_LIMIT`, and `BRIDGE_CHANGED_SINCE`. |
+| `make kamal-bridge-sync-batched` | Trigger remote batched bridge reconciliation. |
 | `make kamal-bridge-status` | Show bridge status remotely. |
 | `make kamal-bridge-status-watch` | Poll remote bridge status. |
 | `make kamal-cron-debug` | Inspect cron container crontab, timezone, and env. |

--- a/docs/make_tasks.md
+++ b/docs/make_tasks.md
@@ -195,6 +195,15 @@ requires slower or faster retry pacing. A batched run that completes with
 record errors now finishes with `bridge_status=failed`, so retry the failed
 records before treating that run as complete.
 
+Bridge resources that disappear from Kithe Bridge are deleted locally, not
+converted to suppressed or retired records. A full bridge sync can detect
+missing records from a complete upstream snapshot, and
+`make bridge-sync RESOURCE_ID=<id>` deletes the local bridge-managed record when
+that upstream record is absent. A delta sync with `BRIDGE_CHANGED_SINCE` cannot
+infer deletions because unchanged records are intentionally absent from the
+delta window. The deletion guard is limited to bridge-managed rows
+(`bridge_resource_state`) or legacy Kithe-origin rows with `resources.import_id`.
+
 June 2026 bridge cutover note: the Kithe Bridge server moved to
 `https://geomg.lib.umn.edu/`, and Kamal points `KITHE_BRIDGE_URL` at the
 collection endpoint `https://geomg.lib.umn.edu/api/kithe_bridge` with


### PR DESCRIPTION
## Summary

- Delete local bridge-managed resources when a full, batched, or targeted Kithe Bridge reconciliation confirms the upstream record is missing.
- Keep `gbl_suppressed_b` and resource retirement semantics intact; these are not treated as deletion signals.
- Track `deleted` counts in bridge sync stats, status summaries, and reports while retaining `retired` for historical compatibility.
- Add `make kamal-bridge-sync` for targeted remote bridge syncs and run Kamal worker/flower commands from `/app/backend` so AppSignal can find `__appsignal__.py` during worker-side cache refresh.

## Context

This is related to issue #268 and the stray resource `6949f82de6a0414eb9a11bc282af7cf0_0`. During dev2 verification, the configured Kithe Bridge endpoint still returned `HTTP 200` for that resource with `deleted:false`, so the new deletion path correctly did not remove it. This PR fixes the API sync behavior for records that are actually absent from Bridge, but the observed dev2 result indicates the remaining cleanup for that specific resource is upstream/manual-exclusion work.

## Validation

- `make lint-check`
- `python -m pytest backend/tests/services/test_bridge_sync_service.py backend/tests/services/test_bridge_search_index.py backend/tests/scripts/test_bridge_status_summary.py backend/tests/services/test_bridge_sync_report.py`
- `python -m pytest backend/tests/test_kamal_deploy_config.py`
