### PR TITLE
Drop Flower from Kamal deployments

### DIFF
--- a/Dockerfile.kamal
+++ b/Dockerfile.kamal
@@ -169,12 +169,11 @@ ENV PORT="3000"
 
 EXPOSE 8000
 
-# HEALTHCHECK for all roles (web, cron, flower, worker). Each role runs different process:
-# Web: nginx on 8000 | Flower: Celery on 5555 | Cron: cron (PID 1) | Worker: celery, no HTTP
+# HEALTHCHECK for all roles. Each role runs a different process:
+# Web: nginx on 8000 | Cron: cron (PID 1) | Worker: celery, no HTTP
 HEALTHCHECK --interval=10s --timeout=5s --start-period=45s --retries=3 \
   CMD case "$KAMAL_CONTAINER_NAME" in \
         *-web-*) curl -sf http://127.0.0.1:8000/api/docs -o /dev/null ;; \
-        *-flower-*) curl -sf http://127.0.0.1:5555/ -o /dev/null ;; \
         *-cron-*) grep -q cron /proc/1/comm 2>/dev/null ;; \
         *) kill -0 1 2>/dev/null ;; \
       esac

--- a/backend/tests/test_kamal_deploy_config.py
+++ b/backend/tests/test_kamal_deploy_config.py
@@ -36,6 +36,23 @@ def test_prd_allows_search_engine_indexing():
     assert prd_config["env"]["clear"]["SEARCH_ENGINE_INDEXING_ENABLED"] == "true"
 
 
+def test_kamal_configs_do_not_deploy_flower_role():
+    deploy_paths = [
+        "config/deploy.yml",
+        "config/deploy.dev1.yml",
+        "config/deploy.dev2.yml",
+        "config/deploy.prd.yml",
+    ]
+
+    for path in deploy_paths:
+        config = _load_deploy_config(path)
+        assert "flower" not in config.get("servers", {})
+
+    base_config = _load_deploy_config("config/deploy.yml")
+    for accessory in base_config["accessories"].values():
+        assert "flower" not in accessory.get("roles", [])
+
+
 def test_prd_uses_canonical_geoportal_base_url():
     prd_config = _load_deploy_config("config/deploy.prd.yml")
 

--- a/config/deploy.dev1.yml
+++ b/config/deploy.dev1.yml
@@ -13,7 +13,7 @@ servers:
   worker:
     hosts:
       - lib-btaageoapi-dev-app-01.oit.umn.edu
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
+    cmd: bash -c "cd /app/backend && exec /opt/venv/bin/celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: 0.75
       memory: 1536m
@@ -24,11 +24,6 @@ servers:
     cmd: bash -lc '/app/scripts/start_cron.sh'
     options:
       user: root
-
-  flower:
-    hosts:
-      - lib-btaageoapi-dev-app-01.oit.umn.edu
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
 
 proxy:
   host: lib-btaageoapi-dev-app-01.oit.umn.edu

--- a/config/deploy.dev2.yml
+++ b/config/deploy.dev2.yml
@@ -13,7 +13,7 @@ servers:
   worker:
     hosts:
       - lib-geoportal-dev-web-01.oit.umn.edu
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
+    cmd: bash -c "cd /app/backend && exec /opt/venv/bin/celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: 0.75
       memory: 1536m
@@ -24,11 +24,6 @@ servers:
     cmd: bash -lc '/app/scripts/start_cron.sh'
     options:
       user: root
-
-  flower:
-    hosts:
-      - lib-geoportal-dev-web-01.oit.umn.edu
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
 
 proxy:
   host: geodev.btaa.org,lib-geoportal-dev-web-01.oit.umn.edu

--- a/config/deploy.prd.yml
+++ b/config/deploy.prd.yml
@@ -26,7 +26,7 @@ servers:
   worker:
     hosts:
       - lib-geoportal-prd-web-01.oit.umn.edu
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
+    cmd: bash -c "cd /app/backend && exec /opt/venv/bin/celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: 1.75
       memory: 2048m
@@ -37,11 +37,6 @@ servers:
     cmd: bash -lc '/app/scripts/start_cron.sh'
     options:
       user: root
-
-  flower:
-    hosts:
-      - lib-geoportal-prd-web-01.oit.umn.edu
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
 
 proxy:
   host: geo.btaa.org,lib-geoportal-prd-web-01.oit.umn.edu

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -54,7 +54,7 @@ servers:
   worker:
     hosts:
       - <%= ENV['KAMAL_HOST'] %>
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker worker --loglevel=INFO"
+    cmd: bash -c "cd /app/backend && exec /opt/venv/bin/celery -A app.tasks.worker worker --loglevel=INFO"
     options:
       cpus: <%= ENV.fetch('KAMAL_WORKER_CPUS', '1') %>
       memory: <%= ENV.fetch('KAMAL_WORKER_MEMORY', '1024m') %>
@@ -71,14 +71,6 @@ servers:
       cpus: <%= ENV.fetch('KAMAL_CRON_CPUS', '0.25') %>
       memory: <%= ENV.fetch('KAMAL_CRON_MEMORY', '256m') %>
       user: root
-
-  flower:
-    hosts:
-      - <%= ENV['KAMAL_HOST'] %>
-    cmd: bash -lc "cd /app/backend && celery -A app.tasks.worker flower --port=5555"
-    options:
-      cpus: <%= ENV.fetch('KAMAL_FLOWER_CPUS', '0.5') %>
-      memory: <%= ENV.fetch('KAMAL_FLOWER_MEMORY', '512m') %>
 
 proxy:
   ssl: true
@@ -193,7 +185,7 @@ env:
 accessories:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:9.0.0
-    roles: [web, worker, flower]
+    roles: [web, worker]
     env:
       clear:
         discovery.type: single-node
@@ -212,7 +204,7 @@ accessories:
 
   paradedb:
     image: paradedb/paradedb:0.18.11
-    roles: [web, worker, flower]
+    roles: [web, worker]
     env:
       clear:
         POSTGRES_USER: postgres
@@ -225,7 +217,7 @@ accessories:
 
   redis:
     image: redis:7.4.6-alpine
-    roles: [web, worker, flower]
+    roles: [web, worker]
     env:
       clear:
         REDIS_MAXMEMORY: "<%= ENV.fetch('REDIS_MAXMEMORY', '12gb') %>"

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ Core runtime technologies:
 | Database | ParadeDB/PostgreSQL, SQLAlchemy table metadata in `backend/db/models.py`, script-based migrations in `backend/db/migrations/`. |
 | Cache | Redis for hot endpoint/cache coordination plus durable database caches in `generated_api_responses`, `generated_resource_representations`, and generated visual asset tables. |
 | Jobs | Celery worker with Redis broker/result backend; Flower for local monitoring. |
-| Deployment | Kamal with `web`, `worker`, `cron`, and `flower` roles plus Elasticsearch, ParadeDB, and Redis accessories. |
+| Deployment | Kamal with `web`, `worker`, and `cron` roles plus Elasticsearch, ParadeDB, and Redis accessories. |
 | Public docs | MkDocs Material under `mkdocs/`, served locally with `make docs-serve` and built with `make docs-build`. |
 | Performance tests | Dockerized Grafana k6 scripts under `performance/k6`. |
 
@@ -218,7 +218,6 @@ Kamal roles:
 | `web` | Single-host runtime that starts FastAPI public/internal pools and React Router SSR through `scripts/start_web_singlehost.sh`. |
 | `worker` | Celery worker for ingest, cache, bridge, OGM, thumbnail, static-map, and indexing jobs. |
 | `cron` | Root cron container that loads `config/crontab` and env values rendered by `scripts/render_cron_env.py`. |
-| `flower` | Flower task monitor. |
 
 Accessories:
 

--- a/docs/backend/codebase_overview.md
+++ b/docs/backend/codebase_overview.md
@@ -467,8 +467,7 @@ Kamal deploys the application as a single-host stack with roles for:
 
 - web,
 - worker,
-- cron,
-- flower.
+- cron.
 
 Accessories run alongside the application:
 

--- a/docs/backend/k6_stress_comparison_2026-05-05.md
+++ b/docs/backend/k6_stress_comparison_2026-05-05.md
@@ -193,8 +193,7 @@ make k6-run K6_ENTRY=stress.js \
    event-loop issues, but under multi-worker production load it makes Postgres
    absorb avoidable connection churn.
 4. Set explicit Postgres connection budget math for each prd process group:
-   public API workers, internal API workers, SSR workers, worker, cron, and
-   Flower.
+   public API workers, internal API workers, SSR workers, worker, and cron.
 5. Rerun the same three corrected prd profiles after connection changes. The
    success target is the dev1-equivalent `6 frontend + 18 API` profile passing
    with 0% failures and API p95 below 1.5 s.

--- a/docs/backend/kamal_deployment.md
+++ b/docs/backend/kamal_deployment.md
@@ -100,7 +100,6 @@ Each destination is a single-host deployment with these app roles:
 - `web`: nginx + SSR + FastAPI on the public host
 - `worker`: Celery worker
 - `cron`: cron container for scheduled bridge/blog/analytics-maintenance tasks
-- `flower`: Celery monitoring UI
 
 Each destination also runs these accessories on the same VM:
 
@@ -307,7 +306,6 @@ destinations. For `dev2`, prefer `https://geodev.btaa.org`.
 kamal app logs -d prd --roles web
 kamal app logs -d prd --roles worker
 kamal app logs -d prd --roles cron
-kamal app logs -d prd --roles flower
 kamal accessory logs -d prd paradedb
 kamal accessory logs -d prd elasticsearch
 kamal accessory logs -d prd redis
@@ -539,19 +537,6 @@ That usually means the Celery worker never started the task. Check:
 make kamal-worker-logs KAMAL_DEST=prd
 kamal app details -d prd
 ```
-
-If needed, open Flower through an SSH tunnel:
-
-```bash
-set -a
-source .kamal/secrets-common
-source .kamal/secrets.prd
-set +a
-
-ssh -L 5555:localhost:5555 $KAMAL_SSH_USER@$KAMAL_HOST
-```
-
-Then open `http://localhost:5555`.
 
 ### Storage drift
 


### PR DESCRIPTION
## Summary
- Remove the Flower role from Kamal destination configs and accessory role assignments.
- Remove the Flower-specific Kamal image healthcheck branch.
- Point Kamal worker commands at `/opt/venv/bin/celery` directly so worker boots do not lose the venv path under `bash -lc`.
- Update deployment docs and add a guard test that keeps Flower out of Kamal configs.

## Why
Dev2 deploys were failing when the Flower role booted. The failed container exited with code 127 because the Kamal command used `bash -lc`, which reset `PATH` and hid `/opt/venv/bin/celery`. Since Flower is no longer needed on the Kamal instances, removing the role avoids that boot path entirely, while the worker command fix prevents the same PATH issue for Celery workers.

## Validation
- `python -m pytest backend/tests/test_kamal_deploy_config.py`
- `kamal config -d dev1`
- `kamal config -d dev2`
- `kamal config -d prd`
- `git diff --check`

## Operational note
Existing running Flower containers on dev1, dev2, and prd were stopped after this config change was prepared.