### PR TITLE
Add client analytics headers

### DIFF
--- a/docs/backend/analytics_program.md
+++ b/docs/backend/analytics_program.md
@@ -65,6 +65,8 @@ Current first-party client identities:
 
 - `geoportal-web` for same-origin browser API requests
 - `geoportal-ssr` for server-side fetches
+- `qgis-plugin` with channel `qgis`
+- `btaa-mcp-http-bridge` and `btaa-mcp-websocket-bridge` with channel `mcp`
 
 External or partner clients can opt into the same attribution model by sending the `X-BTAA-Client-*` headers.
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -83,6 +83,14 @@ Both bridge scripts default to the local API at `http://127.0.0.1:8000`.
   Full WebSocket MCP URL override for `mcp/mcp_websocket_bridge.js`.
 - `MCP_NODE_BIN`
   Optional absolute path to a modern Node binary for `mcp/run_mcp_websocket_bridge.py`.
+- `BTAA_MCP_CLIENT_VERSION`
+  Optional version value sent in `X-BTAA-Client-Version`; defaults to `local`.
+- `BTAA_MCP_CLIENT_INSTANCE`
+  Optional instance value sent in `X-BTAA-Client-Instance`.
+
+The HTTP and WebSocket bridges identify traffic with `X-BTAA-Client-Channel: mcp`.
+The WebSocket bridge attaches these headers when it can use the optional `ws`
+package; Node's built-in WebSocket API does not support custom handshake headers.
 
 ## Claude Desktop
 

--- a/mcp/client_headers.js
+++ b/mcp/client_headers.js
@@ -1,0 +1,23 @@
+"use strict";
+
+function clientVersion() {
+  return process.env.BTAA_MCP_CLIENT_VERSION || "local";
+}
+
+function clientHeaders(clientName) {
+  const version = clientVersion();
+  const headers = {
+    "User-Agent": `${clientName}/${version}`,
+    "X-BTAA-Client-Name": clientName,
+    "X-BTAA-Client-Version": version,
+    "X-BTAA-Client-Channel": "mcp",
+  };
+
+  if (process.env.BTAA_MCP_CLIENT_INSTANCE) {
+    headers["X-BTAA-Client-Instance"] = process.env.BTAA_MCP_CLIENT_INSTANCE;
+  }
+
+  return headers;
+}
+
+module.exports = { clientHeaders, clientVersion };

--- a/mcp/client_headers.test.js
+++ b/mcp/client_headers.test.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { clientHeaders, clientVersion } = require("./client_headers");
+
+function withEnv(updates, callback) {
+  const previous = {};
+  for (const key of Object.keys(updates)) {
+    previous[key] = process.env[key];
+    if (updates[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = updates[key];
+    }
+  }
+
+  try {
+    callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test("clientVersion falls back to local", () => {
+  withEnv({ BTAA_MCP_CLIENT_VERSION: undefined }, () => {
+    assert.equal(clientVersion(), "local");
+  });
+});
+
+test("clientHeaders returns stable MCP analytics headers", () => {
+  withEnv(
+    {
+      BTAA_MCP_CLIENT_VERSION: "1.2.3",
+      BTAA_MCP_CLIENT_INSTANCE: "desktop-1",
+    },
+    () => {
+      assert.deepEqual(clientHeaders("btaa-mcp-http-bridge"), {
+        "User-Agent": "btaa-mcp-http-bridge/1.2.3",
+        "X-BTAA-Client-Name": "btaa-mcp-http-bridge",
+        "X-BTAA-Client-Version": "1.2.3",
+        "X-BTAA-Client-Channel": "mcp",
+        "X-BTAA-Client-Instance": "desktop-1",
+      });
+    },
+  );
+});
+
+test("clientHeaders omits empty client instance", () => {
+  withEnv(
+    {
+      BTAA_MCP_CLIENT_VERSION: "1.2.3",
+      BTAA_MCP_CLIENT_INSTANCE: undefined,
+    },
+    () => {
+      assert.equal(clientHeaders("btaa-mcp-http-bridge")["X-BTAA-Client-Instance"], undefined);
+    },
+  );
+});

--- a/mcp/mcp_http_bridge.js
+++ b/mcp/mcp_http_bridge.js
@@ -10,6 +10,10 @@ const http = require("http");
 const https = require("https");
 const readline = require("readline");
 
+const { clientHeaders } = require("./client_headers");
+
+const CLIENT_NAME = "btaa-mcp-http-bridge";
+
 function baseUrl() {
   return (process.env.BTAA_GEOSPATIAL_API_BASE_URL || "http://127.0.0.1:8000").replace(
     /\/$/,
@@ -19,6 +23,14 @@ function baseUrl() {
 
 function mcpHttpUrl() {
   return process.env.MCP_SERVER_URL || process.env.MCP_HTTP_URL || `${baseUrl()}/api/v1/mcp`;
+}
+
+function requestHeaders(requestBody) {
+  return {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(requestBody),
+    ...clientHeaders(CLIENT_NAME),
+  };
 }
 
 function writeJson(message) {
@@ -46,10 +58,7 @@ async function postMessage(message) {
         port: target.port || (target.protocol === "https:" ? 443 : 80),
         path: `${target.pathname}${target.search}`,
         method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "content-length": Buffer.byteLength(requestBody),
-        },
+        headers: requestHeaders(requestBody),
       },
       (response) => {
         let body = "";
@@ -119,7 +128,19 @@ async function main() {
   await queue;
 }
 
-main().catch((error) => {
-  process.stderr.write(`MCP HTTP bridge failed: ${error.stack || error.message}\n`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`MCP HTTP bridge failed: ${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  baseUrl,
+  handleLine,
+  jsonRpcError,
+  main,
+  mcpHttpUrl,
+  postMessage,
+  requestHeaders,
+};

--- a/mcp/mcp_http_bridge.test.js
+++ b/mcp/mcp_http_bridge.test.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { requestHeaders } = require("./mcp_http_bridge");
+
+test("requestHeaders includes JSON and MCP analytics headers", () => {
+  const previousVersion = process.env.BTAA_MCP_CLIENT_VERSION;
+  process.env.BTAA_MCP_CLIENT_VERSION = "9.8.7";
+
+  try {
+    assert.deepEqual(requestHeaders('{"jsonrpc":"2.0"}'), {
+      "content-type": "application/json",
+      "content-length": 17,
+      "User-Agent": "btaa-mcp-http-bridge/9.8.7",
+      "X-BTAA-Client-Name": "btaa-mcp-http-bridge",
+      "X-BTAA-Client-Version": "9.8.7",
+      "X-BTAA-Client-Channel": "mcp",
+    });
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.BTAA_MCP_CLIENT_VERSION;
+    } else {
+      process.env.BTAA_MCP_CLIENT_VERSION = previousVersion;
+    }
+  }
+});

--- a/mcp/mcp_websocket_bridge.js
+++ b/mcp/mcp_websocket_bridge.js
@@ -8,6 +8,10 @@
 
 const readline = require("readline");
 
+const { clientHeaders } = require("./client_headers");
+
+const CLIENT_NAME = "btaa-mcp-websocket-bridge";
+
 function baseUrl() {
   return (process.env.BTAA_GEOSPATIAL_API_BASE_URL || "http://127.0.0.1:8000").replace(
     /\/$/,
@@ -26,17 +30,21 @@ function mcpWebSocketUrl() {
 }
 
 function getWebSocketImplementation() {
-  if (typeof WebSocket === "function") {
-    return WebSocket;
-  }
-
   try {
-    return require("ws");
+    return { WebSocketImpl: require("ws"), supportsHeaders: true };
   } catch (_error) {
+    if (typeof WebSocket === "function") {
+      return { WebSocketImpl: WebSocket, supportsHeaders: false };
+    }
+
     throw new Error(
       "WebSocket is unavailable. Use Node.js 22+ or install the optional 'ws' package.",
     );
   }
+}
+
+function webSocketOptions() {
+  return { headers: clientHeaders(CLIENT_NAME) };
 }
 
 function writeJson(message) {
@@ -72,13 +80,20 @@ function normalizeIncomingPayload(payload) {
 }
 
 async function connect() {
-  const WebSocketImpl = getWebSocketImplementation();
+  const { WebSocketImpl, supportsHeaders } = getWebSocketImplementation();
   const bridgeUrl = mcpWebSocketUrl();
 
   process.stderr.write(`Using MCP WebSocket bridge -> ${bridgeUrl}\n`);
+  if (!supportsHeaders) {
+    process.stderr.write(
+      "MCP WebSocket bridge is using a WebSocket implementation that cannot attach BTAA client headers\n",
+    );
+  }
 
   return await new Promise((resolve, reject) => {
-    const socket = new WebSocketImpl(bridgeUrl);
+    const socket = supportsHeaders
+      ? new WebSocketImpl(bridgeUrl, webSocketOptions())
+      : new WebSocketImpl(bridgeUrl);
     let opened = false;
 
     const onOpen = () => {
@@ -152,7 +167,20 @@ async function main() {
   await new Promise((resolve) => rl.on("close", resolve));
 }
 
-main().catch((error) => {
-  process.stderr.write(`MCP WebSocket bridge failed: ${error.stack || error.message}\n`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`MCP WebSocket bridge failed: ${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  baseUrl,
+  connect,
+  getWebSocketImplementation,
+  jsonRpcError,
+  main,
+  mcpWebSocketUrl,
+  normalizeIncomingPayload,
+  webSocketOptions,
+};

--- a/mcp/mcp_websocket_bridge.test.js
+++ b/mcp/mcp_websocket_bridge.test.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { webSocketOptions } = require("./mcp_websocket_bridge");
+
+test("webSocketOptions includes MCP analytics headers", () => {
+  const previousVersion = process.env.BTAA_MCP_CLIENT_VERSION;
+  process.env.BTAA_MCP_CLIENT_VERSION = "9.8.7";
+
+  try {
+    assert.deepEqual(webSocketOptions(), {
+      headers: {
+        "User-Agent": "btaa-mcp-websocket-bridge/9.8.7",
+        "X-BTAA-Client-Name": "btaa-mcp-websocket-bridge",
+        "X-BTAA-Client-Version": "9.8.7",
+        "X-BTAA-Client-Channel": "mcp",
+      },
+    });
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.BTAA_MCP_CLIENT_VERSION;
+    } else {
+      process.env.BTAA_MCP_CLIENT_VERSION = previousVersion;
+    }
+  }
+});

--- a/qgis-plugin/api_client.py
+++ b/qgis-plugin/api_client.py
@@ -25,7 +25,7 @@ class BtaaApiClient:
                 "User-Agent": f"BTAA-QGIS-Plugin/{plugin_version}",
                 "X-BTAA-Client-Name": "qgis-plugin",
                 "X-BTAA-Client-Version": plugin_version,
-                "X-BTAA-Client-Channel": "desktop",
+                "X-BTAA-Client-Channel": "qgis",
             }
         )
 

--- a/qgis-plugin/tests/test_api_client.py
+++ b/qgis-plugin/tests/test_api_client.py
@@ -16,6 +16,13 @@ def test_init_sets_base_url():
     assert client.session.verify is False
 
 
+def test_init_sets_analytics_headers(api_client):
+    assert api_client.session.headers["User-Agent"].startswith("BTAA-QGIS-Plugin/")
+    assert api_client.session.headers["X-BTAA-Client-Name"] == "qgis-plugin"
+    assert api_client.session.headers["X-BTAA-Client-Version"]
+    assert api_client.session.headers["X-BTAA-Client-Channel"] == "qgis"
+
+
 @patch("requests.Session.get")
 def test_get_facets(mock_get, api_client):
     mock_response = Mock()


### PR DESCRIPTION
## Summary

- Add shared MCP client header helpers for `X-BTAA-Client-*` attribution and `User-Agent` values.
- Send MCP client headers from the HTTP bridge and from the WebSocket bridge when the optional `ws` implementation is available.
- Update the QGIS plugin client channel to `qgis` and cover the expected analytics headers in tests.
- Document the MCP header environment variables and the current first-party client identities.

## Why

The analytics program needs stable first-party client attribution across desktop and MCP clients, not only browser and SSR traffic. These headers let downstream analytics distinguish QGIS, MCP HTTP bridge, and MCP WebSocket bridge requests.

## Impact

MCP bridge and QGIS traffic can now be attributed with explicit client name, version, channel, and optional instance metadata. The WebSocket bridge warns when it falls back to a WebSocket implementation that cannot attach custom handshake headers.

## Validation

- `/Users/ewlarson/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test mcp/client_headers.test.js mcp/mcp_http_bridge.test.js mcp/mcp_websocket_bridge.test.js`
- `/Users/ewlarson/.pyenv/versions/3.13.1/bin/python -m pytest qgis-plugin/tests`

Note: `python -m pytest qgis-plugin/tests` passed with an existing pytest-asyncio deprecation warning about `asyncio_default_fixture_loop_scope`.