### PR TITLE
Track citation copy clicks before clipboard write

### DIFF
--- a/frontend/src/__tests__/components/resource/CitationTable.test.tsx
+++ b/frontend/src/__tests__/components/resource/CitationTable.test.tsx
@@ -186,6 +186,30 @@ describe('CitationTable', () => {
     });
   });
 
+  it('pushes cite_copy even when clipboard write is denied', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    renderWithRouter(<CitationTable {...trackableProps} />);
+    fireEvent.click(screen.getByTitle('Copy citation'));
+
+    await waitFor(() => {
+      expect(pushDataLayerEvent).toHaveBeenCalledWith('cite_copy', {
+        resource_id: trackableProps.resourceId,
+        resource_title: trackableProps.resourceTitle,
+      });
+    });
+
+    consoleError.mockRestore();
+  });
+
   it('copies permalink to clipboard when permalink Copy clicked', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {
@@ -220,6 +244,30 @@ describe('CitationTable', () => {
         resource_title: trackableProps.resourceTitle,
       });
     });
+  });
+
+  it('pushes cite_url even when clipboard write is denied', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    renderWithRouter(<CitationTable {...trackableProps} />);
+    fireEvent.click(screen.getByTitle('Copy permalink'));
+
+    await waitFor(() => {
+      expect(pushDataLayerEvent).toHaveBeenCalledWith('cite_url', {
+        resource_id: trackableProps.resourceId,
+        resource_title: trackableProps.resourceTitle,
+      });
+    });
+
+    consoleError.mockRestore();
   });
 
   it.each([

--- a/frontend/src/components/resource/CitationTable.tsx
+++ b/frontend/src/components/resource/CitationTable.tsx
@@ -70,9 +70,10 @@ export function CitationTable({
   };
 
   const handleCopyPermalink = async () => {
+    trackCitationDataLayerEvent('cite_url');
+
     try {
       await navigator.clipboard.writeText(permalink);
-      trackCitationDataLayerEvent('cite_url');
       scheduleAnalyticsBatch({
         events: [
           {
@@ -93,9 +94,10 @@ export function CitationTable({
   };
 
   const handleCopyCitation = async () => {
+    trackCitationDataLayerEvent('cite_copy');
+
     try {
       await navigator.clipboard.writeText(displayCitation);
-      trackCitationDataLayerEvent('cite_copy');
       scheduleAnalyticsBatch({
         events: [
           {


### PR DESCRIPTION
## Summary

- Push `cite_copy` and `cite_url` GTM dataLayer events before attempting clipboard writes.
- Keep internal analytics batching and copied UI state behind successful clipboard writes.
- Add regression coverage for clipboard-denied copy clicks still emitting GTM events.

## Why

Live testing on `/resources/00000157c02249ae81ad7ee1300d3586_0` showed both copy clicks can fail with `NotAllowedError: Failed to execute 'writeText' on 'Clipboard': Write permission denied.` Because the GTM push was after `writeText`, those clicks never reached GTM Preview.

## Validation

- `npm test -- --run src/__tests__/components/resource/CitationTable.test.tsx`
- `npx eslint src/components/resource/CitationTable.tsx src/__tests__/components/resource/CitationTable.test.tsx`
- `npx prettier --check src/components/resource/CitationTable.tsx src/__tests__/components/resource/CitationTable.test.tsx`
- `git diff --check`

Note: ESLint/Prettier emitted the local pyenv rehash warning but exited successfully.