### PR TITLE
Reduce production DB connection burst during deploys

### DIFF
--- a/config/deploy.prd.yml
+++ b/config/deploy.prd.yml
@@ -101,8 +101,10 @@ env:
     API_KEY_TIER_CACHE_TTL_SECONDS: "60"
     API_KEY_LAST_USED_UPDATE_INTERVAL_SECONDS: "60"
     API_KEY_TIER_CACHE_MAX_ENTRIES: "2048"
-    DB_POOL_MIN: "1"
-    DB_POOL_MAX: "2"
+    # Keep per-worker DB pools tiny so rolling deploys have enough Postgres
+    # connection headroom while old and new web containers overlap.
+    DB_POOL_MIN: "0"
+    DB_POOL_MAX: "1"
     SQLALCHEMY_ASYNC_USE_NULLPOOL: "false"
     SQLALCHEMY_ASYNC_POOL_SIZE: "1"
     SQLALCHEMY_ASYNC_MAX_OVERFLOW: "0"
@@ -111,8 +113,8 @@ env:
     SQLALCHEMY_SYNC_POOL_SIZE: "1"
     SQLALCHEMY_SYNC_MAX_OVERFLOW: "0"
     SQLALCHEMY_SYNC_POOL_TIMEOUT: "5"
-    WEB_UVICORN_WORKERS: "4"
-    WEB_INTERNAL_UVICORN_WORKERS: "6"
+    WEB_UVICORN_WORKERS: "2"
+    WEB_INTERNAL_UVICORN_WORKERS: "2"
     WEB_SSR_WORKERS: "4"
     BACKUP_ENABLED: "<%= ENV.fetch('BACKUP_ENABLED', 'true') %>"
     BACKUP_REQUIRED_DEST: prd


### PR DESCRIPTION
## Summary

- Set production `DB_POOL_MIN=0` and `DB_POOL_MAX=1` to avoid eager per-worker DB connections during web container startup.
- Reduce production FastAPI workers from 4 public + 6 internal to 2 public + 2 internal.
- Add a short comment explaining the rolling deploy connection-headroom constraint.

## Why

The 0.8.9 deployment logs show FastAPI workers failing at startup with:

`asyncpg.exceptions.TooManyConnectionsError: sorry, too many clients already`

The production web container currently starts 10 FastAPI workers, and during a rolling deploy old and new containers overlap. Each worker creates its own DB pool, so startup can exceed Postgres connection headroom before the new container becomes healthy.

## Validation

- `git diff --check`
- Verified asyncpg permits `min_size=0` for pools.

No backend tests were run for this config-only change.