### PR TITLE
Track citation GTM events

### DIFF
--- a/frontend/src/__tests__/components/resource/CitationTable.test.tsx
+++ b/frontend/src/__tests__/components/resource/CitationTable.test.tsx
@@ -1,29 +1,44 @@
-import React from 'react';
-import { vi } from 'vitest';
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-} from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import {
   CitationTable,
   type CitationStyle,
 } from '../../../components/resource/CitationTable';
+import { pushDataLayerEvent } from '../../../services/analytics';
 
 vi.mock('../../../services/analytics', () => ({
+  pushDataLayerEvent: vi.fn(),
   scheduleAnalyticsBatch: vi.fn(),
 }));
 
-const renderWithRouter = (ui: React.ReactElement) =>
+const renderWithRouter = (ui: ReactElement) =>
   render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const clickWithoutNavigation = (element: HTMLElement) => {
+  const clickEvent = new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+  });
+  clickEvent.preventDefault();
+  fireEvent(element, clickEvent);
+};
 
 describe('CitationTable', () => {
   const defaultProps = {
     citation: 'Author. (2023). Test Title. Publisher. https://example.com',
     permalink: 'https://geoportal.example.org/resources/123',
   };
+  const trackableProps = {
+    ...defaultProps,
+    resourceId: 'test-resource-123',
+    resourceTitle: 'Test Title',
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
 
   it('renders without crashing', () => {
     renderWithRouter(<CitationTable {...defaultProps} />);
@@ -45,18 +60,14 @@ describe('CitationTable', () => {
     renderWithRouter(
       <CitationTable {...defaultProps} resourceId="test-resource-456" />
     );
-    expect(
-      screen.getByText('Export for citation tools')
-    ).toBeInTheDocument();
+    expect(screen.getByText('Export for citation tools')).toBeInTheDocument();
     expect(screen.getByText('RIS')).toBeInTheDocument();
     expect(screen.getByText('BibTeX')).toBeInTheDocument();
     expect(screen.getByText('JSON-LD')).toBeInTheDocument();
   });
 
   it('Export RIS link has correct href', () => {
-    renderWithRouter(
-      <CitationTable {...defaultProps} resourceId="abc-123" />
-    );
+    renderWithRouter(<CitationTable {...defaultProps} resourceId="abc-123" />);
     const risLink = screen.getByRole('link', { name: /RIS/i });
     expect(risLink).toHaveAttribute(
       'href',
@@ -66,9 +77,7 @@ describe('CitationTable', () => {
   });
 
   it('Export BibTeX link has correct href', () => {
-    renderWithRouter(
-      <CitationTable {...defaultProps} resourceId="xyz-789" />
-    );
+    renderWithRouter(<CitationTable {...defaultProps} resourceId="xyz-789" />);
     const bibLink = screen.getByRole('link', { name: /BibTeX/i });
     expect(bibLink).toHaveAttribute(
       'href',
@@ -152,6 +161,31 @@ describe('CitationTable', () => {
     });
   });
 
+  it('does not push citation dataLayer events on render', () => {
+    renderWithRouter(<CitationTable {...trackableProps} />);
+
+    expect(pushDataLayerEvent).not.toHaveBeenCalled();
+  });
+
+  it('pushes cite_copy to the dataLayer when citation copy is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    renderWithRouter(<CitationTable {...trackableProps} />);
+    fireEvent.click(screen.getByTitle('Copy citation'));
+
+    await waitFor(() => {
+      expect(pushDataLayerEvent).toHaveBeenCalledWith('cite_copy', {
+        resource_id: trackableProps.resourceId,
+        resource_title: trackableProps.resourceTitle,
+      });
+    });
+  });
+
   it('copies permalink to clipboard when permalink Copy clicked', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {
@@ -166,6 +200,41 @@ describe('CitationTable', () => {
 
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(defaultProps.permalink);
+    });
+  });
+
+  it('pushes cite_url to the dataLayer when permalink copy is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    renderWithRouter(<CitationTable {...trackableProps} />);
+    fireEvent.click(screen.getByTitle('Copy permalink'));
+
+    await waitFor(() => {
+      expect(pushDataLayerEvent).toHaveBeenCalledWith('cite_url', {
+        resource_id: trackableProps.resourceId,
+        resource_title: trackableProps.resourceTitle,
+      });
+    });
+  });
+
+  it.each([
+    ['RIS', 'RIS'],
+    ['BibTeX', 'BibTeX'],
+    ['JSON-LD', 'JSON-LD'],
+  ])('pushes cite_export for %s exports', (linkName, format) => {
+    renderWithRouter(<CitationTable {...trackableProps} />);
+
+    clickWithoutNavigation(screen.getByRole('link', { name: linkName }));
+
+    expect(pushDataLayerEvent).toHaveBeenCalledWith('cite_export', {
+      resource_id: trackableProps.resourceId,
+      resource_title: trackableProps.resourceTitle,
+      format,
     });
   });
 

--- a/frontend/src/__tests__/services/analytics.test.ts
+++ b/frontend/src/__tests__/services/analytics.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../services/api', () => ({
 }));
 
 import {
+  pushDataLayerEvent,
   sendAnalyticsBatch,
   serializeSearchParams,
 } from '../../services/analytics';
@@ -86,5 +87,25 @@ describe('analytics service', () => {
         }),
       })
     );
+  });
+
+  it('pushes custom events to the Google Tag Manager dataLayer', () => {
+    window.dataLayer = undefined;
+
+    const pushed = pushDataLayerEvent('cite_export', {
+      resource_id: 'abc-123',
+      resource_title: 'Test Resource',
+      format: 'RIS',
+    });
+
+    expect(pushed).toBe(true);
+    expect(window.dataLayer).toEqual([
+      {
+        event: 'cite_export',
+        resource_id: 'abc-123',
+        resource_title: 'Test Resource',
+        format: 'RIS',
+      },
+    ]);
   });
 });

--- a/frontend/src/components/resource/CitationTable.tsx
+++ b/frontend/src/components/resource/CitationTable.tsx
@@ -1,8 +1,13 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Copy, Check, Download } from 'lucide-react';
-import { scheduleAnalyticsBatch } from '../../services/analytics';
+import {
+  pushDataLayerEvent,
+  scheduleAnalyticsBatch,
+} from '../../services/analytics';
 
 export type CitationStyle = 'apa' | 'mla' | 'chicago';
+type CitationDataLayerEvent = 'cite_copy' | 'cite_export' | 'cite_url';
+type CitationExportFormat = 'RIS' | 'BibTeX' | 'JSON-LD';
 
 interface CitationTableProps {
   /** Primary/default citation (APA format) - for backward compatibility */
@@ -12,6 +17,7 @@ interface CitationTableProps {
   permalink: string;
   /** Resource ID for export links (JSON-LD, RIS, BibTeX) */
   resourceId?: string;
+  resourceTitle?: string;
   searchId?: string;
 }
 
@@ -33,6 +39,7 @@ export function CitationTable({
   citations,
   permalink,
   resourceId,
+  resourceTitle,
   searchId,
 }: CitationTableProps) {
   const [copiedPermalink, setCopiedPermalink] = useState(false);
@@ -46,10 +53,26 @@ export function CitationTable({
     citations && selectedStyle in citations && citations[selectedStyle]
       ? citations[selectedStyle]!
       : citation;
+  const apiBase = getApiBase();
+  const citationDataLayerParams = {
+    resource_id: resourceId,
+    resource_title: resourceTitle,
+  };
+
+  const trackCitationDataLayerEvent = (
+    event: CitationDataLayerEvent,
+    params: Record<string, unknown> = {}
+  ) => {
+    pushDataLayerEvent(event, {
+      ...citationDataLayerParams,
+      ...params,
+    });
+  };
 
   const handleCopyPermalink = async () => {
     try {
       await navigator.clipboard.writeText(permalink);
+      trackCitationDataLayerEvent('cite_url');
       scheduleAnalyticsBatch({
         events: [
           {
@@ -72,6 +95,7 @@ export function CitationTable({
   const handleCopyCitation = async () => {
     try {
       await navigator.clipboard.writeText(displayCitation);
+      trackCitationDataLayerEvent('cite_copy');
       scheduleAnalyticsBatch({
         events: [
           {
@@ -91,6 +115,25 @@ export function CitationTable({
     } catch (err) {
       console.error('Failed to copy citation:', err);
     }
+  };
+
+  const handleCitationExport = (
+    format: CitationExportFormat,
+    destinationUrl: string
+  ) => {
+    trackCitationDataLayerEvent('cite_export', { format });
+    scheduleAnalyticsBatch({
+      events: [
+        {
+          event_type: 'citation_export',
+          search_id: searchId,
+          resource_id: resourceId,
+          label: format,
+          destination_url: destinationUrl,
+          source_component: 'CitationTable',
+        },
+      ],
+    });
   };
 
   return (
@@ -116,7 +159,9 @@ export function CitationTable({
                     <select
                       id="citation-style"
                       value={selectedStyle}
-                      onChange={(e) => setSelectedStyle(e.target.value as CitationStyle)}
+                      onChange={(e) =>
+                        setSelectedStyle(e.target.value as CitationStyle)
+                      }
                       className="text-xs border border-gray-300 rounded px-2 py-1 bg-white"
                     >
                       {styleOptions.map((s) => (
@@ -128,7 +173,9 @@ export function CitationTable({
                   )}
                 </div>
                 <div className="flex gap-2">
-                  <div className="flex-1 text-sm text-gray-900">{displayCitation}</div>
+                  <div className="flex-1 text-sm text-gray-900">
+                    {displayCitation}
+                  </div>
                   <button
                     onClick={handleCopyCitation}
                     className="inline-flex items-center px-3 py-1.5 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
@@ -152,21 +199,13 @@ export function CitationTable({
                 </div>
                 <div className="flex flex-wrap gap-3">
                   <a
-                    href={`${getApiBase()}/resources/${resourceId}/citation/ris`}
+                    href={`${apiBase}/resources/${resourceId}/citation/ris`}
                     download={`${resourceId}.ris`}
                     onClick={() =>
-                      scheduleAnalyticsBatch({
-                        events: [
-                          {
-                            event_type: 'citation_export',
-                            search_id: searchId,
-                            resource_id: resourceId,
-                            label: 'RIS',
-                            destination_url: `${getApiBase()}/resources/${resourceId}/citation/ris`,
-                            source_component: 'CitationTable',
-                          },
-                        ],
-                      })
+                      handleCitationExport(
+                        'RIS',
+                        `${apiBase}/resources/${resourceId}/citation/ris`
+                      )
                     }
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
                   >
@@ -174,21 +213,13 @@ export function CitationTable({
                     RIS
                   </a>
                   <a
-                    href={`${getApiBase()}/resources/${resourceId}/citation/bibtex`}
+                    href={`${apiBase}/resources/${resourceId}/citation/bibtex`}
                     download={`${resourceId}.bib`}
                     onClick={() =>
-                      scheduleAnalyticsBatch({
-                        events: [
-                          {
-                            event_type: 'citation_export',
-                            search_id: searchId,
-                            resource_id: resourceId,
-                            label: 'BibTeX',
-                            destination_url: `${getApiBase()}/resources/${resourceId}/citation/bibtex`,
-                            source_component: 'CitationTable',
-                          },
-                        ],
-                      })
+                      handleCitationExport(
+                        'BibTeX',
+                        `${apiBase}/resources/${resourceId}/citation/bibtex`
+                      )
                     }
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
                   >
@@ -196,22 +227,14 @@ export function CitationTable({
                     BibTeX
                   </a>
                   <a
-                    href={`${getApiBase()}/resources/${resourceId}/citation/json-ld`}
+                    href={`${apiBase}/resources/${resourceId}/citation/json-ld`}
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={() =>
-                      scheduleAnalyticsBatch({
-                        events: [
-                          {
-                            event_type: 'citation_export',
-                            search_id: searchId,
-                            resource_id: resourceId,
-                            label: 'JSON-LD',
-                            destination_url: `${getApiBase()}/resources/${resourceId}/citation/json-ld`,
-                            source_component: 'CitationTable',
-                          },
-                        ],
-                      })
+                      handleCitationExport(
+                        'JSON-LD',
+                        `${apiBase}/resources/${resourceId}/citation/json-ld`
+                      )
                     }
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
                   >
@@ -219,7 +242,8 @@ export function CitationTable({
                   </a>
                 </div>
                 <p className="text-xs text-gray-500 mt-1.5">
-                  RIS and BibTeX for Zotero, EndNote, Mendeley. JSON-LD for Schema.org/Google Dataset Search.
+                  RIS and BibTeX for Zotero, EndNote, Mendeley. JSON-LD for
+                  Schema.org/Google Dataset Search.
                 </p>
               </td>
             </tr>

--- a/frontend/src/components/resource/ResourceView.tsx
+++ b/frontend/src/components/resource/ResourceView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, Link, useLocation, useNavigate } from 'react-router';
 import { ArrowLeft, ArrowRight, ArrowLeftCircle, XCircle } from 'lucide-react';
 import {
@@ -347,6 +347,8 @@ export function ResourceView() {
                       <CitationTable
                         citation={data.data.meta.ui.citation}
                         permalink={window.location.href}
+                        resourceId={data.data.id}
+                        resourceTitle={data.data.attributes.ogm.dct_title_s}
                       />
                     </div>
                   )}

--- a/frontend/src/pages/ResourceView.tsx
+++ b/frontend/src/pages/ResourceView.tsx
@@ -818,6 +818,7 @@ export function ResourceView({
                           citations={data.meta?.ui?.citations}
                           permalink={isMounted ? window.location.href : ''}
                           resourceId={data.id}
+                          resourceTitle={data.attributes.ogm.dct_title_s}
                           searchId={searchState?.searchId}
                         />
                       </div>

--- a/frontend/src/services/analytics.ts
+++ b/frontend/src/services/analytics.ts
@@ -60,6 +60,22 @@ interface AnalyticsBatchPayload {
   events?: AnalyticsEventRecord[];
 }
 
+interface AnalyticsDefaultFields {
+  visit_token?: string;
+  client_name?: string;
+  client_version?: string;
+  client_channel?: string;
+  client_instance?: string;
+  source_host?: string;
+  occurred_at?: string;
+}
+
+declare global {
+  interface Window {
+    dataLayer?: Array<Record<string, unknown>>;
+  }
+}
+
 const ANALYTICS_CLIENT_NAME = 'geoportal-web';
 const ANALYTICS_CLIENT_CHANNEL = 'browser';
 
@@ -94,7 +110,9 @@ function getSourceHost(): string | undefined {
   return window.location.host || undefined;
 }
 
-function withDefaults<T extends Record<string, unknown>>(row: T): T {
+function withDefaults<T extends AnalyticsDefaultFields>(
+  row: T
+): T & AnalyticsDefaultFields {
   return {
     ...row,
     visit_token: row.visit_token ?? getVisitToken(),
@@ -118,7 +136,7 @@ export function serializeSearchParams(
     .sort()
     .forEach((key) => {
       const values = searchParams.getAll(key);
-      serialized[key] = values.length > 1 ? values : values[0] ?? '';
+      serialized[key] = values.length > 1 ? values : (values[0] ?? '');
     });
 
   return serialized;
@@ -138,7 +156,11 @@ export function sendAnalyticsBatch(payload: AnalyticsBatchPayload): boolean {
     })
   );
 
-  if (searches.length === 0 && impressions.length === 0 && events.length === 0) {
+  if (
+    searches.length === 0 &&
+    impressions.length === 0 &&
+    events.length === 0
+  ) {
     return false;
   }
 
@@ -180,10 +202,28 @@ export function scheduleAnalyticsBatch(payload: AnalyticsBatchPayload): void {
     sendAnalyticsBatch(payload);
   };
 
-  if ('requestIdleCallback' in window) {
+  if (typeof window.requestIdleCallback === 'function') {
     window.requestIdleCallback(flush, { timeout: 1000 });
     return;
   }
 
   window.setTimeout(flush, 0);
+}
+
+export function pushDataLayerEvent(
+  event: string,
+  params: Record<string, unknown> = {}
+): boolean {
+  if (typeof window === 'undefined') return false;
+
+  if (!Array.isArray(window.dataLayer)) {
+    window.dataLayer = [];
+  }
+
+  window.dataLayer.push({
+    event,
+    ...params,
+  });
+
+  return true;
 }


### PR DESCRIPTION
## Summary

- Add a GTM `dataLayer` helper for custom frontend events.
- Fire `cite_copy`, `cite_url`, and `cite_export` events from the Cite & Reference panel with resource metadata.
- Include the export `format` parameter for RIS, BibTeX, and JSON-LD export clicks.
- Add coverage for no page-load event and each click payload.

Closes #275.

## Validation

- `npm test -- --run src/__tests__/components/resource/CitationTable.test.tsx src/__tests__/services/analytics.test.ts`
- `npx eslint src/components/resource/CitationTable.tsx src/services/analytics.ts src/__tests__/components/resource/CitationTable.test.tsx src/__tests__/services/analytics.test.ts src/pages/ResourceView.tsx src/components/resource/ResourceView.tsx`
- `npx prettier --check src/components/resource/CitationTable.tsx src/services/analytics.ts src/__tests__/components/resource/CitationTable.test.tsx src/__tests__/services/analytics.test.ts src/pages/ResourceView.tsx src/components/resource/ResourceView.tsx`
- `git diff --check`

Note: full frontend lint/typecheck still report existing unrelated repo issues outside this PR scope.