### PR TITLE
Adjust response handling and file checks

### DIFF
--- a/backend/app/api/ogc/endpoints.py
+++ b/backend/app/api/ogc/endpoints.py
@@ -15,6 +15,7 @@ from app.api.schemas import (
     OGCSortablesResponse,
 )
 from app.api.v1.shared import SortOption
+from app.api.v1.utils import sanitize_for_json
 from app.services.ogc_projector import OGCResponseProjector
 from app.services.search_service import SearchService
 
@@ -150,7 +151,9 @@ async def get_items(
         logger.error("OGC search request failed in search service")
         raise HTTPException(status_code=503, detail="Elasticsearch search failed")
 
-    return OGCResponseProjector.build_items_response(url, results, page, limit, "btaa-records")
+    return sanitize_for_json(
+        OGCResponseProjector.build_items_response(url, results, page, limit, "btaa-records")
+    )
 
 
 @router.get(

--- a/backend/app/api/v1/endpoint_modules/admin.py
+++ b/backend/app/api/v1/endpoint_modules/admin.py
@@ -1,6 +1,7 @@
-import html as _html
+import html
 import ipaddress
 import logging
+import os
 from pathlib import Path
 from typing import List, Optional
 
@@ -68,6 +69,54 @@ _admin_service_dependency = Depends(get_admin_service)
 api_key_service = APIKeyService()
 ogm_repo = OGMHarvestRepository()
 bridge_repo = BridgeSyncRepository()
+
+_OGM_DUMP_BASE_DIR_ENV = "OGM_DUMP_BASE_DIR"
+_OGM_DUMP_DEFAULT_BASE_DIR = "data/harvest_dumps/ogm"
+
+
+def _ogm_dump_base_dir() -> Path:
+    return Path(os.getenv(_OGM_DUMP_BASE_DIR_ENV, _OGM_DUMP_DEFAULT_BASE_DIR)).resolve()
+
+
+def _resolve_ogm_dump_dir(raw_dump_dir: str | Path, run_id: int) -> Path:
+    try:
+        base_dir = _ogm_dump_base_dir()
+        dump_dir = Path(raw_dump_dir).resolve()
+        dump_dir.relative_to(base_dir)
+    except (OSError, RuntimeError, ValueError):
+        raise HTTPException(status_code=404, detail="Dump not found for run") from None
+    if dump_dir.name != str(run_id):
+        raise HTTPException(status_code=404, detail="Dump not found for run")
+    return dump_dir
+
+
+def _ogm_dump_filename(filename: str) -> str:
+    try:
+        safe_filename = require_safe_filename(filename)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid filename") from exc
+
+    if safe_filename == "dataset.ndjson":
+        return "dataset.ndjson"
+    if safe_filename == "dataset.json":
+        return "dataset.json"
+    if safe_filename == "dataset.parquet":
+        return "dataset.parquet"
+    if safe_filename == "manifest.json":
+        return "manifest.json"
+    raise HTTPException(status_code=404, detail="File not found")
+
+
+def _resolve_ogm_dump_file(raw_dump_dir: str | Path, run_id: int, filename: str) -> Path:
+    dump_dir = _resolve_ogm_dump_dir(raw_dump_dir, run_id)
+    safe_filename = _ogm_dump_filename(filename)
+
+    try:
+        candidate = (dump_dir / safe_filename).resolve()
+        candidate.relative_to(dump_dir)
+    except (OSError, RuntimeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid filename") from None
+    return candidate
 
 
 # Pydantic models for request/response
@@ -781,26 +830,32 @@ async def ogm_harvest_status(
             "<td>{errs}</td>"
             "<td><small>{err}</small></td>"
             "</tr>".format(
-                cls=_html.escape(css_class),
-                name=_html.escape(name),
-                enabled=_html.escape(enabled_txt),
-                mode=_html.escape(watch_mode or "-"),
-                status=_html.escape(run_status),
-                stage=_html.escape(str(stage)),
-                run_id=_html.escape(str(run_id) if run_id is not None else "-"),
-                dur=_html.escape(dur),
-                upd=_html.escape((_age(upd_dt) + " ago") if upd_dt else "-"),
-                imp=_html.escape(str(imported) if imported is not None else "-"),
-                errs=_html.escape(str(errors) if errors is not None else "-"),
-                err=_html.escape(err_short) if err_short else "",
+                cls=html.escape(css_class),
+                name=html.escape(name),
+                enabled=html.escape(enabled_txt),
+                mode=html.escape(watch_mode or "-"),
+                status=html.escape(run_status),
+                stage=html.escape(str(stage)),
+                run_id=html.escape(str(run_id) if run_id is not None else "-"),
+                dur=html.escape(dur),
+                upd=html.escape((_age(upd_dt) + " ago") if upd_dt else "-"),
+                imp=html.escape(str(imported) if imported is not None else "-"),
+                errs=html.escape(str(errors) if errors is not None else "-"),
+                err=html.escape(err_short) if err_short else "",
             )
         )
 
     counts_html = (
-        f"<div><strong>Counts (last {runs_limit} runs)</strong>: "
-        f"running={counts['running']}, success={counts['success']}, "
-        f"failed={counts['failed']}, other={counts['other']}</div>"
+        "<div><strong>Counts (last {runs_limit} runs)</strong>: "
+        "running={running}, success={success}, failed={failed}, other={other}</div>"
+    ).format(
+        runs_limit=html.escape(str(runs_limit)),
+        running=html.escape(str(counts["running"])),
+        success=html.escape(str(counts["success"])),
+        failed=html.escape(str(counts["failed"])),
+        other=html.escape(str(counts["other"])),
     )
+    rows_table_html = "\n".join(rows_html)
 
     html_body = f"""
 <!doctype html>
@@ -850,7 +905,7 @@ async def ogm_harvest_status(
       </tr>
     </thead>
     <tbody>
-      {"".join(rows_html)}
+      {rows_table_html}
     </tbody>
   </table>
 </body>
@@ -874,8 +929,7 @@ async def get_ogm_dump_manifest(run_id: int):
     run = await ogm_repo.get_harvest_run(run_id)
     if not run or not run.get("ogm_dump_dir"):
         raise HTTPException(status_code=404, detail="Dump not found for run")
-    dump_dir = Path(run["ogm_dump_dir"])
-    manifest_path = dump_dir / "manifest.json"
+    manifest_path = _resolve_ogm_dump_file(run["ogm_dump_dir"], run_id, "manifest.json")
     if not manifest_path.exists():
         raise HTTPException(status_code=404, detail="manifest.json not found")
     return FileResponse(str(manifest_path), media_type="application/json")
@@ -887,17 +941,8 @@ async def download_ogm_dump_file(run_id: int, filename: str):
     if not run or not run.get("ogm_dump_dir"):
         raise HTTPException(status_code=404, detail="Dump not found for run")
 
-    try:
-        safe_filename = require_safe_filename(filename)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail="Invalid filename") from exc
-
-    dump_dir = Path(run["ogm_dump_dir"])
-    resolved_dump_dir = dump_dir.resolve()
-    # Prevent path traversal
-    candidate = (resolved_dump_dir / safe_filename).resolve()
-    if resolved_dump_dir not in candidate.parents:
-        raise HTTPException(status_code=400, detail="Invalid filename")
+    candidate = _resolve_ogm_dump_file(run["ogm_dump_dir"], run_id, filename)
+    safe_filename = candidate.name
 
     if not candidate.exists() or not candidate.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/backend/app/api/v1/endpoint_modules/mcp.py
+++ b/backend/app/api/v1/endpoint_modules/mcp.py
@@ -5,6 +5,7 @@ from fastapi.responses import JSONResponse, Response
 
 from app.api.errors import PUBLIC_ERROR_RESPONSES
 from app.api.schemas import JSONRPCResponse, MCPInfoResponse
+from app.api.v1.utils import sanitize_for_json
 from app.services.mcp_service import get_mcp_service_info, handle_mcp_message
 
 logger = logging.getLogger(__name__)
@@ -14,7 +15,7 @@ router = APIRouter()
 @router.get("/mcp", response_model=MCPInfoResponse, responses=PUBLIC_ERROR_RESPONSES)
 async def mcp_endpoint():
     """Return MCP service information and connection details."""
-    return JSONResponse(content=get_mcp_service_info())
+    return JSONResponse(content=sanitize_for_json(get_mcp_service_info()))
 
 
 @router.post("/mcp", response_model=JSONRPCResponse, responses=PUBLIC_ERROR_RESPONSES)
@@ -35,7 +36,7 @@ async def mcp_http_transport(request: Request):
     if response is None:
         return Response(status_code=204)
 
-    return JSONResponse(content=response)
+    return JSONResponse(content=sanitize_for_json(response))
 
 
 @router.websocket("/mcp/ws")

--- a/backend/app/api/v1/endpoint_modules/slack.py
+++ b/backend/app/api/v1/endpoint_modules/slack.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from app.api.v1.utils import sanitize_for_json
 from app.services.slackbot_service import handle_slack_command, verify_slack_signature
 
 router = APIRouter()
@@ -39,4 +40,4 @@ async def slack_command(request: Request):
 
     form_data = parse_qs(body.decode("utf-8"), keep_blank_values=True)
     response = await handle_slack_command(form_data)
-    return JSONResponse(content=response)
+    return JSONResponse(content=sanitize_for_json(response))

--- a/backend/app/api/v1/utils.py
+++ b/backend/app/api/v1/utils.py
@@ -44,6 +44,8 @@ def sanitize_for_json(obj: Any) -> Any:
         return obj.isoformat()
     elif hasattr(obj, "isoformat"):  # Handle other objects with isoformat (fallback)
         return obj.isoformat()
+    elif isinstance(obj, BaseException):
+        return "Internal error"
     elif hasattr(obj, "__dict__"):  # Handle objects with __dict__
         return sanitize_for_json(obj.__dict__)
     elif isinstance(obj, bool):  # Handle boolean objects (before float conversion)

--- a/backend/app/services/mcp_service.py
+++ b/backend/app/services/mcp_service.py
@@ -90,6 +90,19 @@ def _api_response_error_type(payload: dict[str, Any]) -> str:
     return "http"
 
 
+def _jsonrpc_error_response(
+    msg_id: Any,
+    *,
+    code: int = -32603,
+    message: str = "Internal error",
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": code, "message": message},
+    }
+
+
 class OGMMCPService:
     """MCP service for GeoBTAA API endpoints."""
 
@@ -394,7 +407,8 @@ class OGMMCPService:
             except Exception as e:
                 logger.error(f"Error in tool {name}: {str(e)}", exc_info=True)
                 return CallToolResult(
-                    content=[TextContent(type="text", text=f"Error: {str(e)}")], isError=True
+                    content=[TextContent(type="text", text="Error: Tool request failed")],
+                    isError=True,
                 )
 
         logger.info("MCP tools registered successfully")
@@ -449,7 +463,6 @@ class OGMMCPService:
                 {
                     "error": "Search request failed",
                     "error_type": _api_request_error_type(e),
-                    "detail": str(e),
                     "query": query,
                     "page": page,
                     "per_page": per_page,
@@ -1030,15 +1043,9 @@ async def run_mcp_websocket_server(websocket):
                         {"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}}
                     )
                 )
-            except Exception as e:
-                await websocket.send_text(
-                    json.dumps(
-                        {
-                            "jsonrpc": "2.0",
-                            "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
-                        }
-                    )
-                )
+            except Exception:
+                logger.error("Error handling MCP WebSocket message", exc_info=True)
+                await websocket.send_text(json.dumps(_jsonrpc_error_response(None)))
     except Exception as e:
         logging.error(f"WebSocket error: {e}")
 
@@ -1133,12 +1140,9 @@ async def handle_mcp_message(data: Dict[str, Any]) -> Dict[str, Any] | None:
                 },
             }
 
-        except Exception as e:
-            return {
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
-            }
+        except Exception:
+            logger.error("Error handling MCP tool call", exc_info=True)
+            return _jsonrpc_error_response(msg_id)
 
     else:
         return {

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -32,6 +32,15 @@ from app.services.viewer_service import ViewerService
 from db.database import database
 
 logger = logging.getLogger(__name__)
+_SEARCH_ERROR_CODE = "search_request_failed"
+
+
+def _search_error_payload(error: object) -> Dict[str, str]:
+    return {
+        "message": "Search operation failed",
+        "error": _SEARCH_ERROR_CODE,
+        "error_type": _search_error_type(error),
+    }
 
 
 def _search_error_text(error: object) -> str:
@@ -196,8 +205,7 @@ class SearchService:
             if not isinstance(results, dict):
                 results = {}
             if "error" in results:
-                results.setdefault("message", "Search operation failed")
-                results.setdefault("error_type", _search_error_type(results))
+                results.update(_search_error_payload(results))
 
             total_time = time.time() - start_time
             query_timings = results.get("queryTime", {})
@@ -229,14 +237,7 @@ class SearchService:
 
         except Exception as e:
             logger.error("Search service error", exc_info=True)
-            return {
-                "message": "Search operation failed",
-                "error": str(e),
-                "error_type": _search_error_type(e),
-                "query": q,
-                "filters": filter_query if "filter_query" in locals() else None,
-                "sort": sort,
-            }
+            return _search_error_payload(e)
 
     async def get_resource(
         self,

--- a/backend/tests/api/v1/test_endpoint_modules_admin.py
+++ b/backend/tests/api/v1/test_endpoint_modules_admin.py
@@ -5,11 +5,13 @@ Tests for the admin endpoint module (app.api.v1.endpoint_modules.admin).
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from app.api.v1.endpoint_modules.admin import (
     clear_cache,
+    download_ogm_dump_file,
+    get_ogm_dump_manifest,
     identify_geo_entities,
     reindex,
     router,
@@ -131,6 +133,77 @@ class TestClearCacheEndpoint:
         assert result.status_code == 500
         data = json.loads(result.body)
         assert "error" in data
+
+
+class TestOGMDumpEndpoints:
+    @pytest.mark.asyncio
+    async def test_get_ogm_dump_manifest_serves_file_under_configured_base(
+        self, monkeypatch, tmp_path
+    ):
+        from app.api.v1.endpoint_modules import admin as admin_module
+
+        base_dir = tmp_path / "harvest_dumps" / "ogm"
+        dump_dir = base_dir / "repo" / "2026-06-18" / "123"
+        dump_dir.mkdir(parents=True)
+        manifest_path = dump_dir / "manifest.json"
+        manifest_path.write_text("{}", encoding="utf-8")
+
+        monkeypatch.setenv("OGM_DUMP_BASE_DIR", str(base_dir))
+        monkeypatch.setattr(
+            admin_module.ogm_repo,
+            "get_harvest_run",
+            AsyncMock(return_value={"ogm_dump_dir": str(dump_dir)}),
+        )
+
+        response = await get_ogm_dump_manifest(123)
+
+        assert response.path == str(manifest_path)
+        assert response.media_type == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_get_ogm_dump_manifest_rejects_file_outside_configured_base(
+        self, monkeypatch, tmp_path
+    ):
+        from app.api.v1.endpoint_modules import admin as admin_module
+
+        base_dir = tmp_path / "harvest_dumps" / "ogm"
+        outside_dir = tmp_path / "elsewhere" / "repo" / "2026-06-18" / "123"
+        outside_dir.mkdir(parents=True)
+        (outside_dir / "manifest.json").write_text("{}", encoding="utf-8")
+
+        monkeypatch.setenv("OGM_DUMP_BASE_DIR", str(base_dir))
+        monkeypatch.setattr(
+            admin_module.ogm_repo,
+            "get_harvest_run",
+            AsyncMock(return_value={"ogm_dump_dir": str(outside_dir)}),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await get_ogm_dump_manifest(123)
+
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_download_ogm_dump_file_requires_expected_artifact_name(
+        self, monkeypatch, tmp_path
+    ):
+        from app.api.v1.endpoint_modules import admin as admin_module
+
+        base_dir = tmp_path / "harvest_dumps" / "ogm"
+        dump_dir = base_dir / "repo" / "2026-06-18" / "123"
+        dump_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("OGM_DUMP_BASE_DIR", str(base_dir))
+        monkeypatch.setattr(
+            admin_module.ogm_repo,
+            "get_harvest_run",
+            AsyncMock(return_value={"ogm_dump_dir": str(dump_dir)}),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await download_ogm_dump_file(123, "notes.txt")
+
+        assert exc.value.status_code == 404
 
 
 class TestReindexEndpoint:

--- a/backend/tests/api/v1/test_endpoint_modules_resources_production.py
+++ b/backend/tests/api/v1/test_endpoint_modules_resources_production.py
@@ -41,8 +41,8 @@ class TestResourcesProductionDatabase:
 
         if response.status_code == 404:
             data = response.json()
-            assert "error" in data
-            assert "not found" in data["error"].lower()
+            message = data.get("error") or data.get("detail", "")
+            assert "not found" in message.lower()
 
     def test_get_resource_ogm_with_real_database(self):
         """Test get resource OGM with real database connection."""

--- a/backend/tests/api/v1/test_mcp_endpoints.py
+++ b/backend/tests/api/v1/test_mcp_endpoints.py
@@ -197,6 +197,34 @@ class TestMCPEndpoints:
         assert "tools" in data["result"]
         assert len(data["result"]["tools"]) > 0
 
+    def test_mcp_http_transport_tool_error_uses_generic_message(self, monkeypatch):
+        """Tool handler exceptions should keep response details stable."""
+        from app.services import mcp_service as mcp_service_module
+
+        async def failing_handler(_arguments):
+            raise RuntimeError("internal traceback detail")
+
+        monkeypatch.setitem(
+            mcp_service_module.mcp_service.tool_handlers,
+            "search_resources",
+            failing_handler,
+        )
+
+        response = client.post(
+            "/api/v1/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "search_resources", "arguments": {}},
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["error"]["message"] == "Internal error"
+        assert "internal traceback detail" not in response.text
+
     def test_mcp_http_transport_initialized_notification(self):
         """Test that initialized notifications do not generate a JSON-RPC reply."""
         response = client.post(

--- a/backend/tests/api/v1/test_utils.py
+++ b/backend/tests/api/v1/test_utils.py
@@ -69,6 +69,11 @@ class TestSanitizeForJson:
         result = sanitize_for_json(obj)
         assert result == {"name": "test", "value": 123}
 
+    def test_sanitize_for_json_exception(self):
+        """Exception objects should not expose their internal attributes."""
+        result = sanitize_for_json(RuntimeError("connection failed at internal/path.py:42"))
+        assert result == "Internal error"
+
     def test_sanitize_for_json_nested_structures(self):
         """Test sanitizing nested structures with various types."""
         data = {

--- a/backend/tests/integration/test_mkdocs_interactive_examples.py
+++ b/backend/tests/integration/test_mkdocs_interactive_examples.py
@@ -190,6 +190,16 @@ def _visible_text_from_html(html: str) -> str:
     return " ".join(parser.parts)
 
 
+def _visible_url_hosts(text: str) -> set[str]:
+    hosts = set()
+    for token in text.split():
+        candidate = token.strip(".,;:!?)('\"[]{}")
+        parsed = urlsplit(candidate)
+        if parsed.scheme in {"http", "https"} and parsed.hostname:
+            hosts.add(parsed.hostname)
+    return hosts
+
+
 def _is_frontend_turnstile_gate(response: requests.Response) -> bool:
     content_type = (response.headers.get("Content-Type") or "").lower()
     if "text/html" not in content_type:
@@ -506,5 +516,5 @@ def test_resource_page_hides_display_note_style_prefixes():
 
     visible_text = _visible_text_from_html(response.text)
     assert DISPLAY_NOTE_PREFIX_REGRESSION_BODY in visible_text
-    assert "https://opendata.minneapolismn.gov" in visible_text
+    assert any(host == "opendata.minneapolismn.gov" for host in _visible_url_hosts(visible_text))
     assert f"Warning: {DISPLAY_NOTE_PREFIX_REGRESSION_BODY}" not in visible_text

--- a/backend/tests/services/test_mcp_service.py
+++ b/backend/tests/services/test_mcp_service.py
@@ -143,7 +143,8 @@ class TestOGMMCPService:
         payload = json.loads(result.content[0].text)
         assert payload["error"] == "Search request failed"
         assert payload["error_type"] == "connection"
-        assert payload["detail"] == "connection refused"
+        assert "detail" not in payload
+        assert "connection refused" not in result.content[0].text
         assert payload["query"] == "palestine"
         assert payload["page"] == 3
         assert payload["source"]["transport"] == "http"

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -182,7 +182,7 @@ class TestSearchService:
             assert "error" in result
             assert result["message"] == "Search operation failed"
             assert result["error_type"] == "elasticsearch"
-            assert "Elasticsearch error" in result["error"]
+            assert result["error"] == "search_request_failed"
 
     @pytest.mark.asyncio
     async def test_search_classifies_returned_dependency_errors(self):

--- a/backend/tests/services/test_sitemap_service.py
+++ b/backend/tests/services/test_sitemap_service.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from urllib.parse import urlsplit
 from xml.etree import ElementTree as ET
 
 import pytest_asyncio
@@ -124,17 +125,22 @@ def test_build_sitemap_documents_renders_single_urlset():
 
     urls = root.findall("sm:url", NS)
     locs = [url.findtext("sm:loc", namespaces=NS) for url in urls]
+    locs_by_path = {urlsplit(loc or "").path: urlsplit(loc or "") for loc in locs}
 
-    assert "https://geo.example.org/" in locs
-    assert "https://geo.example.org/search" in locs
-    assert "https://geo.example.org/map" in locs
-    assert "https://geo.example.org/resources/ark:-77981-gmgs8p5v86m" in locs
+    assert locs_by_path["/"].scheme == "https"
+    assert locs_by_path["/"].netloc == "geo.example.org"
+    assert locs_by_path["/search"].scheme == "https"
+    assert locs_by_path["/search"].netloc == "geo.example.org"
+    assert locs_by_path["/map"].scheme == "https"
+    assert locs_by_path["/map"].netloc == "geo.example.org"
+    assert locs_by_path["/resources/ark:-77981-gmgs8p5v86m"].scheme == "https"
+    assert locs_by_path["/resources/ark:-77981-gmgs8p5v86m"].netloc == "geo.example.org"
 
     resource_url = next(
         url
         for url in urls
-        if url.findtext("sm:loc", namespaces=NS)
-        == "https://geo.example.org/resources/ark:-77981-gmgs8p5v86m"
+        if urlsplit(url.findtext("sm:loc", namespaces=NS) or "").path
+        == "/resources/ark:-77981-gmgs8p5v86m"
     )
     assert resource_url.findtext("sm:lastmod", namespaces=NS) == "2026-04-08"
 


### PR DESCRIPTION
## Summary
- Normalize API error payloads across search, MCP, Slack, and OGC response paths.
- Constrain OGM dump artifact downloads to the configured dump directory and expected generated filenames.
- Update URL assertions to compare parsed hosts and paths instead of broad string matches.

## Validation
- `uv run --extra dev pytest tests/api/v1/test_utils.py tests/api/v1/test_endpoint_modules_admin.py tests/api/v1/test_mcp_endpoints.py tests/services/test_search_service.py tests/services/test_sitemap_service.py tests/integration/test_mkdocs_interactive_examples.py -q`
- `uv run --extra dev ruff check app/api/v1/utils.py app/api/v1/endpoint_modules/slack.py app/api/v1/endpoint_modules/mcp.py app/api/v1/endpoint_modules/admin.py app/api/ogc/endpoints.py app/services/search_service.py app/services/mcp_service.py tests/api/v1/test_utils.py tests/api/v1/test_endpoint_modules_admin.py tests/api/v1/test_mcp_endpoints.py tests/services/test_search_service.py tests/services/test_sitemap_service.py tests/integration/test_mkdocs_interactive_examples.py`
- `uv run --extra dev ruff format --check app/api/v1/utils.py app/api/v1/endpoint_modules/slack.py app/api/v1/endpoint_modules/mcp.py app/api/v1/endpoint_modules/admin.py app/api/ogc/endpoints.py app/services/search_service.py app/services/mcp_service.py tests/api/v1/test_utils.py tests/api/v1/test_endpoint_modules_admin.py tests/api/v1/test_mcp_endpoints.py tests/services/test_search_service.py tests/services/test_sitemap_service.py tests/integration/test_mkdocs_interactive_examples.py`