### PR TITLE
Handle Bridge tombstone deletes

### DIFF
--- a/backend/app/services/bridge_sync/batched.py
+++ b/backend/app/services/bridge_sync/batched.py
@@ -424,7 +424,7 @@ async def sync_bridge_resource_batch(
             run_started_at=run_started_at,
             batch_size=min(len(records), normalize_batch_size(None)),
         )
-        for key in ("imported", "skipped", "errors"):
+        for key in ("imported", "skipped", "errors", "deleted"):
             batch_stats[key] = int(batch_stats.get(key) or 0) + int(import_stats.get(key) or 0)
         if import_stats.get("error_samples"):
             batch_stats.setdefault("error_samples", []).extend(import_stats["error_samples"])
@@ -434,7 +434,7 @@ async def sync_bridge_resource_batch(
     if missing_ids:
         deleted_count = await repo.delete_missing_resources(missing_ids)
         batch_stats["missing"] = len(missing_ids)
-        batch_stats["deleted"] = deleted_count
+        batch_stats["deleted"] = int(batch_stats.get("deleted") or 0) + deleted_count
 
     search_refresh_ids = resource_ids_for_bridge_records(records) + missing_ids
     if search_refresh_ids:

--- a/backend/app/services/bridge_sync/harvest.py
+++ b/backend/app/services/bridge_sync/harvest.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def _merge_stats(total: Dict[str, Any], page_stats: Dict[str, Any]) -> None:
-    for key in ("processed", "imported", "skipped", "errors"):
+    for key in ("processed", "imported", "skipped", "errors", "deleted"):
         total[key] = int(total.get(key, 0)) + int(page_stats.get(key, 0) or 0)
 
     samples = list(total.get("error_samples") or [])
@@ -221,7 +221,7 @@ async def sync_bridge(
                 "stage": "complete",
                 "pages_processed": pages_processed,
                 "missing": len(missing_ids),
-                "deleted": deleted_count,
+                "deleted": int(stats.get("deleted") or 0) + deleted_count,
                 "updated_at": datetime.utcnow().isoformat() + "Z",
             }
         )

--- a/backend/app/services/bridge_sync/importer.py
+++ b/backend/app/services/bridge_sync/importer.py
@@ -162,6 +162,14 @@ class BridgeResourceImporter:
 
         return out
 
+    def _is_deleted_record(self, record: Dict[str, Any]) -> bool:
+        deleted = record.get("deleted")
+        if isinstance(deleted, bool):
+            return deleted
+        if deleted is None:
+            return False
+        return str(deleted).strip().lower() in {"1", "true", "yes", "y", "on"}
+
     def _authoritative_reference_uris_for_record(
         self,
         record: Dict[str, Any],
@@ -238,7 +246,13 @@ class BridgeResourceImporter:
         run_started_at: datetime,
         batch_size: int = 500,
     ) -> Dict[str, Any]:
-        stats: Dict[str, Any] = {"processed": 0, "imported": 0, "skipped": 0, "errors": 0}
+        stats: Dict[str, Any] = {
+            "processed": 0,
+            "imported": 0,
+            "skipped": 0,
+            "errors": 0,
+            "deleted": 0,
+        }
         error_samples: List[Dict[str, Any]] = []
         error_signature_counts: Dict[str, int] = {}
 
@@ -353,6 +367,15 @@ class BridgeResourceImporter:
         for record in records:
             stats["processed"] += 1
             try:
+                raw_rid = extract_record_id(record)
+                if self._is_deleted_record(record):
+                    if not raw_rid:
+                        stats["skipped"] += 1
+                        continue
+                    await _flush()
+                    stats["deleted"] += await self.repo.delete_missing_resources([str(raw_rid)])
+                    continue
+
                 normalized = self._normalize_record(record)
                 rid = normalized.get("id")
                 if not rid:

--- a/backend/app/services/bridge_sync/search_index.py
+++ b/backend/app/services/bridge_sync/search_index.py
@@ -80,7 +80,7 @@ async def _index_changed_resource_batch(
         if not row:
             missing += 1
             try:
-                await es.delete(index=index_name, id=resource_id, ignore_status=[404])
+                await es.options(ignore_status=[404]).delete(index=index_name, id=resource_id)
             except Exception as exc:
                 errors += 1
                 logger.warning(

--- a/backend/tests/services/test_bridge_search_index.py
+++ b/backend/tests/services/test_bridge_search_index.py
@@ -32,12 +32,17 @@ class FakeElasticsearch:
         self.indexed = []
         self.deleted = []
         self.indices = FakeIndices()
+        self.options_kwargs = {}
+
+    def options(self, **kwargs):
+        self.options_kwargs = kwargs
+        return self
 
     async def index(self, *, index, id, document):
         self.indexed.append({"index": index, "id": id, "document": document})
 
-    async def delete(self, *, index, id, ignore_status):
-        self.deleted.append({"index": index, "id": id, "ignore_status": ignore_status})
+    async def delete(self, *, index, id):
+        self.deleted.append({"index": index, "id": id, "options": self.options_kwargs})
 
 
 @pytest.mark.asyncio
@@ -77,6 +82,39 @@ async def test_index_changed_resources_indexes_every_changed_id_even_if_legacy_l
         "resource-2",
     ]
     assert fake_database.fetch_calls == 3
+    assert fake_es.indices.refreshed == ["btaa_geospatial_api"]
+
+
+@pytest.mark.asyncio
+async def test_index_changed_resources_deletes_missing_ids(monkeypatch):
+    fake_database = FakeDatabase([])
+    fake_es = FakeElasticsearch()
+
+    monkeypatch.setenv("BRIDGE_SEARCH_INDEX_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("BRIDGE_SEARCH_INDEX_MAX_RESOURCE_IDS", "5000")
+    monkeypatch.setenv("ELASTICSEARCH_INDEX", "btaa_geospatial_api")
+    monkeypatch.setattr(search_index, "database", fake_database)
+    monkeypatch.setattr(search_index, "es", fake_es)
+    monkeypatch.setattr(search_index, "process_resource", AsyncMock())
+
+    stats = await search_index.index_changed_resources(["missing-resource"])
+
+    assert stats == {
+        "enabled": True,
+        "resource_ids": 1,
+        "batch_size": 5000,
+        "batches": 1,
+        "indexed": 0,
+        "missing": 1,
+        "errors": 0,
+    }
+    assert fake_es.deleted == [
+        {
+            "index": "btaa_geospatial_api",
+            "id": "missing-resource",
+            "options": {"ignore_status": [404]},
+        }
+    ]
     assert fake_es.indices.refreshed == ["btaa_geospatial_api"]
 
 

--- a/backend/tests/services/test_bridge_sync_service.py
+++ b/backend/tests/services/test_bridge_sync_service.py
@@ -1711,6 +1711,115 @@ class TestBridgeSyncService:
                 pass
 
     @pytest.mark.asyncio(scope="session")
+    async def test_sync_bridge_changed_since_deletes_tombstone_record(self):
+        repo = BridgeSyncRepository()
+        importer = BridgeResourceImporter(repo=repo)
+        resource_id = "bridge-sync-delta-tombstone"
+
+        if not database.is_connected:
+            await database.connect()
+
+        try:
+            await database.execute(delete(bridge_sync_runs))
+            await database.execute(
+                delete(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id == resource_id
+                )
+            )
+            await database.execute(delete(resources).where(resources.c.id == resource_id))
+            await database.execute(
+                pg_insert(resources).values(
+                    {
+                        "id": resource_id,
+                        "dct_title_s": "Bridge Sync Delta Tombstone",
+                        "publication_state": "published",
+                        "b1g_publication_state_s": "published",
+                        "import_id": "390",
+                    }
+                )
+            )
+            await database.execute(
+                pg_insert(bridge_resource_state).values(
+                    {
+                        "bridge_resource_id": resource_id,
+                        "bridge_source_import_id": "390",
+                    }
+                )
+            )
+
+            client = FakeBridgeClient(
+                {
+                    "__first__": BridgePage(
+                        data=[
+                            {
+                                "id": resource_id,
+                                "import_id": "390",
+                                "publication_state": "published",
+                                "dct_title_s": "Bridge Sync Delta Tombstone",
+                                "deleted": True,
+                                "deleted_at": "2026-06-17T08:25:32.923-05:00",
+                                "kithe_updated_at": "2026-06-17T08:25:32.923-05:00",
+                            }
+                        ],
+                        next_cursor=None,
+                        has_more=False,
+                    )
+                }
+            )
+
+            result = await sync_bridge(
+                trigger="nightly_cron",
+                limit=500,
+                changed_since="2026-06-16T05:00:00Z",
+                client=client,
+                importer=importer,
+                repo=repo,
+            )
+
+            assert client.calls == [
+                {
+                    "cursor": None,
+                    "limit": 500,
+                    "changed_since": "2026-06-16T05:00:00Z",
+                }
+            ]
+            assert result["stats"]["processed"] == 1
+            assert result["stats"]["imported"] == 0
+            assert result["stats"]["missing"] == 0
+            assert result["stats"]["deleted"] == 1
+            assert result["stats"]["retired"] == 0
+            assert result["stats"]["search_index_refresh"]["enabled"] is False
+            assert result["stats"]["cache_refresh"]["enabled"] is False
+
+            row = await database.fetch_one(
+                select(resources.c.id).where(resources.c.id == resource_id)
+            )
+            state = await database.fetch_one(
+                select(bridge_resource_state).where(
+                    bridge_resource_state.c.bridge_resource_id == resource_id
+                )
+            )
+            run = await repo.get_sync_run(result["bridge_id"])
+
+            assert row is None
+            assert state is None
+            assert run is not None
+            assert run["bridge_status"] == "success"
+            assert run["bridge_stats_json"]["deleted"] == 1
+        finally:
+            try:
+                await database.execute(
+                    delete(bridge_resource_state).where(
+                        bridge_resource_state.c.bridge_resource_id == resource_id
+                    )
+                )
+                await database.execute(delete(bridge_sync_runs))
+                await database.execute(delete(resources).where(resources.c.id == resource_id))
+            except Exception:
+                # Cleanup is best effort; test assertions should report the real failure.
+                pass
+
+    @pytest.mark.asyncio(scope="session")
     async def test_sync_bridge_resource_id_stops_on_match_without_retiring_others(self):
         repo = BridgeSyncRepository()
         importer = BridgeResourceImporter(repo=repo)


### PR DESCRIPTION
## Summary

- Treat Bridge records with a truthy `deleted` flag as tombstones and delete their local resource/state rows instead of reimporting them.
- Preserve `deleted` counts while merging importer, batch, and full-sync stats.
- Delete missing resources from Elasticsearch refreshes using the current client `options(ignore_status=[404])` API.
- Add focused coverage for tombstone deletes and search-index deletion of missing IDs.

## Impact

Bridge delta syncs can now remove resources that arrive as deleted records, and sync run stats report those deletes correctly. Search refreshes also clean stale Elasticsearch documents for missing resources without relying on the deprecated delete-call signature.

## Validation

- `python -m pytest backend/tests/services/test_bridge_search_index.py::test_index_changed_resources_deletes_missing_ids backend/tests/services/test_bridge_sync_service.py::TestBridgeSyncService::test_sync_bridge_changed_since_deletes_tombstone_record`
- `make lint-check`